### PR TITLE
Minimum version for msgpack

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-msgpack-python
+msgpack-python>=0.5.6
 autowrap>=0.16.0
 pytest
 twine

--- a/python/setup.py
+++ b/python/setup.py
@@ -299,7 +299,7 @@ with symlink_keyvi() as (pykeyvi_source_path, keyvi_source_path):
     PACKAGE_NAME = 'keyvi'
 
     install_requires = [
-        'msgpack-python',
+        'msgpack-python>=0.5.6',
     ]
 
     commands = {'build_ext': build_ext, 'sdist': sdist, 'build': build, 'bdist': bdist}


### PR DESCRIPTION
Set minimum version for msgpack, as we depend on API introduced in 0.5.2. (`raw flag in msgpack.loads(packed_value, raw=False)`) and also some bug fixes were added later on.