### PR TITLE
add python 3.6 as classifier

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -310,6 +310,7 @@ with symlink_keyvi() as (pykeyvi_source_path, keyvi_source_path):
             'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: Implementation :: CPython',
             'Programming Language :: Python :: Implementation :: PyPy',
             'Operating System :: MacOS :: MacOS X',


### PR DESCRIPTION
adds python 3.6 to description

Should fix the badge after the next release