### PR TITLE
fix a corner case, reading a transition value which is spread across 2 chunks

### DIFF
--- a/keyvi/include/keyvi/dictionary/fsa/internal/memory_map_manager.h
+++ b/keyvi/include/keyvi/dictionary/fsa/internal/memory_map_manager.h
@@ -73,7 +73,6 @@ class MemoryMapManager final {
    */
   bool GetAddressQuickTestOk(size_t offset, size_t length) const {
     size_t chunk_offset = offset % chunk_size_;
-
     return (length <= (chunk_size_ - chunk_offset));
   }
 
@@ -192,7 +191,7 @@ class MemoryMapManager final {
 
       while (remaining > 0) {
         size_t bytes_in_chunk = std::min(chunk_size_, remaining);
-        TRACE("write chunk %d, with size: %ld, remaining: %ld", i, bytes_in_chunk, remaining);
+        TRACE("write chunk %d, with size: %ld, remaining: %ld", chunk, bytes_in_chunk, remaining);
 
         const char* ptr = reinterpret_cast<const char*>(mappings_[chunk].region_->get_address());
         stream.write(ptr, bytes_in_chunk);
@@ -229,6 +228,8 @@ class MemoryMapManager final {
 
     mappings_.clear();
   }
+
+  size_t GetChunkSize() const { return chunk_size_; }
 
  private:
   struct mapping {


### PR DESCRIPTION
fix a bug in reading transition values during construction which can be spread across 2 chunks.

This issue found in the code has probably not much impact in practice, nevertheless worth to fix. If a transition value is stored between 2 chunks (1st part in chunk x, 2nd part in chunk x+1) the value wasn't read correctly. Note that chunking is only done at construction time, so lookup isn't affected. Reading the transition value is part of minimization, so worst case this bug prevented minimization of this particular state. I can not think this issue can cause data corruption.