### PR TITLE
Travis - coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ script:
   - if [ "$BUILD_TYPE" == "osx" ]; then source ./travis/build_osx_package.sh ; fi
 
 after_success:
-  - if [ "$CC" = "gcc-4.8" ] && [ "$CONF" = "coverage" ]; then ./travis/coverage.sh ; fi
+  - if [ "$CC" = "gcc-4.8" ] && [ "$CONF" = "coverage" ] && [ "$TRAVIS_REPO_SLUG" == "$GITHUB_REPO" ]; then ./travis/coverage.sh ; fi
   - if [ "$CC" = "gcc-4.8" ] && [ "$CONF" = "coverage" ]; then ./travis/style.sh ; fi
   - if [ "$BUILD_TYPE" == "doc" ] && [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then source ./travis/build_doc.sh ; fi
 


### PR DESCRIPTION
Building coverage only when destination is the upstream branch, so forks travis builds will not fail while trying to post something to coveralls.io.

see: https://travis-ci.org/narekgharibyan/keyvi-1/jobs/342801767