### PR TITLE
Index Autoconfiguration, overcoming filedescriptor limitations

### DIFF
--- a/keyvi/include/keyvi/index/constants.h
+++ b/keyvi/include/keyvi/index/constants.h
@@ -43,4 +43,7 @@ static const char DEFAULT_KEYVIMERGER_BIN[] = "keyvimerger";
 // spinlock wait time if there are to many segments
 static const size_t SPINLOCK_WAIT_FOR_SEGMENT_MERGES_MS = 10;
 
+// max parallel process for segment merging
+static const size_t MAX_CONCURRENT_MERGES_DEFAULT = 8;
+
 #endif  // KEYVI_INDEX_CONSTANTS_H_

--- a/keyvi/include/keyvi/index/constants.h
+++ b/keyvi/include/keyvi/index/constants.h
@@ -40,7 +40,7 @@ static const size_t DEFAULT_REFRESH_INTERVAL = 1000ul;
 static const size_t DEFAULT_COMPILE_KEY_THRESHOLD = 10000ul;
 static const char DEFAULT_KEYVIMERGER_BIN[] = "keyvimerger";
 
-// spinlock wait time if there are to many segments
+// spinlock wait time if there are too many segments
 static const size_t SPINLOCK_WAIT_FOR_SEGMENT_MERGES_MS = 10;
 
 // max parallel process for segment merging

--- a/keyvi/include/keyvi/index/constants.h
+++ b/keyvi/include/keyvi/index/constants.h
@@ -41,6 +41,6 @@ static const size_t DEFAULT_COMPILE_KEY_THRESHOLD = 10000ul;
 static const char DEFAULT_KEYVIMERGER_BIN[] = "keyvimerger";
 
 // spinlock wait time if there are to many segments
-static const size_t SPINLOCK_WAIT_FOR_SEGMENT_MERGES = 10;
+static const size_t SPINLOCK_WAIT_FOR_SEGMENT_MERGES_MS = 10;
 
 #endif  // KEYVI_INDEX_CONSTANTS_H_

--- a/keyvi/include/keyvi/index/constants.h
+++ b/keyvi/include/keyvi/index/constants.h
@@ -25,11 +25,22 @@
 #ifndef KEYVI_INDEX_CONSTANTS_H_
 #define KEYVI_INDEX_CONSTANTS_H_
 
+#include <cstddef>
+
 static const char INDEX_REFRESH_INTERVAL[] = "refresh_interval";
 static const char MERGE_POLICY[] = "merge_policy";
 static const char DEFAULT_MERGE_POLICY[] = "simple";
 static const char KEYVIMERGER_BIN[] = "keyvimerger_bin";
 static const char INDEX_MAX_SEGMENTS[] = "max_segments";
 static const char SEGMENT_COMPILE_KEY_THRESHOLD[] = "segment_compile_key_threshold";
+static const char MAX_CONCURRENT_MERGES[] = "max_concurrent_merges";
+
+// defaults
+static const size_t DEFAULT_REFRESH_INTERVAL = 1000ul;
+static const size_t DEFAULT_COMPILE_KEY_THRESHOLD = 10000ul;
+static const char DEFAULT_KEYVIMERGER_BIN[] = "keyvimerger";
+
+// spinlock wait time if there are to many segments
+static const size_t SPINLOCK_WAIT_FOR_SEGMENT_MERGES = 10;
 
 #endif  // KEYVI_INDEX_CONSTANTS_H_

--- a/keyvi/include/keyvi/index/constants.h
+++ b/keyvi/include/keyvi/index/constants.h
@@ -29,5 +29,7 @@ static const char INDEX_REFRESH_INTERVAL[] = "refresh_interval";
 static const char MERGE_POLICY[] = "merge_policy";
 static const char DEFAULT_MERGE_POLICY[] = "simple";
 static const char KEYVIMERGER_BIN[] = "keyvimerger_bin";
+static const char INDEX_MAX_SEGMENTS[] = "max_segments";
+static const char SEGMENT_COMPILE_KEY_THRESHOLD[] = "segment_compile_key_threshold";
 
 #endif  // KEYVI_INDEX_CONSTANTS_H_

--- a/keyvi/include/keyvi/index/internal/index_auto_config.h
+++ b/keyvi/include/keyvi/index/internal/index_auto_config.h
@@ -44,7 +44,8 @@ namespace internal {
 class IndexAutoConfig final {
  public:
   static size_t MaxSegments() {
-    // increase file descriptors and leave some extra room, to be improved later
+    // increase file descriptors and leave some extra room, 1 segment == 1 file, but we want
+    // to leave some room for the client.
     size_t file_descriptors = keyvi::util::OsUtils::TryIncreaseFileDescriptors();
     return file_descriptors - 100;
   }

--- a/keyvi/include/keyvi/index/internal/index_auto_config.h
+++ b/keyvi/include/keyvi/index/internal/index_auto_config.h
@@ -1,0 +1,64 @@
+/* * keyvi - A key value store.
+ *
+ * Copyright 2018 Hendrik Muhs<hendrik.muhs@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * index_auto_config.h
+ *
+ *  Created on: Apr 11, 2018
+ *      Author: hendrik
+ */
+
+#ifndef KEYVI_INDEX_INTERNAL_INDEX_AUTO_CONFIG_H_
+#define KEYVI_INDEX_INTERNAL_INDEX_AUTO_CONFIG_H_
+
+#include <string>
+#include <thread>  // NOLINT
+#include <unordered_map>
+
+#include "index/constants.h"
+
+#include "util/configuration.h"
+#include "util/os_utils.h"
+
+// #define ENABLE_TRACING
+#include "dictionary/util/trace.h"
+
+namespace keyvi {
+namespace index {
+namespace internal {
+
+class IndexAutoConfig final {
+ public:
+  static size_t MaxSegments() {
+    // increase file descriptors and leave some extra room, to be improved later
+    size_t file_descriptors = keyvi::util::OsUtils::TryIncreaseFileDescriptors();
+    return file_descriptors - 100;
+  }
+
+  static size_t MaxConcurrentMerges() {
+    unsigned int cores = std::thread::hardware_concurrency();
+
+    // for now use half the cores for mergers
+    size_t max_concurrent_merges = cores / 2;
+    return max_concurrent_merges;
+  }
+};
+
+} /* namespace internal */
+} /* namespace index */
+} /* namespace keyvi */
+
+#endif  // KEYVI_INDEX_INTERNAL_INDEX_AUTO_CONFIG_H_

--- a/keyvi/include/keyvi/index/internal/index_auto_config.h
+++ b/keyvi/include/keyvi/index/internal/index_auto_config.h
@@ -24,6 +24,7 @@
 #ifndef KEYVI_INDEX_INTERNAL_INDEX_AUTO_CONFIG_H_
 #define KEYVI_INDEX_INTERNAL_INDEX_AUTO_CONFIG_H_
 
+#include <algorithm>
 #include <string>
 #include <thread>  // NOLINT
 #include <unordered_map>
@@ -53,7 +54,7 @@ class IndexAutoConfig final {
 
     // for now use half the cores for mergers
     size_t max_concurrent_merges = cores / 2;
-    return max_concurrent_merges;
+    return std::min(MAX_CONCURRENT_MERGES_DEFAULT, std::max(size_t(1), max_concurrent_merges));
   }
 };
 

--- a/keyvi/include/keyvi/index/internal/index_settings.h
+++ b/keyvi/include/keyvi/index/internal/index_settings.h
@@ -27,8 +27,10 @@
 #include <string>
 #include <unordered_map>
 
-#include "index/constants.h"
+#include <boost/variant.hpp>
 
+#include "index/constants.h"
+#include "index/internal/index_auto_config.h"
 #include "util/configuration.h"
 
 // #define ENABLE_TRACING
@@ -45,18 +47,23 @@ class IndexSettings final {
     if (params.count(KEYVIMERGER_BIN)) {
       settings_[KEYVIMERGER_BIN] = params.at(KEYVIMERGER_BIN);
     }
+    if (params.count(INDEX_MAX_SEGMENTS)) {
+      settings_[INDEX_MAX_SEGMENTS] = params.at(INDEX_MAX_SEGMENTS);
+    } else {
+      settings_[INDEX_MAX_SEGMENTS] = IndexAutoConfig::MaxSegments();
+    }
   }
 
   const std::string& GetKeyviMergerBin() const {
     if (settings_.count(KEYVIMERGER_BIN)) {
-      return settings_.at(KEYVIMERGER_BIN);
+      return boost::get<std::string>(settings_.at(KEYVIMERGER_BIN));
     }
 
     return default_keyvimerger_bin_;
   }
 
  private:
-  std::unordered_map<std::string, std::string> settings_;
+  std::unordered_map<std::string, boost::variant <std::string, size_t>> settings_;
   const std::string default_keyvimerger_bin_ = "keyvimerger";
 };
 

--- a/keyvi/include/keyvi/index/internal/index_settings.h
+++ b/keyvi/include/keyvi/index/internal/index_settings.h
@@ -46,25 +46,45 @@ class IndexSettings final {
     // only parse what we know
     if (params.count(KEYVIMERGER_BIN)) {
       settings_[KEYVIMERGER_BIN] = params.at(KEYVIMERGER_BIN);
+    } else {
+      settings_[KEYVIMERGER_BIN] = DEFAULT_KEYVIMERGER_BIN;
     }
     if (params.count(INDEX_MAX_SEGMENTS)) {
-      settings_[INDEX_MAX_SEGMENTS] = params.at(INDEX_MAX_SEGMENTS);
+      settings_[INDEX_MAX_SEGMENTS] = keyvi::util::mapGet<size_t>(params, INDEX_REFRESH_INTERVAL);
     } else {
       settings_[INDEX_MAX_SEGMENTS] = IndexAutoConfig::MaxSegments();
     }
-  }
-
-  const std::string& GetKeyviMergerBin() const {
-    if (settings_.count(KEYVIMERGER_BIN)) {
-      return boost::get<std::string>(settings_.at(KEYVIMERGER_BIN));
+    if (params.count(MAX_CONCURRENT_MERGES)) {
+      settings_[MAX_CONCURRENT_MERGES] = keyvi::util::mapGet<size_t>(params, MAX_CONCURRENT_MERGES);
+    } else {
+      settings_[MAX_CONCURRENT_MERGES] = IndexAutoConfig::MaxConcurrentMerges();
     }
-
-    return default_keyvimerger_bin_;
+    if (params.count(SEGMENT_COMPILE_KEY_THRESHOLD)) {
+      settings_[SEGMENT_COMPILE_KEY_THRESHOLD] = keyvi::util::mapGet<size_t>(params, SEGMENT_COMPILE_KEY_THRESHOLD);
+    } else {
+      settings_[SEGMENT_COMPILE_KEY_THRESHOLD] = DEFAULT_COMPILE_KEY_THRESHOLD;
+    }
+    if (params.count(INDEX_REFRESH_INTERVAL)) {
+      settings_[INDEX_REFRESH_INTERVAL] = keyvi::util::mapGet<size_t>(params, INDEX_REFRESH_INTERVAL);
+    } else {
+      settings_[INDEX_REFRESH_INTERVAL] = DEFAULT_REFRESH_INTERVAL;
+    }
   }
+
+  const std::string& GetKeyviMergerBin() const { return boost::get<std::string>(settings_.at(KEYVIMERGER_BIN)); }
+
+  const size_t GetMaxSegments() const { return boost::get<size_t>(settings_.at(INDEX_MAX_SEGMENTS)); }
+
+  const size_t GetSegmentCompileKeyThreshold() const {
+    return boost::get<size_t>(settings_.at(SEGMENT_COMPILE_KEY_THRESHOLD));
+  }
+
+  const size_t GetMaxConcurrentMerges() const { return boost::get<size_t>(settings_.at(MAX_CONCURRENT_MERGES)); }
+
+  const size_t GetRefreshInterval() const { return boost::get<size_t>(settings_.at(INDEX_REFRESH_INTERVAL)); }
 
  private:
-  std::unordered_map<std::string, boost::variant <std::string, size_t>> settings_;
-  const std::string default_keyvimerger_bin_ = "keyvimerger";
+  std::unordered_map<std::string, boost::variant<std::string, size_t>> settings_;
 };
 
 } /* namespace internal */

--- a/keyvi/include/keyvi/index/internal/index_settings.h
+++ b/keyvi/include/keyvi/index/internal/index_settings.h
@@ -50,7 +50,7 @@ class IndexSettings final {
       settings_[KEYVIMERGER_BIN] = DEFAULT_KEYVIMERGER_BIN;
     }
     if (params.count(INDEX_MAX_SEGMENTS)) {
-      settings_[INDEX_MAX_SEGMENTS] = keyvi::util::mapGet<size_t>(params, INDEX_REFRESH_INTERVAL);
+      settings_[INDEX_MAX_SEGMENTS] = keyvi::util::mapGet<size_t>(params, INDEX_MAX_SEGMENTS);
     } else {
       settings_[INDEX_MAX_SEGMENTS] = IndexAutoConfig::MaxSegments();
     }

--- a/keyvi/include/keyvi/index/internal/index_writer_worker.h
+++ b/keyvi/include/keyvi/index/internal/index_writer_worker.h
@@ -64,37 +64,32 @@ class IndexWriterWorker final {
           segments_(),
           mutex_(),
           index_directory_(index_directory),
-          index_toc_file_(index_directory),
-          index_toc_file_part_(index_directory),
+          index_toc_file_(index_directory_ / "index.toc"),
+          index_toc_file_part_(index_directory_ / "index.toc.part"),
           settings_(params),
+          max_concurrent_merges_(settings_.GetMaxConcurrentMerges()),
+          max_segments_(settings_.GetMaxSegments()),
+          compile_key_threshold_(settings_.GetSegmentCompileKeyThreshold()),
+          index_refresh_interval_(settings_.GetRefreshInterval()),
           merge_jobs_(),
           any_delete_(false),
           merge_enabled_(true) {
       segments_ = std::make_shared<segment_vec_t>();
-
-      index_toc_file_ /= "index.toc";
-      index_toc_file_part_ /= "index.toc.part";
-
-      max_concurrent_merges_ = settings_.GetMaxConcurrentMerges();
-      max_segments_ = settings_.GetMaxSegments();
-      compile_key_threshold_ = settings_.GetSegmentCompileKeyThreshold();
-      index_refresh_interval_ = settings_.GetRefreshInterval();
     }
 
     compiler_t compiler_;
     std::atomic_size_t write_counter_;
     segments_t segments_;
     std::mutex mutex_;
-    boost::filesystem::path index_directory_;
-    boost::filesystem::path index_toc_file_;
-    boost::filesystem::path index_toc_file_part_;
-    internal::IndexSettings settings_;
+    const boost::filesystem::path index_directory_;
+    const boost::filesystem::path index_toc_file_;
+    const boost::filesystem::path index_toc_file_part_;
+    const internal::IndexSettings settings_;
+    const size_t max_concurrent_merges_;
+    const size_t max_segments_;
+    const size_t compile_key_threshold_;
+    const size_t index_refresh_interval_;
     std::list<MergeJob> merge_jobs_;
-    size_t max_concurrent_merges_;
-    size_t max_segments_;
-    size_t compile_key_threshold_;
-    size_t index_refresh_interval_;
-
     bool any_delete_;
     std::atomic_bool merge_enabled_;
   };

--- a/keyvi/include/keyvi/index/internal/index_writer_worker.h
+++ b/keyvi/include/keyvi/index/internal/index_writer_worker.h
@@ -74,6 +74,11 @@ class IndexWriterWorker final {
 
       index_toc_file_ /= "index.toc";
       index_toc_file_part_ /= "index.toc.part";
+
+      max_concurrent_merges_ = settings_.GetMaxConcurrentMerges();
+      max_segments_ = settings_.GetMaxSegments();
+      compile_key_threshold_ = settings_.GetSegmentCompileKeyThreshold();
+      index_refresh_interval_ = settings_.GetRefreshInterval();
     }
 
     compiler_t compiler_;
@@ -85,7 +90,11 @@ class IndexWriterWorker final {
     boost::filesystem::path index_toc_file_part_;
     internal::IndexSettings settings_;
     std::list<MergeJob> merge_jobs_;
-    size_t max_concurrent_merges_ = 2;
+    size_t max_concurrent_merges_;
+    size_t max_segments_;
+    size_t compile_key_threshold_;
+    size_t index_refresh_interval_;
+
     bool any_delete_;
     std::atomic_bool merge_enabled_;
   };
@@ -94,9 +103,8 @@ class IndexWriterWorker final {
   explicit IndexWriterWorker(const std::string& index_directory, const keyvi::util::parameters_t& params)
       : payload_(index_directory, params),
         merge_policy_(merge_policy(keyvi::util::mapGet<std::string>(params, MERGE_POLICY, DEFAULT_MERGE_POLICY))),
-        compiler_active_object_(
-            &payload_, std::bind(&index::internal::IndexWriterWorker::ScheduledTask, this),
-            std::chrono::milliseconds(keyvi::util::mapGet<uint64_t>(params, INDEX_REFRESH_INTERVAL, 1000))) {
+        compiler_active_object_(&payload_, std::bind(&index::internal::IndexWriterWorker::ScheduledTask, this),
+                                std::chrono::milliseconds(payload_.index_refresh_interval_)) {
     TRACE("construct worker: %s", payload_.index_directory_.c_str());
     LoadIndex();
   }
@@ -143,10 +151,7 @@ class IndexWriterWorker final {
       payload.compiler_->Add(key, value);
     });
 
-    if (++payload_.write_counter_ > 1000) {
-      compiler_active_object_([](IndexPayload& payload) { Compile(&payload); });
-      payload_.write_counter_ = 0;
-    }
+    CompileIfThresholdIsHit();
   }
 
   void Delete(const std::string& key) {
@@ -165,10 +170,7 @@ class IndexWriterWorker final {
       }
     });
 
-    if (++payload_.write_counter_ > 1000) {
-      compiler_active_object_([](IndexPayload& payload) { Compile(&payload); });
-      payload_.write_counter_ = 0;
-    }
+    CompileIfThresholdIsHit();
   }
 
   /**
@@ -208,6 +210,18 @@ class IndexWriterWorker final {
   std::weak_ptr<segment_vec_t> segments_weak_;
   merge_policy_t merge_policy_;
   util::ActiveObject<IndexPayload> compiler_active_object_;
+
+  void CompileIfThresholdIsHit() {
+    if (++payload_.write_counter_ > payload_.compile_key_threshold_) {
+      compiler_active_object_([](IndexPayload& payload) { Compile(&payload); });
+      payload_.write_counter_ = 0;
+
+      // worst case scenario, to many segments, throttle further writes until we are below the limit
+      while (payload_.segments_->size() >= payload_.max_segments_) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(SPINLOCK_WAIT_FOR_SEGMENT_MERGES));
+      }
+    }
+  }
 
   void ScheduledTask() {
     TRACE("Scheduled task");

--- a/keyvi/include/keyvi/index/internal/index_writer_worker.h
+++ b/keyvi/include/keyvi/index/internal/index_writer_worker.h
@@ -217,8 +217,8 @@ class IndexWriterWorker final {
       payload_.write_counter_ = 0;
 
       // worst case scenario, to many segments, throttle further writes until we are below the limit
-      while (payload_.segments_->size() >= payload_.max_segments_) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(SPINLOCK_WAIT_FOR_SEGMENT_MERGES));
+      while (compiler_active_object_.Size() + payload_.segments_->size() >= payload_.max_segments_) {
+        Flush();
       }
     }
   }

--- a/keyvi/include/keyvi/index/internal/index_writer_worker.h
+++ b/keyvi/include/keyvi/index/internal/index_writer_worker.h
@@ -218,6 +218,8 @@ class IndexWriterWorker final {
 
       // worst case scenario, to many segments, throttle further writes until we are below the limit
       while (compiler_active_object_.Size() + payload_.segments_->size() >= payload_.max_segments_) {
+        // wait some time and then flush, which should give time to reduce the number of open file descriptors
+        std::this_thread::sleep_for(std::chrono::milliseconds(SPINLOCK_WAIT_FOR_SEGMENT_MERGES_MS));
         Flush();
       }
     }

--- a/keyvi/include/keyvi/index/internal/index_writer_worker.h
+++ b/keyvi/include/keyvi/index/internal/index_writer_worker.h
@@ -216,7 +216,7 @@ class IndexWriterWorker final {
       compiler_active_object_([](IndexPayload& payload) { Compile(&payload); });
       payload_.write_counter_ = 0;
 
-      // worst case scenario, to many segments, throttle further writes until we are below the limit
+      // worst case scenario, to0 many segments, throttle further writes until we are below the limit
       while (compiler_active_object_.Size() + payload_.segments_->size() >= payload_.max_segments_) {
         // wait some time and then flush, which should give time to reduce the number of open file descriptors
         std::this_thread::sleep_for(std::chrono::milliseconds(SPINLOCK_WAIT_FOR_SEGMENT_MERGES_MS));

--- a/keyvi/include/keyvi/util/active_object.h
+++ b/keyvi/include/keyvi/util/active_object.h
@@ -81,6 +81,8 @@ class ActiveObject final {
     queue_.Push([=] { f(*resource_); });
   }
 
+  size_t Size() const { return queue_.Size(); }
+
  private:
   mutable SingeProducerSingleConsumerRingBuffer<std::function<void()>, Tsize> queue_;
 

--- a/keyvi/include/keyvi/util/active_object.h
+++ b/keyvi/include/keyvi/util/active_object.h
@@ -43,7 +43,7 @@ class ActiveObject final {
  public:
   explicit ActiveObject(T* resource, const std::function<void()>& scheduled_task,
                         const std::chrono::milliseconds& flush_interval = std::chrono::milliseconds(1000))
-      : queue_(std::min(std::chrono::milliseconds(5), flush_interval_)),
+      : queue_(),
         resource_(resource),
         flush_interval_(flush_interval),
         scheduled_task_(scheduled_task),
@@ -52,7 +52,7 @@ class ActiveObject final {
     worker_ = std::thread([this] {
       std::function<void()> item;
       while (!done_) {
-        if (queue_.Pop(&item)) {
+        if (queue_.Pop(&item, scheduled_task_next_run_)) {
           item();
         }
 
@@ -60,6 +60,7 @@ class ActiveObject final {
         auto tp = std::chrono::system_clock::now();
         if (tp > scheduled_task_next_run_) {
           scheduled_task_next_run_ = tp + flush_interval_;
+          TRACE("run scheduled task");
           scheduled_task_();
         }
       }

--- a/keyvi/include/keyvi/util/os_utils.h
+++ b/keyvi/include/keyvi/util/os_utils.h
@@ -1,0 +1,60 @@
+/* * keyvi - A key value store.
+ *
+ * Copyright 2018 Hendrik Muhs<hendrik.muhs@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * os_utils.h
+ *
+ *  Created on: Mar 21, 2018
+ *      Author: hendrik
+ */
+
+#ifndef KEYVI_UTIL_OS_UTILS_H_
+#define KEYVI_UTIL_OS_UTILS_H_
+
+#include <sys/resource.h>
+
+#include <cstddef>
+#include <vector>
+
+namespace keyvi {
+namespace util {
+
+class OsUtils {
+ public:
+  static size_t TryIncreaseFileDescriptors() {
+    struct rlimit limit;
+
+    getrlimit(RLIMIT_NOFILE, &limit);
+    if (limit.rlim_cur != limit.rlim_max) {
+      // try different limits, as platforms behave differently
+      std::vector<size_t> limits{limit.rlim_max, 10000ul, 3200, 1024};
+
+      for (size_t l : limits) {
+        limit.rlim_cur = l;
+        if (setrlimit(RLIMIT_NOFILE, &limit) == 0) {
+          break;
+        }
+      }
+    }
+    return limit.rlim_cur;
+  }
+};
+
+} /* namespace util */
+} /* namespace keyvi */
+
+#endif  // KEYVI_UTIL_OS_UTILS_H_

--- a/keyvi/include/keyvi/util/os_utils.h
+++ b/keyvi/include/keyvi/util/os_utils.h
@@ -36,7 +36,7 @@ namespace util {
 class OsUtils {
  public:
   static size_t TryIncreaseFileDescriptors() {
-    struct rlimit limit;
+    rlimit limit;
 
     getrlimit(RLIMIT_NOFILE, &limit);
     if (limit.rlim_cur != limit.rlim_max) {
@@ -50,6 +50,9 @@ class OsUtils {
         }
       }
     }
+    // read back to return what ever is set now
+    getrlimit(RLIMIT_NOFILE, &limit);
+
     return limit.rlim_cur;
   }
 };

--- a/keyvi/tests/keyvi/index/index_limits_test.cpp
+++ b/keyvi/tests/keyvi/index/index_limits_test.cpp
@@ -1,0 +1,86 @@
+//
+// keyvi - A key value store.
+//
+// Copyright 2015 Hendrik Muhs<hendrik.muhs@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/*
+ * index_writer_test.cpp
+ *
+ *  Created on: Jan 13, 2017
+ *      Author: hendrik
+ */
+
+#include <sys/resource.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "index/constants.h"
+#include "index/index.h"
+
+inline std::string get_keyvimerger_bin() {
+  boost::filesystem::path path{std::getenv("KEYVI_UNITTEST_BASEPATH")};
+  path /= "keyvimerger";
+
+  BOOST_CHECK(boost::filesystem::is_regular_file(path));
+
+  return path.string();
+}
+
+inline void limit_filedescriptors(size_t file_descriptor_limit) {
+  struct rlimit limit;
+
+  getrlimit(RLIMIT_NOFILE, &limit);
+  limit.rlim_cur = file_descriptor_limit;
+  BOOST_CHECK(setrlimit(RLIMIT_NOFILE, &limit) == 0);
+  getrlimit(RLIMIT_NOFILE, &limit);
+  BOOST_CHECK_EQUAL(file_descriptor_limit, limit.rlim_cur);
+}
+
+namespace keyvi {
+namespace index {
+BOOST_AUTO_TEST_SUITE(IndexLimitsTests)
+
+BOOST_AUTO_TEST_CASE(filedescriptor_limit) {
+  using boost::filesystem::temp_directory_path;
+  using boost::filesystem::unique_path;
+
+  limit_filedescriptors(10);
+
+  auto tmp_path = temp_directory_path();
+  tmp_path /= unique_path("index-limits-test-temp-index-%%%%-%%%%-%%%%-%%%%");
+  {
+    Index writer(tmp_path.string(), {{"refresh_interval", "100"},
+                                     {KEYVIMERGER_BIN, get_keyvimerger_bin()},
+                                     {"segment_compile_key_threshold", "10"},
+                                     {"max_segments", "4"}});
+
+    for (int i = 0; i < 100000; ++i) {
+      writer.Set("a", "{\"id\":" + std::to_string(i) + "}");
+    }
+    writer.Flush();
+    BOOST_CHECK(writer.Contains("a"));
+    dictionary::Match m = writer["a"];
+
+    BOOST_CHECK_EQUAL("{\"id\":9999}", m.GetValueAsString());
+  }
+  boost::filesystem::remove_all(tmp_path);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace index
+}  // namespace keyvi

--- a/keyvi/tests/keyvi/index/index_limits_test.cpp
+++ b/keyvi/tests/keyvi/index/index_limits_test.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(filedescriptor_limit) {
   using boost::filesystem::temp_directory_path;
   using boost::filesystem::unique_path;
 
-  limit_filedescriptors(10);
+  limit_filedescriptors(20);
 
   auto tmp_path = temp_directory_path();
   tmp_path /= unique_path("index-limits-test-temp-index-%%%%-%%%%-%%%%-%%%%");
@@ -66,16 +66,16 @@ BOOST_AUTO_TEST_CASE(filedescriptor_limit) {
     Index writer(tmp_path.string(), {{"refresh_interval", "100"},
                                      {KEYVIMERGER_BIN, get_keyvimerger_bin()},
                                      {"segment_compile_key_threshold", "10"},
-                                     {"max_segments", "4"}});
+                                     {"max_segments", "10"}});
 
-    for (int i = 0; i < 100000; ++i) {
+    for (int i = 0; i < 5000; ++i) {
       writer.Set("a", "{\"id\":" + std::to_string(i) + "}");
     }
     writer.Flush();
     BOOST_CHECK(writer.Contains("a"));
     dictionary::Match m = writer["a"];
 
-    BOOST_CHECK_EQUAL("{\"id\":9999}", m.GetValueAsString());
+    BOOST_CHECK_EQUAL("{\"id\":4999}", m.GetValueAsString());
   }
   boost::filesystem::remove_all(tmp_path);
 }

--- a/keyvi/tests/keyvi/index/index_test.cpp
+++ b/keyvi/tests/keyvi/index/index_test.cpp
@@ -80,7 +80,9 @@ BOOST_AUTO_TEST_CASE(bigger_feed) {
   auto tmp_path = temp_directory_path();
   tmp_path /= unique_path("index-test-temp-index-%%%%-%%%%-%%%%-%%%%");
   {
-    Index writer(tmp_path.string(), {{"refresh_interval", "100"}, {KEYVIMERGER_BIN, get_keyvimerger_bin()}});
+    Index writer(
+        tmp_path.string(),
+        {{"refresh_interval", "100"}, {KEYVIMERGER_BIN, get_keyvimerger_bin()}, {"max_concurrent_merges", "2"}});
 
     for (int i = 0; i < 10000; ++i) {
       writer.Set("a", "{\"id\":" + std::to_string(i) + "}");

--- a/keyvi/tests/keyvi/util/single_producer_consumer_ringbuffer_test.cpp
+++ b/keyvi/tests/keyvi/util/single_producer_consumer_ringbuffer_test.cpp
@@ -46,6 +46,7 @@ BOOST_AUTO_TEST_CASE(SimpleTest) {
   Item a("test");
   Item b("test2");
   Item c("test3");
+  auto now = std::chrono::system_clock::now();
 
   BOOST_CHECK_EQUAL("test", a.key);
   BOOST_CHECK_EQUAL(0, s.Size());
@@ -58,7 +59,7 @@ BOOST_AUTO_TEST_CASE(SimpleTest) {
   BOOST_CHECK_EQUAL(2, s.Size());
   BOOST_CHECK_EQUAL("test", d.key);
 
-  s.Pop(&d);
+  s.Pop(&d, now);
   BOOST_CHECK_EQUAL(1, s.Size());
   BOOST_CHECK_EQUAL("test2", d.key);
 
@@ -69,6 +70,7 @@ BOOST_AUTO_TEST_CASE(SimpleTest) {
 
 BOOST_AUTO_TEST_CASE(SizeTest) {
   SingeProducerSingleConsumerRingBuffer<Item, 11> s;
+  auto now = std::chrono::system_clock::now();
 
   for (size_t i = 0; i < 10; ++i) {
     Item v(std::to_string(i));

--- a/keyvi/tests/keyvi/util/single_producer_consumer_ringbuffer_test.cpp
+++ b/keyvi/tests/keyvi/util/single_producer_consumer_ringbuffer_test.cpp
@@ -72,7 +72,6 @@ BOOST_AUTO_TEST_CASE(SimpleTest) {
 
 BOOST_AUTO_TEST_CASE(SizeTest) {
   SingeProducerSingleConsumerRingBuffer<Item, 11> s;
-  auto now = std::chrono::system_clock::now();
 
   for (size_t i = 0; i < 10; ++i) {
     Item v(std::to_string(i));

--- a/keyvi/tests/keyvi/util/single_producer_consumer_ringbuffer_test.cpp
+++ b/keyvi/tests/keyvi/util/single_producer_consumer_ringbuffer_test.cpp
@@ -23,7 +23,9 @@
  *      Author: hendrik
  */
 
+#include <chrono>  //NOLINT
 #include <string>
+#include <thread>  //NOLINT
 
 #include <boost/test/unit_test.hpp>
 
@@ -92,6 +94,65 @@ BOOST_AUTO_TEST_CASE(SizeTest) {
   s.Pop(&v);
   s.Pop(&v);
   BOOST_CHECK_EQUAL(8, s.Size());
+}
+
+using TestQueue = SingeProducerSingleConsumerRingBuffer<Item, 100>;
+
+void consumer(TestQueue* queue) {
+  std::this_thread::sleep_for(std::chrono::microseconds(5));
+  Item v;
+  for (size_t i = 0; i < 1000; ++i) {
+    queue->Pop(&v);
+    BOOST_CHECK_EQUAL(v.key, std::to_string(i));
+  }
+
+  auto now = std::chrono::system_clock::now();
+  for (size_t i = 0; i < 10; ++i) {
+    BOOST_CHECK(!queue->Pop(&v, now + std::chrono::milliseconds(1)));
+  }
+  BOOST_CHECK(queue->Pop(&v));
+  BOOST_CHECK_EQUAL(v.key, "x");
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+  now = std::chrono::system_clock::now();
+  for (size_t i = 0; i < 1000; ++i) {
+    BOOST_CHECK(queue->Pop(&v, now + std::chrono::milliseconds(4)));
+    BOOST_CHECK_EQUAL(v.key, std::to_string(i));
+  }
+}
+
+BOOST_AUTO_TEST_CASE(ConsumerProducerTest) {
+  TestQueue queue;
+
+  std::thread consumer_thread(consumer, &queue);
+
+  for (size_t i = 0; i < 300; ++i) {
+    Item w(std::to_string(i));
+    queue.Push(std::move(w));
+  }
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(12));
+  for (size_t i = 300; i < 1000; ++i) {
+    Item w(std::to_string(i));
+    queue.Push(std::move(w));
+  }
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  Item x("x");
+  queue.Push(std::move(x));
+
+  for (size_t i = 0; i < 300; ++i) {
+    Item w(std::to_string(i));
+    queue.Push(std::move(w));
+  }
+
+  std::this_thread::sleep_for(std::chrono::microseconds(12));
+  for (size_t i = 300; i < 1000; ++i) {
+    Item w(std::to_string(i));
+    queue.Push(std::move(w));
+  }
+
+  consumer_thread.join();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This change implements auto-configuration of index settings, including configuring the maximum number of segments which is directly connected to the number of file descriptors. If not externally given it tries to increase the limit (usually from 1024 to 1M). In case of running low on file descriptors index operations are automatically throttled so that concurrent compaction can catch up and reduce open descriptors.

Also changes the queue implementation - after benchmarking - to use condition variables instead of a spin-lock if the queue runs full or empty. This improves indexing performance and also fixes a problem in the spin-lock implementation that could cause cpu hogging. 

fixes #60