### PR TITLE
Fuzzy match + clang format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ FILE(GLOB_RECURSE UNIT_TEST_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} keyvi/t
 add_executable(keyvicompiler keyvi/bin/keyvicompiler/keyvicompiler.cpp)
 add_executable(keyviinspector keyvi/bin/keyviinspector/keyviinspector.cpp)
 add_executable(keyvimerger keyvi/bin/keyvimerger/keyvimerger.cpp)
-add_executable(unit_test_all ${UNIT_TEST_SOURCES})
+add_executable(unit_test_all ${UNIT_TEST_SOURCES} keyvi/include/keyvi/dictionary/fuzzy_match.h)
 
 target_link_libraries(keyvicompiler tpie ${Boost_LIBRARIES} ${ZLIB_LIBRARIES})
 target_link_libraries(keyviinspector tpie ${Boost_LIBRARIES} ${ZLIB_LIBRARIES})

--- a/keyvi/.clang-format
+++ b/keyvi/.clang-format
@@ -3,8 +3,10 @@ BasedOnStyle: Google
 ColumnLimit: '120'
 Language: Cpp
 Standard: Cpp11
-TabWidth: '2'
+TabWidth: '4'
 UseTab: Never
-ConstructorInitializerIndentWidth: 4
+IndentWidth: 4
+AccessModifierOffset: -3
+ConstructorInitializerIndentWidth: 8
 
 ...

--- a/keyvi/.clang-format
+++ b/keyvi/.clang-format
@@ -3,8 +3,8 @@ BasedOnStyle: Google
 ColumnLimit: '120'
 Language: Cpp
 Standard: Cpp11
-TabWidth: '4'
+TabWidth: '2'
 UseTab: Never
+ConstructorInitializerIndentWidth: 4
 
 ...
-

--- a/keyvi/check-style.sh
+++ b/keyvi/check-style.sh
@@ -8,7 +8,7 @@ cpplint_files=()
 for file in ${infiles}; do
   fqfile=`git rev-parse --show-toplevel`/${file}
   echo "Checking: ${file}"
-  if ! cmp -s ${fqfile} <(clang-format ${fqfile}); then
+  if ! cmp -s ${fqfile} <(clang-format -style=file ${fqfile}); then
     clang_format_files+=("${file}")
   fi
   if ! cpplint --quiet ${fqfile}; then

--- a/keyvi/include/keyvi/dictionary/dictionary.h
+++ b/keyvi/include/keyvi/dictionary/dictionary.h
@@ -32,6 +32,7 @@
 #include "dictionary/fsa/automata.h"
 #include "dictionary/fsa/state_traverser.h"
 #include "dictionary/fsa/traverser_types.h"
+#include "dictionary/fuzzy_match.h"
 #include "dictionary/match.h"
 #include "dictionary/match_iterator.h"
 
@@ -379,6 +380,12 @@ class Dictionary final {
     };
 
     return MatchIterator::MakeIteratorPair(tfunc);
+  }
+
+  MatchIterator::MatchIteratorPair GetFuzzy(const std::string& query, size_t max_edit_distance) {
+    auto data = std::make_shared<FuzzyMatch>(fsa_, query, max_edit_distance);
+    auto func = [data]() { return data->NextMatch(); };
+    return MatchIterator::MakeIteratorPair(func, data->FirstMatch());
   }
 
   std::string GetManifestAsString() const { return fsa_->GetManifestAsString(); }

--- a/keyvi/include/keyvi/dictionary/fuzzy_match.h
+++ b/keyvi/include/keyvi/dictionary/fuzzy_match.h
@@ -41,89 +41,89 @@ namespace dictionary {
 
 class FuzzyMatch {
  public:
-  FuzzyMatch(fsa::automata_t fsa, const std::string& query, size_t max_edit_distance)
-      : fsa_(std::move(fsa)), query_(query), max_edit_distance_(max_edit_distance) {
-    std::vector<int> codepoints;
-    utf8::unchecked::utf8to32(query.begin(), query.end(), back_inserter(codepoints));
+    FuzzyMatch(fsa::automata_t fsa, const std::string& query, size_t max_edit_distance)
+            : fsa_(std::move(fsa)), query_(query), max_edit_distance_(max_edit_distance) {
+        std::vector<int> codepoints;
+        utf8::unchecked::utf8to32(query.begin(), query.end(), back_inserter(codepoints));
 
-    query_char_length_ = codepoints.size();
-    metric_ptr_.reset(new stringdistance::Levenshtein(codepoints, 20, max_edit_distance_));
+        query_char_length_ = codepoints.size();
+        metric_ptr_.reset(new stringdistance::Levenshtein(codepoints, 20, max_edit_distance_));
 
-    const size_t minimum_exact_prefix_in_chars = 2;
-    size_t exact_prefix_in_bytes = 0;
-    while (exact_prefix_in_chars_ < minimum_exact_prefix_in_chars && exact_prefix_in_bytes < query_.size()) {
-      exact_prefix_in_bytes += util::Utf8Utils::GetCharLength(query[exact_prefix_in_bytes]);
-      ++exact_prefix_in_chars_;
-    }
-
-    // match exact prefix
-    uint64_t state = fsa_->GetStartState();
-    size_t depth = 0;
-    size_t utf8_depth = 0;
-    while (state != 0 && depth < exact_prefix_in_chars_) {
-      const size_t code_point_length = util::Utf8Utils::GetCharLength(query[utf8_depth]);
-      for (size_t i = 0; i < code_point_length; ++i, ++utf8_depth) {
-        state = fsa_->TryWalkTransition(state, query[utf8_depth]);
-        if (0 == state) {
-          break;
+        const size_t minimum_exact_prefix_in_chars = 2;
+        size_t exact_prefix_in_bytes = 0;
+        while (exact_prefix_in_chars_ < minimum_exact_prefix_in_chars && exact_prefix_in_bytes < query_.size()) {
+            exact_prefix_in_bytes += util::Utf8Utils::GetCharLength(query[exact_prefix_in_bytes]);
+            ++exact_prefix_in_chars_;
         }
-      }
-      metric_ptr_->Put(codepoints[depth], depth);
-      ++depth;
+
+        // match exact prefix
+        uint64_t state = fsa_->GetStartState();
+        size_t depth = 0;
+        size_t utf8_depth = 0;
+        while (state != 0 && depth < exact_prefix_in_chars_) {
+            const size_t code_point_length = util::Utf8Utils::GetCharLength(query[utf8_depth]);
+            for (size_t i = 0; i < code_point_length; ++i, ++utf8_depth) {
+                state = fsa_->TryWalkTransition(state, query[utf8_depth]);
+                if (0 == state) {
+                    break;
+                }
+            }
+            metric_ptr_->Put(codepoints[depth], depth);
+            ++depth;
+        }
+
+        if (state) {
+            if (depth == query_char_length_ && fsa_->IsFinalState(state)) {
+                first_match_ = Match(0, query_char_length_, query, 0, fsa_, fsa_->GetStateValue(state));
+            }
+            traverser_ptr_.reset(new fsa::CodePointStateTraverser<fsa::WeightedStateTraverser>(fsa_, state));
+        }
     }
 
-    if (state) {
-      if (depth == query_char_length_ && fsa_->IsFinalState(state)) {
-        first_match_ = Match(0, query_char_length_, query, 0, fsa_, fsa_->GetStateValue(state));
-      }
-      traverser_ptr_.reset(new fsa::CodePointStateTraverser<fsa::WeightedStateTraverser>(fsa_, state));
+    Match FirstMatch() const { return first_match_; }
+
+    Match NextMatch() {
+        for (; traverser_ptr_ && *traverser_ptr_; (*traverser_ptr_)++) {
+            const int intermediate_score = metric_ptr_->Put(traverser_ptr_->GetStateLabel(), candidate_length() - 1);
+            // don't consider subtrees which can not be matched anyways
+            if (query_char_length_ > candidate_length() && intermediate_score > max_edit_distance_) {
+                traverser_ptr_->Prune();
+                continue;
+            }
+
+            if (query_char_length_ + max_edit_distance_ < candidate_length()) {
+                traverser_ptr_->Prune();
+                continue;
+            }
+
+            if (traverser_ptr_->IsFinalState() && metric_ptr_->GetScore() <= max_edit_distance_) {
+                Match m = Match(0, candidate_length(), metric_ptr_->GetCandidate(), metric_ptr_->GetScore(),
+                                traverser_ptr_->GetFsa(), traverser_ptr_->GetStateValue());
+                (*traverser_ptr_)++;
+                return m;
+            }
+        }
+        return Match();
     }
-  }
-
-  Match FirstMatch() const { return first_match_; }
-
-  Match NextMatch() {
-    for (; traverser_ptr_ && *traverser_ptr_; (*traverser_ptr_)++) {
-      const int intermediate_score = metric_ptr_->Put(traverser_ptr_->GetStateLabel(), candidate_length() - 1);
-      // don't consider subtrees which can not be matched anyways
-      if (query_char_length_ > candidate_length() && intermediate_score > max_edit_distance_) {
-        traverser_ptr_->Prune();
-        continue;
-      }
-
-      if (query_char_length_ + max_edit_distance_ < candidate_length()) {
-        traverser_ptr_->Prune();
-        continue;
-      }
-
-      if (traverser_ptr_->IsFinalState() && metric_ptr_->GetScore() <= max_edit_distance_) {
-        Match m = Match(0, candidate_length(), metric_ptr_->GetCandidate(), metric_ptr_->GetScore(),
-                        traverser_ptr_->GetFsa(), traverser_ptr_->GetStateValue());
-        (*traverser_ptr_)++;
-        return m;
-      }
-    }
-    return Match();
-  }
 
  private:
-  size_t candidate_length() const {
-    assert(traverser_ptr_);
-    return exact_prefix_in_chars_ + traverser_ptr_->GetDepth();
-  }
+    size_t candidate_length() const {
+        assert(traverser_ptr_);
+        return exact_prefix_in_chars_ + traverser_ptr_->GetDepth();
+    }
 
  private:
-  fsa::automata_t fsa_;
-  std::string query_;
-  const size_t max_edit_distance_;
+    fsa::automata_t fsa_;
+    std::string query_;
+    const size_t max_edit_distance_;
 
-  size_t exact_prefix_in_chars_ = 0;
-  size_t query_char_length_ = 0;
+    size_t exact_prefix_in_chars_ = 0;
+    size_t query_char_length_ = 0;
 
-  Match first_match_;
+    Match first_match_;
 
-  std::unique_ptr<stringdistance::Levenshtein> metric_ptr_;
-  std::unique_ptr<fsa::CodePointStateTraverser<fsa::WeightedStateTraverser>> traverser_ptr_;
+    std::unique_ptr<stringdistance::Levenshtein> metric_ptr_;
+    std::unique_ptr<fsa::CodePointStateTraverser<fsa::WeightedStateTraverser>> traverser_ptr_;
 };
 
 } /* namespace dictionary */

--- a/keyvi/include/keyvi/dictionary/fuzzy_match.h
+++ b/keyvi/include/keyvi/dictionary/fuzzy_match.h
@@ -1,0 +1,131 @@
+/* * keyvi - A key value store.
+ *
+ * Copyright 2018   Narek Gharibyan<narekgharibyan@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * fuzzy_match.h
+ *
+ *  Created on: February 11, 2018
+ *      Author: Narek Gharibyan <narekgharibyan@gmail.com>
+ */
+
+#ifndef KEYVI_DICTIONARY_FUZZY_MATCH_H_
+#define KEYVI_DICTIONARY_FUZZY_MATCH_H_
+
+#include <string>
+#include <vector>
+
+#include "stringdistance/levenshtein.h"
+
+#include "dictionary/fsa/automata.h"
+#include "dictionary/fsa/codepoint_state_traverser.h"
+#include "dictionary/fsa/traverser_types.h"
+#include "dictionary/match.h"
+#include "dictionary/util/utf8_utils.h"
+
+namespace keyvi {
+namespace dictionary {
+
+class FuzzyMatch {
+ public:
+  FuzzyMatch(fsa::automata_t fsa, const std::string& query, size_t max_edit_distance)
+      : fsa_(std::move(fsa)), query_(query), max_edit_distance_(max_edit_distance) {
+    std::vector<int> codepoints;
+    utf8::unchecked::utf8to32(query.begin(), query.end(), back_inserter(codepoints));
+
+    query_char_length_ = codepoints.size();
+    metric_ptr_.reset(new stringdistance::Levenshtein(codepoints, 20, max_edit_distance_));
+
+    const size_t minimum_exact_prefix_in_chars = 2;
+    size_t exact_prefix_in_bytes = 0;
+    while (exact_prefix_in_chars_ < minimum_exact_prefix_in_chars && exact_prefix_in_bytes < query_.size()) {
+      exact_prefix_in_bytes += util::Utf8Utils::GetCharLength(query[exact_prefix_in_bytes]);
+      ++exact_prefix_in_chars_;
+    }
+
+    // match exact prefix
+    uint64_t state = fsa_->GetStartState();
+    size_t depth = 0;
+    size_t utf8_depth = 0;
+    while (state != 0 && depth < exact_prefix_in_chars_) {
+      const size_t code_point_length = util::Utf8Utils::GetCharLength(query[utf8_depth]);
+      for (size_t i = 0; i < code_point_length; ++i, ++utf8_depth) {
+        state = fsa_->TryWalkTransition(state, query[utf8_depth]);
+        if (0 == state) {
+          break;
+        }
+      }
+      metric_ptr_->Put(codepoints[depth], depth);
+      ++depth;
+    }
+
+    if (state) {
+      if (depth == query_char_length_ && fsa_->IsFinalState(state)) {
+        first_match_ = Match(0, query_char_length_, query, 0, fsa_, fsa_->GetStateValue(state));
+      }
+      traverser_ptr_.reset(new fsa::CodePointStateTraverser<fsa::WeightedStateTraverser>(fsa_, state));
+    }
+  }
+
+  Match FirstMatch() const { return first_match_; }
+
+  Match NextMatch() {
+    for (; traverser_ptr_ && *traverser_ptr_; (*traverser_ptr_)++) {
+      const int intermediate_score = metric_ptr_->Put(traverser_ptr_->GetStateLabel(), candidate_length() - 1);
+      // don't consider subtrees which can not be matched anyways
+      if (query_char_length_ > candidate_length() && intermediate_score > max_edit_distance_) {
+        traverser_ptr_->Prune();
+        continue;
+      }
+
+      if (query_char_length_ + max_edit_distance_ < candidate_length()) {
+        traverser_ptr_->Prune();
+        continue;
+      }
+
+      if (traverser_ptr_->IsFinalState() && metric_ptr_->GetScore() <= max_edit_distance_) {
+        Match m = Match(0, candidate_length(), metric_ptr_->GetCandidate(), metric_ptr_->GetScore(),
+                        traverser_ptr_->GetFsa(), traverser_ptr_->GetStateValue());
+        (*traverser_ptr_)++;
+        return m;
+      }
+    }
+    return Match();
+  }
+
+ private:
+  size_t candidate_length() const {
+    assert(traverser_ptr_);
+    return exact_prefix_in_chars_ + traverser_ptr_->GetDepth();
+  }
+
+ private:
+  fsa::automata_t fsa_;
+  std::string query_;
+  const size_t max_edit_distance_;
+
+  size_t exact_prefix_in_chars_ = 0;
+  size_t query_char_length_ = 0;
+
+  Match first_match_;
+
+  std::unique_ptr<stringdistance::Levenshtein> metric_ptr_;
+  std::unique_ptr<fsa::CodePointStateTraverser<fsa::WeightedStateTraverser>> traverser_ptr_;
+};
+
+} /* namespace dictionary */
+} /* namespace keyvi */
+#endif  // KEYVI_DICTIONARY_FUZZY_MATCH_H_

--- a/keyvi/tests/keyvi/dictionary/fuzzy_match_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fuzzy_match_test.cpp
@@ -33,205 +33,205 @@ namespace dictionary {
 BOOST_AUTO_TEST_SUITE(FuzzyMatchTests)
 
 BOOST_AUTO_TEST_CASE(fuzzy_0) {
-  std::vector<std::pair<std::string, uint32_t>> test_data = {
-      {"türkei news", 23698},
-      {"türkei side", 18838},
-      {"türkei urlaub", 23424},
-      {"türkisch anfänger", 20788},
-      {"türkisch für", 21655},
-      {"türkisch für anfänger", 20735},
-      {"türkçe dublaj", 28575},
-      {"türkçe dublaj izle", 16391},
-      {"türkçe izle", 19946},
-      {"tüv akademie", 9557},
-      {"tüv hessen", 7744},
-      {"tüv i", 331},
-      {"tüv in", 10188},
-      {"tüv ib", 10189},
-      {"tüv kosten", 11387},
-      {"tüv nord", 46052},
-      {"tüs rhein", 462},
-      {"tüs rheinland", 39131},
-      {"tüs öffnungszeiten", 15999},
-  };
-  testing::TempDictionary dictionary(&test_data);
-  dictionary_t d(new Dictionary(dictionary.GetFsa()));
+    std::vector<std::pair<std::string, uint32_t>> test_data = {
+        {"türkei news", 23698},
+        {"türkei side", 18838},
+        {"türkei urlaub", 23424},
+        {"türkisch anfänger", 20788},
+        {"türkisch für", 21655},
+        {"türkisch für anfänger", 20735},
+        {"türkçe dublaj", 28575},
+        {"türkçe dublaj izle", 16391},
+        {"türkçe izle", 19946},
+        {"tüv akademie", 9557},
+        {"tüv hessen", 7744},
+        {"tüv i", 331},
+        {"tüv in", 10188},
+        {"tüv ib", 10189},
+        {"tüv kosten", 11387},
+        {"tüv nord", 46052},
+        {"tüs rhein", 462},
+        {"tüs rheinland", 39131},
+        {"tüs öffnungszeiten", 15999},
+    };
+    testing::TempDictionary dictionary(&test_data);
+    dictionary_t d(new Dictionary(dictionary.GetFsa()));
 
-  std::vector<std::string> expected_output = {"tüv i"};
+    std::vector<std::string> expected_output = {"tüv i"};
 
-  auto expected_it = expected_output.begin();
-  for (auto m : d->GetFuzzy("tüv i", 0)) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
-  }
+    auto expected_it = expected_output.begin();
+    for (auto m : d->GetFuzzy("tüv i", 0)) {
+        BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    }
 
-  BOOST_CHECK(expected_it == expected_output.end());
+    BOOST_CHECK(expected_it == expected_output.end());
 }
 
 BOOST_AUTO_TEST_CASE(fuzzy_1) {
-  std::vector<std::pair<std::string, uint32_t>> test_data = {
-      {"türkei news", 23698},
-      {"türkei side", 18838},
-      {"türkei urlaub", 23424},
-      {"türkisch anfänger", 20788},
-      {"türkisch für", 21655},
-      {"türkisch für anfänger", 20735},
-      {"türkçe dublaj", 28575},
-      {"türkçe dublaj izle", 16391},
-      {"türkçe izle", 19946},
-      {"tüv akademie", 9557},
-      {"tüv hessen", 7744},
-      {"tüv jnohn", 334},
-      {"tüv jnack", 331},
-      {"tüv i", 331},
-      {"tüv in", 10188},
-      {"tüv ib", 10189},
-      {"tüv kosten", 11387},
-      {"tüv nord", 46052},
-      {"tüs rhein", 462},
-      {"tüs rheinland", 39131},
-      {"tüs öffnungszeiten", 15999},
-  };
-  testing::TempDictionary dictionary(&test_data);
-  dictionary_t d(new Dictionary(dictionary.GetFsa()));
+    std::vector<std::pair<std::string, uint32_t>> test_data = {
+        {"türkei news", 23698},
+        {"türkei side", 18838},
+        {"türkei urlaub", 23424},
+        {"türkisch anfänger", 20788},
+        {"türkisch für", 21655},
+        {"türkisch für anfänger", 20735},
+        {"türkçe dublaj", 28575},
+        {"türkçe dublaj izle", 16391},
+        {"türkçe izle", 19946},
+        {"tüv akademie", 9557},
+        {"tüv hessen", 7744},
+        {"tüv jnohn", 334},
+        {"tüv jnack", 331},
+        {"tüv i", 331},
+        {"tüv in", 10188},
+        {"tüv ib", 10189},
+        {"tüv kosten", 11387},
+        {"tüv nord", 46052},
+        {"tüs rhein", 462},
+        {"tüs rheinland", 39131},
+        {"tüs öffnungszeiten", 15999},
+    };
+    testing::TempDictionary dictionary(&test_data);
+    dictionary_t d(new Dictionary(dictionary.GetFsa()));
 
-  std::vector<std::string> expected_output = {
-      "tüv i",
-      "tüv ib",
-      "tüv in",
-  };
+    std::vector<std::string> expected_output = {
+        "tüv i",
+        "tüv ib",
+        "tüv in",
+    };
 
-  auto expected_it = expected_output.begin();
-  for (auto m : d->GetFuzzy("tüv in", 1)) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
-  }
+    auto expected_it = expected_output.begin();
+    for (auto m : d->GetFuzzy("tüv in", 1)) {
+        BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    }
 
-  BOOST_CHECK(expected_it == expected_output.end());
+    BOOST_CHECK(expected_it == expected_output.end());
 }
 
 BOOST_AUTO_TEST_CASE(fuzzy_2) {
-  std::vector<std::pair<std::string, uint32_t>> test_data = {
-      {"türkei news", 23698},
-      {"türkei side", 18838},
-      {"türkei urlaub", 23424},
-      {"türkisch anfänger", 20788},
-      {"türisch anfänger", 20788},
-      {"türkisch", 21657},
-      {"tülkisc", 21654},
-      {"türkisch für", 21655},
-      {"türkisch für anfänger", 20735},
-      {"türkçe dublaj", 28575},
-      {"türkçe dublaj izle", 16391},
-      {"türkçe izle", 19946},
-      {"tüv akademie", 9557},
-      {"tüv hessen", 7744},
-      {"tüv jnohn", 334},
-      {"tüv jnack", 331},
-      {"tüv i", 331},
-      {"tüv in", 10188},
-      {"tüv ib", 10189},
-      {"tüv kosten", 11387},
-      {"tüv nord", 46052},
-      {"tüs rhein", 462},
-      {"tüs rheinland", 39131},
-      {"tüs öffnungszeiten", 15999},
-  };
-  testing::TempDictionary dictionary(&test_data);
-  dictionary_t d(new Dictionary(dictionary.GetFsa()));
+    std::vector<std::pair<std::string, uint32_t>> test_data = {
+        {"türkei news", 23698},
+        {"türkei side", 18838},
+        {"türkei urlaub", 23424},
+        {"türkisch anfänger", 20788},
+        {"türisch anfänger", 20788},
+        {"türkisch", 21657},
+        {"tülkisc", 21654},
+        {"türkisch für", 21655},
+        {"türkisch für anfänger", 20735},
+        {"türkçe dublaj", 28575},
+        {"türkçe dublaj izle", 16391},
+        {"türkçe izle", 19946},
+        {"tüv akademie", 9557},
+        {"tüv hessen", 7744},
+        {"tüv jnohn", 334},
+        {"tüv jnack", 331},
+        {"tüv i", 331},
+        {"tüv in", 10188},
+        {"tüv ib", 10189},
+        {"tüv kosten", 11387},
+        {"tüv nord", 46052},
+        {"tüs rhein", 462},
+        {"tüs rheinland", 39131},
+        {"tüs öffnungszeiten", 15999},
+    };
+    testing::TempDictionary dictionary(&test_data);
+    dictionary_t d(new Dictionary(dictionary.GetFsa()));
 
-  std::vector<std::string> expected_output = {
-      "türkisch",
-      "tülkisc",
-  };
+    std::vector<std::string> expected_output = {
+        "türkisch",
+        "tülkisc",
+    };
 
-  auto expected_it = expected_output.begin();
-  for (auto m : d->GetFuzzy("türkisch", 2)) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
-  }
+    auto expected_it = expected_output.begin();
+    for (auto m : d->GetFuzzy("türkisch", 2)) {
+        BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    }
 
-  BOOST_CHECK(expected_it == expected_output.end());
+    BOOST_CHECK(expected_it == expected_output.end());
 }
 
 BOOST_AUTO_TEST_CASE(fuzzy_2_exact_minimum_prefix) {
-  std::vector<std::pair<std::string, uint32_t>> test_data = {
-      {"türkei news", 23698},
-      {"türkei side", 18838},
-      {"türkei urlaub", 23424},
-      {"türkisch anfänger", 20788},
-      {"türkisch für", 21655},
-      {"türkisch für anfänger", 20735},
-      {"türkçe dublaj", 28575},
-      {"türkçe dublaj izle", 16391},
-      {"türkçe izle", 19946},
-      {"tüv akademie", 9557},
-      {"tüv hessen", 7744},
-      {"tü", 340},
-      {"tüv i", 331},
-      {"tüvk", 334},
-      {"tüv in", 10188},
-      {"tüv ib", 10189},
-      {"tüv kosten", 11387},
-      {"tüv nord", 46052},
-      {"tüs rhein", 462},
-      {"tüs rheinland", 39131},
-      {"tüs öffnungszeiten", 15999},
-  };
-  testing::TempDictionary dictionary(&test_data);
-  dictionary_t d(new Dictionary(dictionary.GetFsa()));
+    std::vector<std::pair<std::string, uint32_t>> test_data = {
+        {"türkei news", 23698},
+        {"türkei side", 18838},
+        {"türkei urlaub", 23424},
+        {"türkisch anfänger", 20788},
+        {"türkisch für", 21655},
+        {"türkisch für anfänger", 20735},
+        {"türkçe dublaj", 28575},
+        {"türkçe dublaj izle", 16391},
+        {"türkçe izle", 19946},
+        {"tüv akademie", 9557},
+        {"tüv hessen", 7744},
+        {"tü", 340},
+        {"tüv i", 331},
+        {"tüvk", 334},
+        {"tüv in", 10188},
+        {"tüv ib", 10189},
+        {"tüv kosten", 11387},
+        {"tüv nord", 46052},
+        {"tüs rhein", 462},
+        {"tüs rheinland", 39131},
+        {"tüs öffnungszeiten", 15999},
+    };
+    testing::TempDictionary dictionary(&test_data);
+    dictionary_t d(new Dictionary(dictionary.GetFsa()));
 
-  std::vector<std::string> expected_output = {
-      "tü",
-      "tüv i",
-      "tüvk",
-  };
+    std::vector<std::string> expected_output = {
+        "tü",
+        "tüv i",
+        "tüvk",
+    };
 
-  auto expected_it = expected_output.begin();
-  for (auto m : d->GetFuzzy("tü", 3)) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
-  }
+    auto expected_it = expected_output.begin();
+    for (auto m : d->GetFuzzy("tü", 3)) {
+        BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    }
 
-  BOOST_CHECK(expected_it == expected_output.end());
+    BOOST_CHECK(expected_it == expected_output.end());
 }
 
 BOOST_AUTO_TEST_CASE(fuzzy_5) {
-  std::vector<std::pair<std::string, uint32_t>> test_data = {
-      {"türkei news", 23698},
-      {"türkei side", 18838},
-      {"türkei urlaub", 23424},
-      {"türkisch anfänger", 20788},
-      {"türisch anfänger", 20788},
-      {"türkisch", 21657},
-      {"tülkisc", 21654},
-      {"türkisch für", 21655},
-      {"türkisch für anfänger", 20735},
-      {"türkçe dublaj", 28575},
-      {"türkçe dublaj izle", 16391},
-      {"türkçe izle", 19946},
-      {"tüv akademie", 9557},
-      {"tüv hessen", 7744},
-      {"tüv jnohn", 334},
-      {"tüv jnack", 331},
-      {"tüv i", 331},
-      {"tüv in", 10188},
-      {"tüv ib", 10189},
-      {"tüv kosten", 11387},
-      {"tüv nord", 46052},
-      {"tüs rhein", 462},
-      {"tüs rheinland", 39131},
-      {"tüs öffnungszeiten", 15999},
-  };
-  testing::TempDictionary dictionary(&test_data);
-  dictionary_t d(new Dictionary(dictionary.GetFsa()));
+    std::vector<std::pair<std::string, uint32_t>> test_data = {
+        {"türkei news", 23698},
+        {"türkei side", 18838},
+        {"türkei urlaub", 23424},
+        {"türkisch anfänger", 20788},
+        {"türisch anfänger", 20788},
+        {"türkisch", 21657},
+        {"tülkisc", 21654},
+        {"türkisch für", 21655},
+        {"türkisch für anfänger", 20735},
+        {"türkçe dublaj", 28575},
+        {"türkçe dublaj izle", 16391},
+        {"türkçe izle", 19946},
+        {"tüv akademie", 9557},
+        {"tüv hessen", 7744},
+        {"tüv jnohn", 334},
+        {"tüv jnack", 331},
+        {"tüv i", 331},
+        {"tüv in", 10188},
+        {"tüv ib", 10189},
+        {"tüv kosten", 11387},
+        {"tüv nord", 46052},
+        {"tüs rhein", 462},
+        {"tüs rheinland", 39131},
+        {"tüs öffnungszeiten", 15999},
+    };
+    testing::TempDictionary dictionary(&test_data);
+    dictionary_t d(new Dictionary(dictionary.GetFsa()));
 
-  std::vector<std::string> expected_output = {
-      "tüv i", "tüv ib", "tüv in", "türkei side", "türkisch", "türkisch für", "tülkisc",
-  };
+    std::vector<std::string> expected_output = {
+        "tüv i", "tüv ib", "tüv in", "türkei side", "türkisch", "türkisch für", "tülkisc",
+    };
 
-  auto expected_it = expected_output.begin();
-  for (auto m : d->GetFuzzy("türkisch", 5)) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
-  }
+    auto expected_it = expected_output.begin();
+    for (auto m : d->GetFuzzy("türkisch", 5)) {
+        BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    }
 
-  BOOST_CHECK(expected_it == expected_output.end());
+    BOOST_CHECK(expected_it == expected_output.end());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/keyvi/tests/keyvi/dictionary/fuzzy_match_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fuzzy_match_test.cpp
@@ -1,0 +1,240 @@
+/* * keyvi - A key value store.
+ *
+ * Copyright 2018   Narek Gharibyan<narekgharibyan@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * fuzzy_match_test.cpp
+ *
+ *  Created on: February 11, 2018
+ *      Author: Narek Gharibyan <narekgharibyan@gmail.com>
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include "dictionary/dictionary.h"
+#include "testing/temp_dictionary.h"
+
+namespace keyvi {
+namespace dictionary {
+
+BOOST_AUTO_TEST_SUITE(FuzzyMatchTests)
+
+BOOST_AUTO_TEST_CASE(fuzzy_0) {
+  std::vector<std::pair<std::string, uint32_t>> test_data = {
+      {"türkei news", 23698},
+      {"türkei side", 18838},
+      {"türkei urlaub", 23424},
+      {"türkisch anfänger", 20788},
+      {"türkisch für", 21655},
+      {"türkisch für anfänger", 20735},
+      {"türkçe dublaj", 28575},
+      {"türkçe dublaj izle", 16391},
+      {"türkçe izle", 19946},
+      {"tüv akademie", 9557},
+      {"tüv hessen", 7744},
+      {"tüv i", 331},
+      {"tüv in", 10188},
+      {"tüv ib", 10189},
+      {"tüv kosten", 11387},
+      {"tüv nord", 46052},
+      {"tüs rhein", 462},
+      {"tüs rheinland", 39131},
+      {"tüs öffnungszeiten", 15999},
+  };
+  testing::TempDictionary dictionary(&test_data);
+  dictionary_t d(new Dictionary(dictionary.GetFsa()));
+
+  std::vector<std::string> expected_output = {"tüv i"};
+
+  auto expected_it = expected_output.begin();
+  for (auto m : d->GetFuzzy("tüv i", 0)) {
+    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+  }
+
+  BOOST_CHECK(expected_it == expected_output.end());
+}
+
+BOOST_AUTO_TEST_CASE(fuzzy_1) {
+  std::vector<std::pair<std::string, uint32_t>> test_data = {
+      {"türkei news", 23698},
+      {"türkei side", 18838},
+      {"türkei urlaub", 23424},
+      {"türkisch anfänger", 20788},
+      {"türkisch für", 21655},
+      {"türkisch für anfänger", 20735},
+      {"türkçe dublaj", 28575},
+      {"türkçe dublaj izle", 16391},
+      {"türkçe izle", 19946},
+      {"tüv akademie", 9557},
+      {"tüv hessen", 7744},
+      {"tüv jnohn", 334},
+      {"tüv jnack", 331},
+      {"tüv i", 331},
+      {"tüv in", 10188},
+      {"tüv ib", 10189},
+      {"tüv kosten", 11387},
+      {"tüv nord", 46052},
+      {"tüs rhein", 462},
+      {"tüs rheinland", 39131},
+      {"tüs öffnungszeiten", 15999},
+  };
+  testing::TempDictionary dictionary(&test_data);
+  dictionary_t d(new Dictionary(dictionary.GetFsa()));
+
+  std::vector<std::string> expected_output = {
+      "tüv i",
+      "tüv ib",
+      "tüv in",
+  };
+
+  auto expected_it = expected_output.begin();
+  for (auto m : d->GetFuzzy("tüv in", 1)) {
+    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+  }
+
+  BOOST_CHECK(expected_it == expected_output.end());
+}
+
+BOOST_AUTO_TEST_CASE(fuzzy_2) {
+  std::vector<std::pair<std::string, uint32_t>> test_data = {
+      {"türkei news", 23698},
+      {"türkei side", 18838},
+      {"türkei urlaub", 23424},
+      {"türkisch anfänger", 20788},
+      {"türisch anfänger", 20788},
+      {"türkisch", 21657},
+      {"tülkisc", 21654},
+      {"türkisch für", 21655},
+      {"türkisch für anfänger", 20735},
+      {"türkçe dublaj", 28575},
+      {"türkçe dublaj izle", 16391},
+      {"türkçe izle", 19946},
+      {"tüv akademie", 9557},
+      {"tüv hessen", 7744},
+      {"tüv jnohn", 334},
+      {"tüv jnack", 331},
+      {"tüv i", 331},
+      {"tüv in", 10188},
+      {"tüv ib", 10189},
+      {"tüv kosten", 11387},
+      {"tüv nord", 46052},
+      {"tüs rhein", 462},
+      {"tüs rheinland", 39131},
+      {"tüs öffnungszeiten", 15999},
+  };
+  testing::TempDictionary dictionary(&test_data);
+  dictionary_t d(new Dictionary(dictionary.GetFsa()));
+
+  std::vector<std::string> expected_output = {
+      "türkisch",
+      "tülkisc",
+  };
+
+  auto expected_it = expected_output.begin();
+  for (auto m : d->GetFuzzy("türkisch", 2)) {
+    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+  }
+
+  BOOST_CHECK(expected_it == expected_output.end());
+}
+
+BOOST_AUTO_TEST_CASE(fuzzy_2_exact_minimum_prefix) {
+  std::vector<std::pair<std::string, uint32_t>> test_data = {
+      {"türkei news", 23698},
+      {"türkei side", 18838},
+      {"türkei urlaub", 23424},
+      {"türkisch anfänger", 20788},
+      {"türkisch für", 21655},
+      {"türkisch für anfänger", 20735},
+      {"türkçe dublaj", 28575},
+      {"türkçe dublaj izle", 16391},
+      {"türkçe izle", 19946},
+      {"tüv akademie", 9557},
+      {"tüv hessen", 7744},
+      {"tü", 340},
+      {"tüv i", 331},
+      {"tüvk", 334},
+      {"tüv in", 10188},
+      {"tüv ib", 10189},
+      {"tüv kosten", 11387},
+      {"tüv nord", 46052},
+      {"tüs rhein", 462},
+      {"tüs rheinland", 39131},
+      {"tüs öffnungszeiten", 15999},
+  };
+  testing::TempDictionary dictionary(&test_data);
+  dictionary_t d(new Dictionary(dictionary.GetFsa()));
+
+  std::vector<std::string> expected_output = {
+      "tü",
+      "tüv i",
+      "tüvk",
+  };
+
+  auto expected_it = expected_output.begin();
+  for (auto m : d->GetFuzzy("tü", 3)) {
+    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+  }
+
+  BOOST_CHECK(expected_it == expected_output.end());
+}
+
+BOOST_AUTO_TEST_CASE(fuzzy_5) {
+  std::vector<std::pair<std::string, uint32_t>> test_data = {
+      {"türkei news", 23698},
+      {"türkei side", 18838},
+      {"türkei urlaub", 23424},
+      {"türkisch anfänger", 20788},
+      {"türisch anfänger", 20788},
+      {"türkisch", 21657},
+      {"tülkisc", 21654},
+      {"türkisch für", 21655},
+      {"türkisch für anfänger", 20735},
+      {"türkçe dublaj", 28575},
+      {"türkçe dublaj izle", 16391},
+      {"türkçe izle", 19946},
+      {"tüv akademie", 9557},
+      {"tüv hessen", 7744},
+      {"tüv jnohn", 334},
+      {"tüv jnack", 331},
+      {"tüv i", 331},
+      {"tüv in", 10188},
+      {"tüv ib", 10189},
+      {"tüv kosten", 11387},
+      {"tüv nord", 46052},
+      {"tüs rhein", 462},
+      {"tüs rheinland", 39131},
+      {"tüs öffnungszeiten", 15999},
+  };
+  testing::TempDictionary dictionary(&test_data);
+  dictionary_t d(new Dictionary(dictionary.GetFsa()));
+
+  std::vector<std::string> expected_output = {
+      "tüv i", "tüv ib", "tüv in", "türkei side", "türkisch", "türkisch für", "tülkisc",
+  };
+
+  auto expected_it = expected_output.begin();
+  for (auto m : d->GetFuzzy("türkisch", 5)) {
+    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+  }
+
+  BOOST_CHECK(expected_it == expected_output.end());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} /* namespace dictionary */
+} /* namespace keyvi */

--- a/python/setup.py
+++ b/python/setup.py
@@ -257,7 +257,7 @@ with symlink_keyvi() as (pykeyvi_source_path, keyvi_source_path):
 
     PACKAGE_NAME = 'keyvi'
 
-    version = '0.2.5'
+    version = '0.2.6'
 
     install_requires = [
         'msgpack-python',


### PR DESCRIPTION
@hendrikmuhs This PR contains PR https://github.com/KeyviDev/keyvi/pull/39 plus it uses `IndentWidth: 4` for `clang-format`. 
I think that formatting is easier to read, as the code is less dense. 
But as changing this param later on will require all touched files to be reformatted, I'm not very sure about it. 
Please let me know what you think.