### PR TITLE
add error handling in memorymapmanager

### DIFF
--- a/keyvi/include/keyvi/dictionary/fsa/internal/memory_map_manager.h
+++ b/keyvi/include/keyvi/dictionary/fsa/internal/memory_map_manager.h
@@ -183,8 +183,6 @@ class MemoryMapManager final {
         if (!data_stream) {
           throw memory_map_manager_exception("failed to write into output stream");
         }
-
-        data_stream.close();
       }
     } else if (number_of_chunks_ == 0) {
       return;


### PR DESCRIPTION
adds error handling to memory map manager so that problems like exhausted file handles get visible.

relates #60