### PR TITLE
Fix issue with deleted keys on index reload and lazy loading

### DIFF
--- a/keyvi/include/keyvi/index/internal/index_writer_worker.h
+++ b/keyvi/include/keyvi/index/internal/index_writer_worker.h
@@ -347,7 +347,7 @@ class IndexWriterWorker final {
     for (boost::property_tree::ptree::value_type& f : index_toc.get_child("files")) {
       boost::filesystem::path p(payload_.index_directory_);
       p /= f.second.data();
-      payload_.segments_->emplace_back(new Segment(p));
+      payload_.segments_->emplace_back(new Segment(p, false));
     }
   }
 
@@ -386,7 +386,7 @@ class IndexWriterWorker final {
     // add/register new segment
     // we have to copy the segments (shallow copy/list of shared pointers to segments)
     // and then swap it
-    segment_t new_segment(new Segment(p));
+    segment_t new_segment(new Segment(p, true));
     segments_t new_segments = std::make_shared<segment_vec_t>(*payload->segments_);
     new_segments->push_back(new_segment);
 

--- a/keyvi/include/keyvi/index/internal/merge_job.h
+++ b/keyvi/include/keyvi/index/internal/merge_job.h
@@ -100,7 +100,7 @@ class MergeJob final {
   const std::vector<segment_t>& Segments() const { return payload_.segments_; }
 
   const segment_t MergedSegment() const {
-    return segment_t(new Segment(payload_.output_filename_, payload_.segments_, false));
+    return segment_t(new Segment(payload_.output_filename_, payload_.segments_));
   }
 
   void SetMerged() { payload_.merge_done = true; }

--- a/keyvi/include/keyvi/index/internal/merge_policy.h
+++ b/keyvi/include/keyvi/index/internal/merge_policy.h
@@ -19,6 +19,7 @@
 #ifndef KEYVI_INDEX_INTERNAL_MERGE_POLICY_H_
 #define KEYVI_INDEX_INTERNAL_MERGE_POLICY_H_
 
+#include <cstddef>
 #include <vector>
 
 #include "index/internal/segment.h"

--- a/keyvi/include/keyvi/index/internal/read_only_segment.h
+++ b/keyvi/include/keyvi/index/internal/read_only_segment.h
@@ -62,7 +62,8 @@ class ReadOnlySegment {
     deleted_keys_path_ += ".dk";
     deleted_keys_during_merge_path_ += ".dkm";
 
-    Load();
+    LoadDictionary();
+    LoadDeletedKeys();
   }
 
   dictionary::dictionary_t& operator*() { return dictionary_; }
@@ -104,47 +105,10 @@ class ReadOnlySegment {
   const std::string& GetDictionaryFilename() const { return dictionary_filename_; }
 
  protected:
-  void Load() {
+  void LoadDictionary() {
     // load dictionary
     dictionary_.reset(new dictionary::Dictionary(dictionary_path_.string()));
-
-    // load deleted keys
-    LoadDeletedKeys();
   }
-
- private:
-  //! path of the underlying dictionary
-  boost::filesystem::path dictionary_path_;
-
-  //! list of deleted keys
-  boost::filesystem::path deleted_keys_path_;
-
-  //! deleted keys while segment gets merged with other segments
-  boost::filesystem::path deleted_keys_during_merge_path_;
-
-  //! just the filename part of the dictionary
-  std::string dictionary_filename_;
-
-  //! the dictionary itself
-  dictionary::dictionary_t dictionary_;
-
-  //! quick and cheap check whether this segment has deletes (assuming that deletes are rare)
-  std::atomic_bool has_deleted_keys_;
-
-  //! deleted keys
-  std::shared_ptr<std::unordered_set<std::string>> deleted_keys_;
-
-  //! a weak ptr to deleted keys for access in the main thread
-  std::weak_ptr<std::unordered_set<std::string>> deleted_keys_weak_;
-
-  //! a mutex to secure access to the deleted keys shared pointer
-  std::mutex mutex_;
-
-  //! last modification time for the deleted keys file
-  std::time_t last_modification_time_deleted_keys_;
-
-  //! last modification time for the deleted keys file during a merge operation
-  std::time_t last_modification_time_deleted_keys_during_merge_;
 
   void LoadDeletedKeys() {
     TRACE("load deleted keys");
@@ -190,6 +154,42 @@ class ReadOnlySegment {
       has_deleted_keys_ = true;
     }
   }
+
+  const std::unordered_set<std::string>& DeletedKeysDirect() const { return *deleted_keys_; }
+
+ private:
+  //! path of the underlying dictionary
+  boost::filesystem::path dictionary_path_;
+
+  //! list of deleted keys
+  boost::filesystem::path deleted_keys_path_;
+
+  //! deleted keys while segment gets merged with other segments
+  boost::filesystem::path deleted_keys_during_merge_path_;
+
+  //! just the filename part of the dictionary
+  std::string dictionary_filename_;
+
+  //! the dictionary itself
+  dictionary::dictionary_t dictionary_;
+
+  //! quick and cheap check whether this segment has deletes (assuming that deletes are rare)
+  std::atomic_bool has_deleted_keys_;
+
+  //! deleted keys
+  std::shared_ptr<std::unordered_set<std::string>> deleted_keys_;
+
+  //! a weak ptr to deleted keys for access in the main thread
+  std::weak_ptr<std::unordered_set<std::string>> deleted_keys_weak_;
+
+  //! a mutex to secure access to the deleted keys shared pointer
+  std::mutex mutex_;
+
+  //! last modification time for the deleted keys file
+  std::time_t last_modification_time_deleted_keys_;
+
+  //! last modification time for the deleted keys file during a merge operation
+  std::time_t last_modification_time_deleted_keys_during_merge_;
 
   inline static std::unordered_set<std::string> LoadAndUnserializeDeletedKeys(const std::string& filename) {
     TRACE("loading deleted keys file %s", filename.c_str());

--- a/keyvi/include/keyvi/index/internal/read_only_segment.h
+++ b/keyvi/include/keyvi/index/internal/read_only_segment.h
@@ -105,6 +105,28 @@ class ReadOnlySegment {
   const std::string& GetDictionaryFilename() const { return dictionary_filename_; }
 
  protected:
+  explicit ReadOnlySegment(const boost::filesystem::path& path, bool load_dictionary, bool load_deleted_keys)
+      : dictionary_path_(path),
+        deleted_keys_path_(path),
+        deleted_keys_during_merge_path_(path),
+        dictionary_filename_(path.filename().string()),
+        dictionary_(),
+        has_deleted_keys_(false),
+        deleted_keys_(),
+        last_modification_time_deleted_keys_(0),
+        last_modification_time_deleted_keys_during_merge_(0) {
+    deleted_keys_path_ += ".dk";
+    deleted_keys_during_merge_path_ += ".dkm";
+
+    if (load_dictionary) {
+      LoadDictionary();
+    }
+
+    if (load_deleted_keys) {
+      LoadDeletedKeys();
+    }
+  }
+
   void LoadDictionary() {
     // load dictionary
     dictionary_.reset(new dictionary::Dictionary(dictionary_path_.string()));

--- a/keyvi/include/keyvi/index/internal/segment.h
+++ b/keyvi/include/keyvi/index/internal/segment.h
@@ -41,34 +41,27 @@ namespace internal {
 
 class Segment final : public ReadOnlySegment {
  public:
-  explicit Segment(const boost::filesystem::path& path, const bool load = false)
+  explicit Segment(const boost::filesystem::path& path, bool no_deletes = false)
       : ReadOnlySegment(path),
         deleted_keys_for_write_(),
         deleted_keys_during_merge_for_write_(),
-        loaded(load),
+        dictionary_loaded(false),
+        deletes_loaded(no_deletes),
         in_merge_(false),
         new_delete_(false),
         deleted_keys_swap_filename_(path) {
-    if (load) {
-      Load();
-    }
-
     deleted_keys_swap_filename_ += ".dk-swap";
   }
 
-  explicit Segment(const boost::filesystem::path& path, const std::vector<std::shared_ptr<Segment>>& parent_segments,
-                   const bool load = true)
+  explicit Segment(const boost::filesystem::path& path, const std::vector<std::shared_ptr<Segment>>& parent_segments)
       : ReadOnlySegment(path),
         deleted_keys_for_write_(),
         deleted_keys_during_merge_for_write_(),
-        loaded(load),
+        dictionary_loaded(false),
+        deletes_loaded(true),
         in_merge_(false),
         new_delete_(false),
         deleted_keys_swap_filename_(path) {
-    if (load) {
-      Load();
-    }
-
     deleted_keys_swap_filename_ += ".dk-swap";
 
     // move deletions that happened during merge into the list of deleted keys
@@ -85,28 +78,27 @@ class Segment final : public ReadOnlySegment {
   }
 
   dictionary::dictionary_t& operator*() {
-    LazyLoad();
+    LazyLoadDictionary();
     return ReadOnlySegment::GetDictionary();
   }
 
   dictionary::dictionary_t& GetDictionary() {
-    LazyLoad();
+    LazyLoadDictionary();
     return ReadOnlySegment::GetDictionary();
   }
 
   bool HasDeletedKeys() {
-    LazyLoad();
+    LazyLoadDeletedKeys();
     return ReadOnlySegment::HasDeletedKeys();
   }
 
   const std::shared_ptr<std::unordered_set<std::string>> DeletedKeys() {
-    LazyLoad();
+    LazyLoadDeletedKeys();
     return ReadOnlySegment::DeletedKeys();
   }
 
   bool IsDeleted(const std::string& key) {
-    LazyLoad();
-
+    LazyLoadDeletedKeys();
     return ReadOnlySegment::IsDeleted(key);
   }
 
@@ -143,6 +135,9 @@ class Segment final : public ReadOnlySegment {
       return;
     }
 
+    // load deleted keys as well
+    LazyLoadDeletedKeys();
+
     if (in_merge_) {
       TRACE("delete key (in merge) %s", key.c_str());
       deleted_keys_during_merge_for_write_.insert(key);
@@ -174,15 +169,32 @@ class Segment final : public ReadOnlySegment {
  private:
   std::unordered_set<std::string> deleted_keys_for_write_;
   std::unordered_set<std::string> deleted_keys_during_merge_for_write_;
-  bool loaded;
+  bool dictionary_loaded;
+  bool deletes_loaded;
   bool in_merge_;
   bool new_delete_;
   boost::filesystem::path deleted_keys_swap_filename_;
 
-  inline void LazyLoad() {
-    if (!loaded) {
-      Load();
-      loaded = true;
+  inline void LazyLoadDictionary() {
+    if (!dictionary_loaded) {
+      LoadDictionary();
+      dictionary_loaded = true;
+    }
+  }
+
+  inline void LazyLoadDeletedKeys() {
+    if (!deletes_loaded) {
+      LoadDeletedKeys();
+
+      // get a copy of the deleted keys for writing
+      if (ReadOnlySegment::HasDeletedKeys()) {
+        if (in_merge_) {
+          deleted_keys_during_merge_for_write_.insert(DeletedKeysDirect().begin(), DeletedKeysDirect().end());
+        } else {
+          deleted_keys_for_write_.insert(DeletedKeysDirect().begin(), DeletedKeysDirect().end());
+        }
+      }
+      deletes_loaded = true;
     }
   }
 

--- a/keyvi/include/keyvi/index/internal/segment.h
+++ b/keyvi/include/keyvi/index/internal/segment.h
@@ -42,7 +42,7 @@ namespace internal {
 class Segment final : public ReadOnlySegment {
  public:
   explicit Segment(const boost::filesystem::path& path, bool no_deletes = false)
-      : ReadOnlySegment(path),
+      : ReadOnlySegment(path, false, !no_deletes),
         deleted_keys_for_write_(),
         deleted_keys_during_merge_for_write_(),
         dictionary_loaded(false),
@@ -54,7 +54,7 @@ class Segment final : public ReadOnlySegment {
   }
 
   explicit Segment(const boost::filesystem::path& path, const std::vector<std::shared_ptr<Segment>>& parent_segments)
-      : ReadOnlySegment(path),
+      : ReadOnlySegment(path, false, false),
         deleted_keys_for_write_(),
         deleted_keys_during_merge_for_write_(),
         dictionary_loaded(false),

--- a/keyvi/include/keyvi/index/internal/simple_merge_policy.h
+++ b/keyvi/include/keyvi/index/internal/simple_merge_policy.h
@@ -44,6 +44,10 @@ class SimpleMergePolicy final : public MergePolicy {
         TRACE("Add to merge list %s", s->GetFilename().c_str());
         to_merge.push_back(s);
       }
+
+      if (to_merge.size() > MAX_SEGMENT_PER_MERGE) {
+        break;
+      }
     }
 
     *id = 0;
@@ -54,6 +58,9 @@ class SimpleMergePolicy final : public MergePolicy {
 
     return false;
   }
+
+ private:
+  static const size_t MAX_SEGMENT_PER_MERGE = 500;
 };
 
 } /* namespace internal */

--- a/keyvi/tests/keyvi/index/internal/segment_test.cpp
+++ b/keyvi/tests/keyvi/index/internal/segment_test.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(deletekey) {
   testing::TempDictionary dictionary = testing::TempDictionary::makeTempDictionaryFromJson(&test_data);
 
   // do with lazy load
-  segment_t segment(new Segment(dictionary.GetFileName(), false));
+  segment_t segment(new Segment(dictionary.GetFileName()));
 
   // delete a key
   segment->DeleteKey("abc");
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE(deletekeyMerging) {
   testing::TempDictionary dictionary2 = testing::TempDictionary::makeTempDictionaryFromJson(&test_data_segment2);
 
   // mixin lazy load
-  segment_t segment2(new Segment(dictionary2.GetFileName(), false));
+  segment_t segment2(new Segment(dictionary2.GetFileName()));
 
   // simulate a merge operation
   segment1->ElectedForMerge();
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE(deletekeyendtoend) {
                                                              {"tyc", "{o:2}"}};
   testing::TempDictionary dictionary = testing::TempDictionary::makeTempDictionaryFromJson(&test_data);
 
-  segment_t segment(new Segment(dictionary.GetFileName(), true));
+  segment_t segment(new Segment(dictionary.GetFileName()));
 
   BOOST_CHECK(!segment->HasDeletedKeys());
   BOOST_CHECK(!segment->DeletedKeys());


### PR DESCRIPTION
Fix an issue that deleted keys were not loaded correctly on index reload from disk. Also fixes lazy loading for segments in writer. 