### PR TITLE
Using libcpp_utf8_output_string from autowrap

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 msgpack-python
-autowrap
+autowrap>=0.16.0
 pytest
 twine
 wheel

--- a/python/src/converters/__init__.py
+++ b/python/src/converters/__init__.py
@@ -1,6 +1,6 @@
 from .pykeyvi_autowrap_conversion_providers import *
 from autowrap.ConversionProvider import special_converters
 
+
 def register_converters():
     special_converters.append(MatchIteratorPairConverter())
-    special_converters.append(OutputStdStringUnicodeConverter())

--- a/python/src/converters/pykeyvi_autowrap_conversion_providers.py
+++ b/python/src/converters/pykeyvi_autowrap_conversion_providers.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 from autowrap.Code import Code
-from autowrap.ConversionProvider import TypeConverterBase, StdStringUnicodeConverter
+from autowrap.ConversionProvider import TypeConverterBase
 
 
 class MatchIteratorPairConverter(TypeConverterBase):
@@ -33,9 +33,3 @@ class MatchIteratorPairConverter(TypeConverterBase):
             |$output_py_var.it = _r.begin()
             |$output_py_var.end = _r.end()
             """, locals())
-
-
-class OutputStdStringUnicodeConverter(StdStringUnicodeConverter):
-
-    def output_conversion(self, cpp_type, input_cpp_var, output_py_var):
-        return "%s = %s.decode('utf-8')" % (output_py_var, input_cpp_var)

--- a/python/src/pxds/match.pxd
+++ b/python/src/pxds/match.pxd
@@ -1,6 +1,7 @@
 from libc.stdint cimport uint32_t
 from libcpp.string cimport string as libcpp_string
 from libcpp.string cimport string as libcpp_utf8_string
+from libcpp.string cimport string as libcpp_utf8_output_string
 from libcpp cimport bool
 from cpython.ref cimport PyObject
 
@@ -14,10 +15,10 @@ cdef extern from "dictionary/match.h" namespace "keyvi::dictionary":
         void SetEnd(size_t end)
         float GetScore()
         void SetScore(float score)
-        libcpp_utf8_string GetMatchedString()
+        libcpp_utf8_output_string GetMatchedString()
         void SetMatchedString (libcpp_utf8_string matched_string)
         PyObject* GetAttributePy(libcpp_utf8_string) nogil except + # wrap-ignore
-        libcpp_utf8_string GetValueAsString() except +
+        libcpp_utf8_output_string GetValueAsString() except +
         libcpp_string GetRawValueAsString() except +
         libcpp_string GetMsgPackedValueAsString() except + # wrap-ignore
         void SetRawValue(libcpp_utf8_string) except + # wrap-ignore

--- a/python/src/pxds/vector.pxd
+++ b/python/src/pxds/vector.pxd
@@ -1,15 +1,15 @@
-from libcpp.string cimport string as libcpp_utf8_string
+from libcpp.string cimport string as libcpp_utf8_output_string
 
 cdef extern from "vector/vector_types.h" namespace "keyvi::vector":
     cdef cppclass JsonVector:
-        JsonVector(libcpp_utf8_string filename) except +
-        libcpp_utf8_string Get(size_t index) # wrap-ignore
+        JsonVector(libcpp_utf8_output_string filename) except +
+        libcpp_utf8_output_string Get(size_t index) # wrap-ignore
         size_t Size()
-        libcpp_utf8_string Manifest()
+        libcpp_utf8_output_string Manifest()
 
 cdef extern from "vector/vector_types.h" namespace "keyvi::vector":
     cdef cppclass StringVector:
-        StringVector(libcpp_utf8_string filename) except +
-        libcpp_utf8_string Get(size_t index)
+        StringVector(libcpp_utf8_output_string filename) except +
+        libcpp_utf8_output_string Get(size_t index)
         size_t Size()
-        libcpp_utf8_string Manifest()
+        libcpp_utf8_output_string Manifest()


### PR DESCRIPTION
 - using libcpp_utf8_output_string from autowrap (https://github.com/uweschmitt/autowrap/pull/71)
 - set minimum required autowrap version