### PR TITLE
thread-safe boost::spirit

### DIFF
--- a/keyvi/include/keyvi/dictionary/fsa/internal/serialization_utils.h
+++ b/keyvi/include/keyvi/dictionary/fsa/internal/serialization_utils.h
@@ -30,6 +30,8 @@
 #include <string>
 
 #include <boost/lexical_cast.hpp>
+// boost json parser depends on boost::spirit, and spirit is not thread-safe by default. so need to enable thread-safety
+#define BOOST_SPIRIT_THREADSAFE
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 


### PR DESCRIPTION
- boost json parser depends on boost::spirit, and spirit is not thread-safe by default. so need to enable thread-safety
(cherry picked from commit 96ca66c632e96fe2206ea9409b774e5c89f2aacc)
