### PR TITLE
[index] rewrite make bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(keyvi)
 
-string(TOLOWER ${CMAKE_BUILD_TYPE} LOWERCASE_CMAKE_BUILD_TYPE)
-
 # configure C++11
 if(NOT CMAKE_VERSION VERSION_LESS 3.1)
     set(CMAKE_CXX_STANDARD 11)
@@ -61,25 +59,23 @@ include_directories(keyvi/3rdparty/tiny-process-library/)
 include_directories(${CMAKE_BINARY_DIR}/keyvi/3rdparty/tpie)
 include_directories(${CMAKE_BINARY_DIR}/keyvi/3rdparty/tiny-process-library/)
 
-# workaroundL we need to build something that requires tpie
+FILE(GLOB_RECURSE UNIT_TEST_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} keyvi/tests/keyvi/*.cpp)
+add_executable(unit_test_all ${UNIT_TEST_SOURCES})
+add_executable(keyvicompiler keyvi/bin/keyvicompiler/keyvicompiler.cpp)
+add_executable(keyviinspector keyvi/bin/keyviinspector/keyviinspector.cpp)
 add_executable(keyvimerger keyvi/bin/keyvimerger/keyvimerger.cpp)
+
+target_link_libraries(unit_test_all tiny-process-library tpie ${Boost_LIBRARIES} ${ZLIB_LIBRARIES})
+target_link_libraries(keyvicompiler tpie ${Boost_LIBRARIES} ${ZLIB_LIBRARIES})
+target_link_libraries(keyviinspector tpie ${Boost_LIBRARIES} ${ZLIB_LIBRARIES})
 target_link_libraries(keyvimerger tpie ${Boost_LIBRARIES} ${ZLIB_LIBRARIES})
-install (TARGETS keyvimerger DESTINATION bin)
 
-# if build for bindings, do not compile binaries and unit tests
-IF(NOT LOWERCASE_CMAKE_BUILD_TYPE MATCHES bindings)
-    FILE(GLOB_RECURSE UNIT_TEST_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} keyvi/tests/keyvi/*.cpp)
-    add_executable(unit_test_all ${UNIT_TEST_SOURCES})
-    add_executable(keyvicompiler keyvi/bin/keyvicompiler/keyvicompiler.cpp)
-    add_executable(keyviinspector keyvi/bin/keyviinspector/keyviinspector.cpp)
+install (TARGETS keyvicompiler DESTINATION bin COMPONENT applications OPTIONAL)
+install (TARGETS keyviinspector DESTINATION bin COMPONENT applications OPTIONAL)
+install (TARGETS keyvimerger DESTINATION bin COMPONENT applications)
 
-    target_link_libraries(keyvicompiler tpie ${Boost_LIBRARIES} ${ZLIB_LIBRARIES})
-    target_link_libraries(keyviinspector tpie ${Boost_LIBRARIES} ${ZLIB_LIBRARIES})
-    target_link_libraries(unit_test_all tiny-process-library tpie ${Boost_LIBRARIES} ${ZLIB_LIBRARIES})
-
-    install (TARGETS keyvicompiler DESTINATION bin)
-    install (TARGETS keyviinspector DESTINATION bin)
-ENDIF(NOT LOWERCASE_CMAKE_BUILD_TYPE MATCHES bindings)
-
-install  (FILES $<TARGET_FILE:tpie> DESTINATION lib CONFIGURATIONS bindings)
-install  (FILES $<TARGET_FILE:tiny-process-library> DESTINATION lib CONFIGURATIONS bindings)
+add_custom_target(bindings
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:tpie> ${CMAKE_BINARY_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:tiny-process-library> ${CMAKE_BINARY_DIR}
+    DEPENDS tpie tiny-process-library
+)

--- a/python/setup.py
+++ b/python/setup.py
@@ -62,9 +62,6 @@ with symlink_keyvi() as (pykeyvi_source_path, keyvi_source_path):
 
     dictionary_sources = path.abspath(keyvi_cpp_link)
     keyvi_build_dir = path.join(keyvi_cpp, 'build')
-    keyvi_install_prefix = 'install'
-    keyvi_install_dir = path.join(keyvi_build_dir, keyvi_install_prefix)
-    keyvi_lib_dir = path.join(keyvi_install_dir, 'lib')
 
     additional_compile_flags = []
 
@@ -95,7 +92,7 @@ with symlink_keyvi() as (pykeyvi_source_path, keyvi_source_path):
     mac_os_static_libs_dir = 'mac_os_static_libs'
 
     extra_link_arguments = []
-    link_library_dirs = [keyvi_lib_dir]
+    link_library_dirs = [keyvi_build_dir]
     zlib_root = None
 
     if sys.platform == 'darwin':
@@ -239,15 +236,12 @@ with symlink_keyvi() as (pykeyvi_source_path, keyvi_source_path):
 
             keyvi_build_cmd = 'mkdir -p {}'.format(keyvi_build_dir)
             keyvi_build_cmd += ' && cd {}'.format(keyvi_build_dir)
-            keyvi_build_cmd += ' && cmake -D CMAKE_BUILD_TYPE:STRING=bindings ' \
-                                ' -D CMAKE_CXX_FLAGS="{CXX_FLAGS}"' \
-                                ' -D CMAKE_INSTALL_PREFIX={INSTALL_PREFIX}'.format(
-                CXX_FLAGS=CMAKE_CXX_FLAGS, INSTALL_PREFIX=keyvi_install_prefix)
+            keyvi_build_cmd += ' && cmake' \
+                                ' -D CMAKE_CXX_FLAGS="{CXX_FLAGS}"'.format(CXX_FLAGS=CMAKE_CXX_FLAGS)
             if zlib_root is not None:
                  keyvi_build_cmd += ' -D ZLIB_ROOT={ZLIB_ROOT}'.format(ZLIB_ROOT=zlib_root)
             keyvi_build_cmd += ' ..'
-            keyvi_build_cmd += ' && make -j {}'.format(cpu_count)
-            keyvi_build_cmd += ' && make install'
+            keyvi_build_cmd += ' && make -j {} bindings'.format(cpu_count)
 
             print ("Building keyvi C++ part: " + keyvi_build_cmd)
             subprocess.call(keyvi_build_cmd, shell=True)


### PR DESCRIPTION
rewrite cmake target to introduce `make bindings` instead of using a build type