### PR TITLE
keyvi vector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,8 @@ target_link_libraries(keyviinspector tpie ${Boost_LIBRARIES} ${ZLIB_LIBRARIES})
 target_link_libraries(keyvimerger tpie ${Boost_LIBRARIES} ${ZLIB_LIBRARIES})
 target_link_libraries(keyvi_c tpie ${Boost_LIBRARIES} ${ZLIB_LIBRARIES})
 
+add_dependencies(unit_test_all keyvimerger)
+
 install (TARGETS keyvicompiler DESTINATION bin COMPONENT applications OPTIONAL)
 install (TARGETS keyviinspector DESTINATION bin COMPONENT applications OPTIONAL)
 install (TARGETS keyvimerger DESTINATION bin COMPONENT applications)

--- a/keyvi/include/keyvi/dictionary/fsa/automata.h
+++ b/keyvi/include/keyvi/dictionary/fsa/automata.h
@@ -90,7 +90,7 @@ class Automata final {
     transitions_region_ = boost::interprocess::mapped_region(
         file_mapping_, boost::interprocess::read_only, transitionsOffset, bucket_size * array_size, 0, map_options);
 
-    const auto advise = internal::MemoryMapFlags::ValuesGetMemoryMapAdvices(loading_strategy);
+    const auto advise = internal::MemoryMapFlags::FSAGetMemoryMapAdvices(loading_strategy);
 
     labels_region_.advise(advise);
     transitions_region_.advise(advise);

--- a/keyvi/include/keyvi/dictionary/util/endian.h
+++ b/keyvi/include/keyvi/dictionary/util/endian.h
@@ -22,65 +22,63 @@
  *      Author: hendrik
  */
 
-#ifndef SRC_CPP_DICTIONARY_UTIL_ENDIAN_H_
-#define SRC_CPP_DICTIONARY_UTIL_ENDIAN_H_
+#ifndef KEYVI_DICTIONARY_UTIL_ENDIAN_H_
+#define KEYVI_DICTIONARY_UTIL_ENDIAN_H_
 
 #if defined(OS_MACOSX)
-    #include <libkern/OSByteOrder.h>
+#include <libkern/OSByteOrder.h>
 
-    #define htobe16(x) OSSwapHostToBigInt16(x)
-    #define htole16(x) OSSwapHostToLittleInt16(x)
-    #define be16toh(x) OSSwapBigToHostInt16(x)
-    #define le16toh(x) OSSwapLittleToHostInt16(x)
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
 
-    #define htobe32(x) OSSwapHostToBigInt32(x)
-    #define htole32(x) OSSwapHostToLittleInt32(x)
-    #define be32toh(x) OSSwapBigToHostInt32(x)
-    #define le32toh(x) OSSwapLittleToHostInt32(x)
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
 
-    #define htobe64(x) OSSwapHostToBigInt64(x)
-    #define htole64(x) OSSwapHostToLittleInt64(x)
-    #define be64toh(x) OSSwapBigToHostInt64(x)
-    #define le64toh(x) OSSwapLittleToHostInt64(x)
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
 
-    #if defined(__LITTLE_ENDIAN__)
-        #define CLQ_LITTLE_ENDIAN
-    #elif defined(__BIG_ENDIAN__)
-        #define CLQ_BIG_ENDIAN
-    #else
-        #error "Unknown endianess"
-    #endif
+#if defined(__LITTLE_ENDIAN__)
+#define CLQ_LITTLE_ENDIAN
+#elif defined(__BIG_ENDIAN__)
+#define CLQ_BIG_ENDIAN
+#else
+#error "Unknown endianess"
+#endif
 
 #elif defined(OS_SOLARIS)
-    #include <sys/isa_defs.h>
-    #ifdef _LITTLE_ENDIAN
-        #define LITTLE_ENDIAN
-    #else
-        #define BIG_ENDIAN
-    #endif
+#include <sys/isa_defs.h>
+#ifdef _LITTLE_ENDIAN
+#define LITTLE_ENDIAN
+#else
+#define BIG_ENDIAN
+#endif
 #elif defined(OS_FREEBSD) || defined(OS_OPENBSD) || defined(OS_NETBSD) || defined(OS_DRAGONFLYBSD)
-    #include <sys/types.h>
-    #include <sys/endian.h>
+#include <sys/endian.h>
+#include <sys/types.h>
 #elif defined(__linux__) && (__BYTE_ORDER == __LITTLE_ENDIAN) && (__GLIBC__ <= 2 && __GLIBC_MINOR__ < 9)
 
-    #define CLQ_LITTLE_ENDIAN
-    #define htole16(x) (x)
-    #define le16toh(x) (x)
-    #define htole64(x) (x)
-    #define le64toh(x) (x)
+#define CLQ_LITTLE_ENDIAN
+#define htole16(x) (x)
+#define le16toh(x) (x)
+#define htole64(x) (x)
+#define le64toh(x) (x)
 
 #else
-    #include <endian.h>
-    #if __BYTE_ORDER == __LITTLE_ENDIAN
-        #define CLQ_LITTLE_ENDIAN
-    #elif __BYTE_ORDER == __BIG_ENDIAN
-        #define CLQ_BIG_ENDIAN
-    #else
-        #error "Unknown endianess"
-    #endif
+#include <endian.h>
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#define CLQ_LITTLE_ENDIAN
+#elif __BYTE_ORDER == __BIG_ENDIAN
+#define CLQ_BIG_ENDIAN
+#else
+#error "Unknown endianess"
+#endif
 
 #endif
 
-
-
-#endif /* SRC_CPP_DICTIONARY_UTIL_ENDIAN_H_ */
+#endif  // KEYVI_DICTIONARY_UTIL_ENDIAN_H_"

--- a/keyvi/include/keyvi/dictionary/util/endian.h
+++ b/keyvi/include/keyvi/dictionary/util/endian.h
@@ -66,8 +66,8 @@
     #define CLQ_LITTLE_ENDIAN
     #define htole16(x) (x)
     #define le16toh(x) (x)
-    #define htobe32(x) __bswap_32(x)
-    #define be32toh(x) __bswap_32(x)
+    #define htole64(x) (x)
+    #define le64toh(x) (x)
 
 #else
     #include <endian.h>

--- a/keyvi/include/keyvi/vector/types.h
+++ b/keyvi/include/keyvi/vector/types.h
@@ -1,0 +1,41 @@
+/* * keyvi - A key value store.
+ *
+ * Copyright 2018   Narek Gharibyan<narekgharibyan@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ *  types.h
+ *
+ *  Created on: March 17, 2018
+ *      Author: Narek Gharibyan <narekgharibyan@gmail.com>
+ */
+
+#ifndef KEYVI_VECTOR_TYPES_H_
+#define KEYVI_VECTOR_TYPES_H_
+
+#include "dictionary/fsa/internal/ivalue_store.h"
+#include "dictionary/fsa/internal/memory_map_manager.h"
+
+namespace keyvi {
+namespace vector {
+
+using offset_type = uint64_t;
+using MemoryMapManager = dictionary::fsa::internal::MemoryMapManager;
+using value_store_t = dictionary::fsa::internal::value_store_t;
+
+} /* namespace vector */
+} /* namespace keyvi */
+
+#endif  // KEYVI_VECTOR_TYPES_H_

--- a/keyvi/include/keyvi/vector/vector.h
+++ b/keyvi/include/keyvi/vector/vector.h
@@ -28,6 +28,7 @@
 #include <exception>
 #include <string>
 
+#include "dictionary/util/endian.h"
 #include "vector/vector_file.h"
 
 namespace keyvi {
@@ -44,7 +45,8 @@ class Vector final {
     if (index >= vector_file_.size_) {
       throw std::out_of_range("out of range access");
     }
-    return vector_file_.value_store_reader_->GetValueAsString(index_ptr_[index]);
+    const offset_type offset = le64toh(index_ptr_[index]);
+    return vector_file_.value_store_reader_->GetValueAsString(offset);
   }
 
   size_t Size() const { return vector_file_.size_; }

--- a/keyvi/include/keyvi/vector/vector.h
+++ b/keyvi/include/keyvi/vector/vector.h
@@ -1,0 +1,62 @@
+/* * keyvi - A key value store.
+ *
+ * Copyright 2018   Narek Gharibyan<narekgharibyan@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ *  vector.h
+ *
+ *  Created on: March 17, 2018
+ *      Author: Narek Gharibyan <narekgharibyan@gmail.com>
+ */
+
+#ifndef KEYVI_VECTOR_VECTOR_H_
+#define KEYVI_VECTOR_VECTOR_H_
+
+#include <exception>
+#include <string>
+
+#include "vector/vector_file.h"
+
+namespace keyvi {
+namespace vector {
+
+template <value_store_t value_store_type>
+class Vector final {
+ public:
+  explicit Vector(const std::string& filename)
+      : vector_file_(filename, value_store_type),
+        index_ptr_(static_cast<offset_type*>(vector_file_.index_region_.get_address())) {}
+
+  std::string Get(const size_t index) const throw(std::out_of_range) {
+    if (index >= vector_file_.size_) {
+      throw std::out_of_range("out of range access");
+    }
+    return vector_file_.value_store_reader_->GetValueAsString(index_ptr_[index]);
+  }
+
+  size_t Size() const { return vector_file_.size_; }
+
+  std::string Manifest() const { return vector_file_.manifest_; }
+
+ private:
+  const VectorFile vector_file_;
+  const offset_type* const index_ptr_;
+};
+
+} /* namespace vector */
+} /* namespace keyvi */
+
+#endif  //  KEYVI_VECTOR_VECTOR_H_

--- a/keyvi/include/keyvi/vector/vector_file.h
+++ b/keyvi/include/keyvi/vector/vector_file.h
@@ -79,7 +79,8 @@ class VectorFile {
     const auto map_options = dictionary::fsa::internal::MemoryMapFlags::FSAGetMemoryMapOptions(loading_strategy);
     index_region_ = mapped_region(file_mapping, boost::interprocess::read_only, in_stream.tellg(), index_size, nullptr,
                                   map_options);
-    index_region_.advise(mapped_region::advice_types::advice_random);
+    const auto advise = dictionary::fsa::internal::MemoryMapFlags::FSAGetMemoryMapAdvices(loading_strategy);
+    index_region_.advise(advise);
 
     in_stream.seekg(size_t(in_stream.tellg()) + index_size);
     value_store_reader_.reset(dictionary::fsa::internal::ValueStoreFactory::MakeReader(

--- a/keyvi/include/keyvi/vector/vector_file.h
+++ b/keyvi/include/keyvi/vector/vector_file.h
@@ -1,0 +1,147 @@
+/* * keyvi - A key value store.
+ *
+ * Copyright 2018   Narek Gharibyan<narekgharibyan@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ *  vector_file.h
+ *
+ *  Created on: March 17, 2018
+ *      Author: Narek Gharibyan <narekgharibyan@gmail.com>
+ */
+
+#ifndef KEYVI_VECTOR_VECTOR_FILE_H_
+#define KEYVI_VECTOR_VECTOR_FILE_H_
+
+#include <exception>
+#include <fstream>
+#include <memory>
+#include <string>
+
+#include <boost/property_tree/ptree.hpp>
+
+#include "dictionary/fsa/internal/value_store_factory.h"
+#include "util/serialization_utils.h"
+#include "vector/types.h"
+
+static const char KEYVI_VECTOR_BEGIN[] = "KEYVI_VECTOR_BEGIN";
+static const size_t KEYVI_VECTOR_BEGIN_LEN = 18;
+static const char KEYVI_VECTOR_END[] = "KEYVI_VECTOR_END";
+static const size_t KEYVI_VECTOR_END_LEN = 16;
+static const char MANIFEST[] = "manifest";
+static const char SIZE[] = "size";
+static const char VALUE_STORE_TYPE[] = "value_store_type";
+
+namespace keyvi {
+namespace vector {
+
+template <value_store_t>
+class Vector;
+
+class VectorFile {
+  template <value_store_t>
+  friend class Vector;
+
+  using mapped_region = boost::interprocess::mapped_region;
+  using IValueStoreReader = dictionary::fsa::internal::IValueStoreReader;
+
+ public:
+  explicit VectorFile(const std::string& filename, const value_store_t value_store_type) {
+    const auto loading_strategy = dictionary::loading_strategy_types::lazy_no_readahead;
+    std::ifstream in_stream(filename, std::ios::binary);
+
+    CheckValidity(&in_stream);
+
+    in_stream.seekg(KEYVI_VECTOR_BEGIN_LEN);
+    const auto file_ptree = util::SerializationUtils::ReadJsonRecord(in_stream);
+    if (value_store_type != boost::lexical_cast<size_t>(file_ptree.get<std::string>(VALUE_STORE_TYPE))) {
+      throw std::invalid_argument("wrong vector file");
+    }
+    manifest_ = file_ptree.get<std::string>(MANIFEST);
+
+    const auto index_ptree = util::SerializationUtils::ReadJsonRecord(in_stream);
+    size_ = boost::lexical_cast<size_t>(index_ptree.get<std::string>(SIZE));
+    const auto index_size = size_ * sizeof(offset_type);
+
+    auto file_mapping = boost::interprocess::file_mapping(filename.c_str(), boost::interprocess::read_only);
+    const auto map_options = dictionary::fsa::internal::MemoryMapFlags::FSAGetMemoryMapOptions(loading_strategy);
+    index_region_ = mapped_region(file_mapping, boost::interprocess::read_only, in_stream.tellg(), index_size, nullptr,
+                                  map_options);
+    index_region_.advise(mapped_region::advice_types::advice_random);
+
+    in_stream.seekg(size_t(in_stream.tellg()) + index_size);
+    value_store_reader_.reset(dictionary::fsa::internal::ValueStoreFactory::MakeReader(
+        value_store_type, in_stream, &file_mapping, loading_strategy));
+  }
+
+  template <typename ValueStoreT>
+  static void WriteToFile(const std::string& filename, const std::string& manifest,
+                          const std::unique_ptr<MemoryMapManager>& index_store, const size_t size,
+                          const std::unique_ptr<ValueStoreT>& value_store) {
+    std::ofstream out_stream(filename, std::ios::binary);
+
+    boost::property_tree::ptree file_ptree;
+    file_ptree.put("file_version", "1");
+    file_ptree.put(MANIFEST, manifest);
+    file_ptree.put(VALUE_STORE_TYPE, value_store->GetValueStoreType());
+    file_ptree.put("index_version", "1");
+
+    boost::property_tree::ptree index_ptree;
+    index_ptree.put(SIZE, std::to_string(size));
+
+    out_stream.write(KEYVI_VECTOR_BEGIN, KEYVI_VECTOR_BEGIN_LEN);
+    util::SerializationUtils::WriteJsonRecord(out_stream, file_ptree);
+    util::SerializationUtils::WriteJsonRecord(out_stream, index_ptree);
+
+    index_store->Write(out_stream, index_store->GetSize());
+    value_store->Write(out_stream);
+
+    out_stream.write(KEYVI_VECTOR_END, KEYVI_VECTOR_END_LEN);
+
+    out_stream.close();
+  }
+
+ private:
+  void CheckValidity(std::ifstream* in_stream) const {
+    if (!in_stream->good()) {
+      throw std::invalid_argument("file not found");
+    }
+    char magic_start[KEYVI_VECTOR_BEGIN_LEN];
+    in_stream->read(magic_start, KEYVI_VECTOR_BEGIN_LEN);
+    if (std::strncmp(magic_start, KEYVI_VECTOR_BEGIN, KEYVI_VECTOR_BEGIN_LEN)) {
+      throw std::invalid_argument("not a keyvi vector file");
+    }
+
+    in_stream->seekg(-KEYVI_VECTOR_END_LEN, std::ios_base::end);
+    char magic_end[KEYVI_VECTOR_END_LEN];
+    in_stream->read(magic_end, KEYVI_VECTOR_END_LEN);
+    if (std::strncmp(magic_end, KEYVI_VECTOR_END, KEYVI_VECTOR_END_LEN)) {
+      throw std::invalid_argument("the file is corrupt(truncated)");
+    }
+  }
+
+ private:
+  mapped_region index_region_;
+  std::unique_ptr<IValueStoreReader> value_store_reader_;
+
+  size_t size_;
+
+  std::string manifest_;
+};
+
+} /* namespace vector */
+} /* namespace keyvi */
+
+#endif  //  KEYVI_VECTOR_VECTOR_FILE_H_

--- a/keyvi/include/keyvi/vector/vector_file.h
+++ b/keyvi/include/keyvi/vector/vector_file.h
@@ -40,9 +40,9 @@ static const char KEYVI_VECTOR_BEGIN[] = "KEYVI_VECTOR_BEGIN";
 static const size_t KEYVI_VECTOR_BEGIN_LEN = 18;
 static const char KEYVI_VECTOR_END[] = "KEYVI_VECTOR_END";
 static const size_t KEYVI_VECTOR_END_LEN = 16;
-static const char MANIFEST[] = "manifest";
-static const char SIZE[] = "size";
-static const char VALUE_STORE_TYPE[] = "value_store_type";
+static const char MANIFEST_LABEL[] = "manifest";
+static const char SIZE_LABEL[] = "size";
+static const char VALUE_STORE_TYPE_LABEl[] = "value_store_type";
 
 namespace keyvi {
 namespace vector {
@@ -66,13 +66,13 @@ class VectorFile {
 
     in_stream.seekg(KEYVI_VECTOR_BEGIN_LEN);
     const auto file_ptree = util::SerializationUtils::ReadJsonRecord(in_stream);
-    if (value_store_type != boost::lexical_cast<size_t>(file_ptree.get<std::string>(VALUE_STORE_TYPE))) {
+    if (value_store_type != boost::lexical_cast<size_t>(file_ptree.get<std::string>(VALUE_STORE_TYPE_LABEl))) {
       throw std::invalid_argument("wrong vector file");
     }
-    manifest_ = file_ptree.get<std::string>(MANIFEST);
+    manifest_ = file_ptree.get<std::string>(MANIFEST_LABEL);
 
     const auto index_ptree = util::SerializationUtils::ReadJsonRecord(in_stream);
-    size_ = boost::lexical_cast<size_t>(index_ptree.get<std::string>(SIZE));
+    size_ = boost::lexical_cast<size_t>(index_ptree.get<std::string>(SIZE_LABEL));
     const auto index_size = size_ * sizeof(offset_type);
 
     auto file_mapping = boost::interprocess::file_mapping(filename.c_str(), boost::interprocess::read_only);
@@ -94,12 +94,12 @@ class VectorFile {
 
     boost::property_tree::ptree file_ptree;
     file_ptree.put("file_version", "1");
-    file_ptree.put(MANIFEST, manifest);
-    file_ptree.put(VALUE_STORE_TYPE, value_store->GetValueStoreType());
+    file_ptree.put(MANIFEST_LABEL, manifest);
+    file_ptree.put(VALUE_STORE_TYPE_LABEl, value_store->GetValueStoreType());
     file_ptree.put("index_version", "1");
 
     boost::property_tree::ptree index_ptree;
-    index_ptree.put(SIZE, std::to_string(size));
+    index_ptree.put(SIZE_LABEL, std::to_string(size));
 
     out_stream.write(KEYVI_VECTOR_BEGIN, KEYVI_VECTOR_BEGIN_LEN);
     util::SerializationUtils::WriteJsonRecord(out_stream, file_ptree);

--- a/keyvi/include/keyvi/vector/vector_generator.h
+++ b/keyvi/include/keyvi/vector/vector_generator.h
@@ -30,6 +30,7 @@
 #include <boost/filesystem/path.hpp>
 
 #include "dictionary/fsa/internal/constants.h"
+#include "dictionary/util/endian.h"
 #include "util/configuration.h"
 #include "vector/vector_file.h"
 
@@ -63,8 +64,10 @@ class VectorGenerator final {
   ~VectorGenerator() { boost::filesystem::remove_all(temporary_directory_); }
 
   void PushBack(typename ValueStoreT::value_t value) {
+    static_assert(sizeof(offset_type) == 8, "");
+
     bool dummy_minimization = false;
-    const offset_type value_idx = value_store_->GetValue(value, &dummy_minimization);
+    const offset_type value_idx = htole64(value_store_->GetValue(value, &dummy_minimization));
 
     index_store_->Append(&value_idx, sizeof(offset_type));
     ++size_;

--- a/keyvi/include/keyvi/vector/vector_generator.h
+++ b/keyvi/include/keyvi/vector/vector_generator.h
@@ -1,0 +1,91 @@
+/* * keyvi - A key value store.
+ *
+ * Copyright 2018   Narek Gharibyan<narekgharibyan@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ *  vector_generator.h
+ *
+ *  Created on: March 17, 2018
+ *      Author: Narek Gharibyan <narekgharibyan@gmail.com>
+ */
+
+#ifndef KEYVI_VECTOR_VECTOR_GENERATOR_H_
+#define KEYVI_VECTOR_VECTOR_GENERATOR_H_
+
+#include <string>
+
+#include <boost/filesystem/path.hpp>
+
+#include "dictionary/fsa/internal/constants.h"
+#include "util/configuration.h"
+#include "vector/vector_file.h"
+
+namespace keyvi {
+namespace vector {
+
+template <class ValueStoreT>
+class VectorGenerator final {
+  static const size_t INDEX_EXTERNAL_MEMORY_CHUNK_SIZE = sizeof(offset_type) * 100 * 1000 * 1000;
+
+  using parameters_t = keyvi::util::parameters_t;
+
+ public:
+  explicit VectorGenerator(const parameters_t& params_arg = parameters_t()) {
+    parameters_t params = params_arg;
+    params[TEMPORARY_PATH_KEY] = keyvi::util::mapGetTemporaryPath(params);
+    params[MINIMIZATION_KEY] = "off";
+
+    temporary_directory_ = params[TEMPORARY_PATH_KEY];
+    temporary_directory_ /= boost::filesystem::unique_path("keyvi-vector-%%%%-%%%%-%%%%-%%%%");
+    boost::filesystem::create_directory(temporary_directory_);
+
+    index_store_.reset(new MemoryMapManager(INDEX_EXTERNAL_MEMORY_CHUNK_SIZE, temporary_directory_, "index-chunk"));
+    value_store_.reset(new ValueStoreT(params));
+  }
+
+  VectorGenerator& operator=(VectorGenerator const&) = delete;
+
+  VectorGenerator(const VectorGenerator&) = delete;
+
+  ~VectorGenerator() { boost::filesystem::remove_all(temporary_directory_); }
+
+  void PushBack(typename ValueStoreT::value_t value) {
+    bool dummy_minimization = false;
+    const offset_type value_idx = value_store_->GetValue(value, &dummy_minimization);
+
+    index_store_->Append(&value_idx, sizeof(offset_type));
+    ++size_;
+  }
+
+  void SetManifest(const std::string& manifest) { manifest_ = manifest; }
+
+  void WriteToFile(const std::string& filename) {
+    VectorFile::WriteToFile(filename, manifest_, index_store_, size_, value_store_);
+  }
+
+ private:
+  boost::filesystem::path temporary_directory_;
+  std::unique_ptr<MemoryMapManager> index_store_;
+  std::unique_ptr<ValueStoreT> value_store_;
+  size_t size_ = 0;
+
+  std::string manifest_;
+};
+
+} /* namespace vector */
+} /* namespace keyvi */
+
+#endif  // KEYVI_VECTOR_VECTOR_GENERATOR_H_

--- a/keyvi/include/keyvi/vector/vector_types.h
+++ b/keyvi/include/keyvi/vector/vector_types.h
@@ -1,0 +1,44 @@
+/* * keyvi - A key value store.
+ *
+ * Copyright 2018   Narek Gharibyan<narekgharibyan@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ *  vector_types.h
+ *
+ *  Created on: March 17, 2018
+ *      Author: Narek Gharibyan <narekgharibyan@gmail.com>
+ */
+
+#ifndef KEYVI_VECTOR_VECTOR_TYPES_H_
+#define KEYVI_VECTOR_VECTOR_TYPES_H_
+
+#include "vector/types.h"
+#include "vector/vector.h"
+#include "vector/vector_generator.h"
+
+namespace keyvi {
+namespace vector {
+
+using JsonVectorGenerator = VectorGenerator<dictionary::fsa::internal::JsonValueStore>;
+using StringVectorGenerator = VectorGenerator<dictionary::fsa::internal::StringValueStore>;
+
+using JsonVector = Vector<value_store_t::JSON_VALUE_STORE>;
+using StringVector = Vector<value_store_t::STRING_VALUE_STORE>;
+
+} /* namespace vector */
+} /* namespace keyvi */
+
+#endif  // KEYVI_VECTOR_VECTOR_TYPES_H_

--- a/keyvi/tests/keyvi/vector/basic_test.cpp
+++ b/keyvi/tests/keyvi/vector/basic_test.cpp
@@ -1,0 +1,144 @@
+/* * keyvi - A key value store.
+ *
+ * Copyright 2018   Narek Gharibyan<narekgharibyan@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ *  basic_test.h
+ *
+ *  Created on: March 17, 2018
+ *      Author: Narek Gharibyan <narekgharibyan@gmail.com>
+ */
+
+#include <exception>
+#include <string>
+
+#include <boost/test/unit_test.hpp>
+
+#include "vector/vector_types.h"
+
+namespace keyvi {
+namespace vector {
+
+BOOST_AUTO_TEST_SUITE(VectorTests)
+
+BOOST_AUTO_TEST_CASE(string_test) {
+  StringVectorGenerator generator;
+
+  const std::string filename = "vector_string.kvv";
+  const size_t size = 100;
+
+  for (size_t i = 0; i < size; ++i) {
+    generator.PushBack(std::to_string(i));
+  }
+
+  generator.WriteToFile(filename);
+
+  StringVector vector(filename);
+  BOOST_CHECK_EQUAL(size, vector.Size());
+
+  for (size_t i = 0; i < vector.Size(); ++i) {
+    BOOST_CHECK_EQUAL(std::to_string(i), vector.Get(i));
+  }
+}
+
+BOOST_AUTO_TEST_CASE(string_out_of_range) {
+  StringVectorGenerator generator;
+
+  const std::string filename = "vector_string.kvv";
+  const size_t size = 100;
+
+  for (size_t i = 0; i < size; ++i) {
+    generator.PushBack(std::to_string(i));
+  }
+
+  generator.WriteToFile(filename);
+
+  StringVector vector(filename);
+  BOOST_CHECK_THROW(vector.Get(size + 1), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE(json_test) {
+  JsonVectorGenerator generator;
+
+  const std::string filename = "vector.kvv";
+  const size_t size = 100;
+
+  for (size_t i = 0; i < size; ++i) {
+    generator.PushBack(std::to_string(i));
+  }
+
+  generator.WriteToFile(filename);
+
+  JsonVector vector(filename);
+  BOOST_CHECK_EQUAL(size, vector.Size());
+
+  for (size_t i = 0; i < vector.Size(); ++i) {
+    BOOST_CHECK_EQUAL(std::to_string(i), vector.Get(i));
+  }
+}
+
+BOOST_AUTO_TEST_CASE(manifest) {
+  const std::string filename = "vector.kvv";
+
+  JsonVectorGenerator generator;
+  generator.SetManifest("Some manifest");
+  generator.WriteToFile(filename);
+
+  JsonVector vector(filename);
+
+  BOOST_CHECK_EQUAL(vector.Manifest(), "Some manifest");
+}
+
+BOOST_AUTO_TEST_CASE(wrong_value_store) {
+  JsonVectorGenerator generator;
+
+  const std::string filename = "vector.kvv";
+  generator.WriteToFile(filename);
+
+  BOOST_CHECK_THROW(std::move(StringVector(filename)), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(truncation) {
+  JsonVectorGenerator generator;
+
+  const std::string filename = "vector.kvv";
+  generator.WriteToFile(filename);
+
+  // make sure file is okay
+  JsonVector vector_normal(filename);
+
+  std::ifstream in_stream(filename);
+  in_stream.seekg(0, std::ios_base::end);
+  const int file_size = in_stream.tellg();
+  in_stream.seekg(0, std::ios_base::beg);
+
+  std::vector<char> file_content(file_size);
+
+  in_stream.read(file_content.data(), file_size);
+
+  const std::string truncated_filename = "truncated_vector.kvv";
+
+  std::ofstream truncated_file(truncated_filename);
+  truncated_file.write(file_content.data(), file_size - 1);
+  truncated_file.close();
+
+  BOOST_CHECK_THROW(std::move(JsonVector(truncated_filename)), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace vector
+}  // namespace keyvi

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,5 +1,6 @@
 # PyTest
 .cache
+.pytest_cache
 
 # build artifacts
 keyvi.egg-info/

--- a/python/setup.py
+++ b/python/setup.py
@@ -295,6 +295,7 @@ with symlink_keyvi() as (pykeyvi_source_path, keyvi_source_path):
                   'keyvi.dictionary',
                   'keyvi.index',
                   'keyvi.util',
+                  'keyvi.vector',
                   'keyvi._pycore'],
         package_dir={'': 'src/py'},
         ext_modules=ext_modules,

--- a/python/src/addons/JsonVector.pyx
+++ b/python/src/addons/JsonVector.pyx
@@ -1,0 +1,8 @@
+
+
+    def Get(self,  index ):
+        assert isinstance(index, (int, long)), 'arg index wrong type'
+
+        cdef libcpp_utf8_string _r = self.inst.get().Get((<size_t>index))
+        py_result = json.loads(_r.decode('utf-8'))
+        return py_result

--- a/python/src/addons/JsonVectorGenerator.pyx
+++ b/python/src/addons/JsonVectorGenerator.pyx
@@ -1,0 +1,5 @@
+
+
+    def PushBack(self,  in_0 ):
+        dumps = json.dumps(in_0).encode('utf-8')
+        self.inst.get().PushBack((<libcpp_utf8_string>dumps))

--- a/python/src/pxds/vector.pxd
+++ b/python/src/pxds/vector.pxd
@@ -1,0 +1,15 @@
+from libcpp.string cimport string as libcpp_utf8_string
+
+cdef extern from "vector/vector_types.h" namespace "keyvi::vector":
+    cdef cppclass JsonVector:
+        JsonVector(libcpp_utf8_string filename) except +
+        libcpp_utf8_string Get(size_t index) # wrap-ignore
+        size_t Size()
+        libcpp_utf8_string Manifest()
+
+cdef extern from "vector/vector_types.h" namespace "keyvi::vector":
+    cdef cppclass StringVector:
+        StringVector(libcpp_utf8_string filename) except +
+        libcpp_utf8_string Get(size_t index)
+        size_t Size()
+        libcpp_utf8_string Manifest()

--- a/python/src/pxds/vector_generator.pxd
+++ b/python/src/pxds/vector_generator.pxd
@@ -1,0 +1,18 @@
+from libcpp.string  cimport string as libcpp_utf8_string
+from libcpp.map cimport map as libcpp_map
+
+cdef extern from "vector/vector_types.h" namespace "keyvi::vector":
+    cdef cppclass JsonVectorGenerator:
+        JsonVectorGenerator() except +
+        JsonVectorGenerator(libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
+        void PushBack(libcpp_utf8_string) # wrap-ignore
+        void SetManifest(libcpp_utf8_string)
+        void WriteToFile(libcpp_utf8_string) except +
+
+cdef extern from "vector/vector_types.h" namespace "keyvi::vector":
+    cdef cppclass StringVectorGenerator:
+        StringVectorGenerator() except +
+        StringVectorGenerator(libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
+        void PushBack(libcpp_utf8_string)
+        void SetManifest(libcpp_utf8_string)
+        void WriteToFile(libcpp_utf8_string) except +

--- a/python/src/py/keyvi/vector/__init__.py
+++ b/python/src/py/keyvi/vector/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+'''
+keyvi - A key value store.
+
+Copyright 2018 Narek Gharibyan<narekgharibyan@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http:www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+
+from keyvi._core import JsonVector, StringVector
+from keyvi._core import JsonVectorGenerator, StringVectorGenerator

--- a/python/tests/vector/basic_test.py
+++ b/python/tests/vector/basic_test.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Usage: py.test tests
+
+import os
+
+import keyvi.vector
+
+
+def test_basic_json_test():
+    generator = keyvi.vector.JsonVectorGenerator()
+
+    size = 10000
+
+    for i in range(size):
+        generator.PushBack([i, i + 1])
+
+    generator.WriteToFile('vector_json_basic_test.kv')
+
+    vector = keyvi.vector.JsonVector('vector_json_basic_test.kv')
+
+    assert size == vector.Size()
+
+    for i in range(size):
+        assert [i, i + 1] == vector.Get(i)
+
+    os.remove('vector_json_basic_test.kv')
+
+
+def test_basic_string_test():
+    generator = keyvi.vector.StringVectorGenerator()
+
+    size = 10000
+
+    for i in range(size):
+        generator.PushBack(str(i))
+
+    generator.WriteToFile('vector_string_basic_test.kv')
+
+    vector = keyvi.vector.StringVector('vector_string_basic_test.kv')
+
+    assert size == vector.Size()
+
+    for i in range(size):
+        assert str(i) == vector.Get(i)
+
+    os.remove('vector_string_basic_test.kv')
+
+
+def test_basic_manifest():
+    generator = keyvi.vector.StringVectorGenerator()
+    generator.SetManifest('manifest')
+    generator.WriteToFile('vector_manifest.kv')
+
+    vector = keyvi.vector.StringVector('vector_manifest.kv')
+    assert 'manifest' == vector.Manifest()
+
+    os.remove('vector_manifest.kv')


### PR DESCRIPTION
This implements `keyvi.vector` which is a `vector` like `read-only` data-structure implemented by utilizing `mmap`. It enables possibility to access data via just 2 page accesses and basically has a 0 memory requirement.

Some stuff that can be added later: 
 - `msgpack` can be used from python bindings to make it even faster
 - `resize()` like functionality in order to enable assignment by index, and not just only `PushBack`
 - `cross-architecture` support - `done`
