### PR TITLE
remove SetManifest from boost property trees

### DIFF
--- a/keyvi/bin/keyvicompiler/keyvicompiler.cpp
+++ b/keyvi/bin/keyvicompiler/keyvicompiler.cpp
@@ -96,7 +96,7 @@ void finalize_compile(CompilerType* compiler, const std::string& output, const s
   std::ofstream out_stream(output, std::ios::binary);
   compiler->Compile(callback);
   try {
-    compiler->SetManifestFromString(manifest);
+    compiler->SetManifest(manifest);
   } catch (boost::property_tree::json_parser::json_parser_error const& error) {
     std::cout << "Failed to set manifest: " << manifest << std::endl;
     std::cout << error.what() << std::endl;

--- a/keyvi/include/keyvi/dictionary/dictionary_compiler.h
+++ b/keyvi/include/keyvi/dictionary/dictionary_compiler.h
@@ -29,8 +29,6 @@
 #include <functional>
 #include <string>
 
-#include <boost/property_tree/ptree.hpp>
-
 #include "dictionary/fsa/generator_adapter.h"
 #include "dictionary/fsa/internal/constants.h"
 #include "dictionary/fsa/internal/null_value_store.h"
@@ -227,26 +225,9 @@ class DictionaryCompiler final {
   /**
    * Set a custom manifest to be embedded into the index file.
    *
-   * @param manifest as JSON string
+   * @param manifest as string
    */
-  void SetManifestFromString(const std::string& manifest) {
-    SetManifest(keyvi::util::SerializationUtils::ReadJsonRecord(manifest));
-  }
-
-  /**
-   * Set a custom manifest to be embedded into the index file.
-   *
-   * @param manifest
-   */
-  void SetManifest(const boost::property_tree::ptree& manifest) {
-    manifest_ = manifest;
-
-    // if generator object is already there, set it otherwise cache it until it
-    // is created
-    if (generator_) {
-      generator_->SetManifest(manifest);
-    }
-  }
+  void SetManifest(const std::string& manifest) { manifest_ = manifest; }
 
   void Write(std::ostream& stream) {
     if (!generator_) {
@@ -271,7 +252,7 @@ class DictionaryCompiler final {
   keyvi::util::parameters_t params_;
   ValueStoreT* value_store_;
   typename GeneratorAdapter::AdapterPtr generator_;
-  boost::property_tree::ptree manifest_ = boost::property_tree::ptree();
+  std::string manifest_;
   size_t count_ = 0;
   size_t size_of_keys_ = 0;
   bool sort_finalized_ = false;

--- a/keyvi/include/keyvi/dictionary/dictionary_compiler.h
+++ b/keyvi/include/keyvi/dictionary/dictionary_compiler.h
@@ -227,7 +227,15 @@ class DictionaryCompiler final {
    *
    * @param manifest as string
    */
-  void SetManifest(const std::string& manifest) { manifest_ = manifest; }
+  void SetManifest(const std::string& manifest) {
+    manifest_ = manifest;
+
+    // if generator object is already there, set it otherwise cache it until it
+    // is created
+    if (generator_) {
+      generator_->SetManifest(manifest);
+    }
+  }
 
   void Write(std::ostream& stream) {
     if (!generator_) {

--- a/keyvi/include/keyvi/dictionary/dictionary_merger.h
+++ b/keyvi/include/keyvi/dictionary/dictionary_merger.h
@@ -167,13 +167,13 @@ class DictionaryMerger final {
   /**
    * Set a custom manifest to be embedded into the index file.
    *
-   * @param manifest as JSON string
+   * @param manifest as string
    */
-  void SetManifestFromString(const std::string& manifest) { manifest_ = manifest; }
+  void SetManifest(const std::string& manifest) { manifest_ = manifest; }
 
   void Merge(const std::string& filename) {
     Merge();
-    generator_->SetManifestFromString(manifest_);
+    generator_->SetManifest(manifest_);
     generator_->WriteToFile(filename);
   }
 

--- a/keyvi/include/keyvi/dictionary/fsa/generator.h
+++ b/keyvi/include/keyvi/dictionary/fsa/generator.h
@@ -314,18 +314,9 @@ class Generator final {
   /**
    * Set a custom manifest to be embedded into the index file.
    *
-   * @param manifest as JSON string
+   * @param manifest as string
    */
-  inline void SetManifestFromString(const std::string& manifest) {
-    SetManifest(keyvi::util::SerializationUtils::ReadJsonRecord(manifest));
-  }
-
-  /**
-   * Set a custom manifest to be embedded into the index file.
-   *
-   * @param manifest
-   */
-  inline void SetManifest(const boost::property_tree::ptree& manifest) { manifest_ = manifest; }
+  inline void SetManifest(const std::string& manifest) { manifest_ = manifest; }
 
  private:
   size_t memory_limit_;
@@ -340,7 +331,7 @@ class Generator final {
   generator_state state_ = generator_state::FEEDING;
   OffsetTypeT start_state_ = 0;
   uint64_t number_of_states_ = 0;
-  boost::property_tree::ptree manifest_ = boost::property_tree::ptree();
+  std::string manifest_;
   bool minimize_ = true;
 
   void WriteHeader(std::ostream& stream) {
@@ -350,8 +341,7 @@ class Generator final {
     pt.put("number_of_keys", std::to_string(number_of_keys_added_));
     pt.put("value_store_type", std::to_string(static_cast<int>(value_store_->GetValueStoreType())));
     pt.put("number_of_states", std::to_string(number_of_states_));
-    pt.add_child("manifest", manifest_);
-
+    pt.add_child("manifest", keyvi::util::SerializationUtils::ReadJsonRecord(manifest_));
     keyvi::util::SerializationUtils::WriteJsonRecord(stream, pt);
   }
 

--- a/keyvi/include/keyvi/dictionary/fsa/generator_adapter.h
+++ b/keyvi/include/keyvi/dictionary/fsa/generator_adapter.h
@@ -55,8 +55,7 @@ class GeneratorAdapterInterface {
   virtual void CloseFeeding() {}
   virtual void Write(std::ostream& stream) {}
   virtual void WriteToFile(const std::string& filename) {}
-  virtual void SetManifestFromString(const std::string& manifest) {}
-  virtual void SetManifest(const boost::property_tree::ptree& manifest) {}
+  virtual void SetManifest(const std::string& manifest) {}
 
   virtual ~GeneratorAdapterInterface() {}
 };
@@ -82,9 +81,7 @@ class GeneratorAdapter final : public GeneratorAdapterInterface<typename ValueSt
 
   void WriteToFile(const std::string& filename) { generator_.WriteToFile(filename); }
 
-  void SetManifestFromString(const std::string& manifest) { generator_.SetManifestFromString(manifest); }
-
-  void SetManifest(const boost::property_tree::ptree& manifest) { generator_.SetManifest(manifest); }
+  void SetManifest(const std::string& manifest) { generator_.SetManifest(manifest); }
 
  private:
   Generator<PersistenceT, ValueStoreT, OffsetTypeT, HashCodeTypeT> generator_;

--- a/keyvi/tests/keyvi/dictionary/fsa/generator_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fsa/generator_test.cpp
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(manifesttest) {
 
   g.CloseFeeding();
 
-  g.SetManifestFromString("{\"version\":\"42\"}");
+  g.SetManifest("{\"version\":\"42\"}");
 
   std::ofstream out_stream("testFile3", std::ios::binary);
   g.Write(out_stream);

--- a/python/src/addons/CompletionDictionaryCompiler.pyx
+++ b/python/src/addons/CompletionDictionaryCompiler.pyx
@@ -21,7 +21,7 @@
 
     def SetManifest(self, manifest):
         m = json.dumps(manifest).encode('utf-8')
-        self.inst.get().SetManifestFromString(m)
+        self.inst.get().SetManifest(m)
 
 
 # definition for all compilers

--- a/python/src/addons/CompletionDictionaryMerger.pyx
+++ b/python/src/addons/CompletionDictionaryMerger.pyx
@@ -2,4 +2,4 @@
 
     def SetManifest(self, manifest):
         m = json.dumps(manifest).encode('utf-8')
-        self.inst.get().SetManifestFromString(m)
+        self.inst.get().SetManifest(m)

--- a/python/src/addons/IntDictionaryCompiler.pyx
+++ b/python/src/addons/IntDictionaryCompiler.pyx
@@ -21,4 +21,4 @@
 
     def SetManifest(self, manifest):
         m = json.dumps(manifest).encode('utf-8')
-        self.inst.get().SetManifestFromString(m)
+        self.inst.get().SetManifest(m)

--- a/python/src/addons/IntDictionaryMerger.pyx
+++ b/python/src/addons/IntDictionaryMerger.pyx
@@ -2,4 +2,4 @@
 
     def SetManifest(self, manifest):
         m = json.dumps(manifest).encode('utf-8')
-        self.inst.get().SetManifestFromString(m)
+        self.inst.get().SetManifest(m)

--- a/python/src/addons/JsonDictionaryCompiler.pyx
+++ b/python/src/addons/JsonDictionaryCompiler.pyx
@@ -21,4 +21,4 @@
 
     def SetManifest(self, manifest):
         m = json.dumps(manifest).encode('utf-8')
-        self.inst.get().SetManifestFromString(m)
+        self.inst.get().SetManifest(m)

--- a/python/src/addons/JsonDictionaryCompilerSmallData.pyx
+++ b/python/src/addons/JsonDictionaryCompilerSmallData.pyx
@@ -36,4 +36,4 @@
 
     def SetManifest(self, manifest):
         m = json.dumps(manifest).encode('utf-8')
-        self.inst.get().SetManifestFromString(m)
+        self.inst.get().SetManifest(m)

--- a/python/src/addons/JsonDictionaryMerger.pyx
+++ b/python/src/addons/JsonDictionaryMerger.pyx
@@ -2,4 +2,4 @@
 
     def SetManifest(self, manifest):
         m = json.dumps(manifest).encode('utf-8')
-        self.inst.get().SetManifestFromString(m)
+        self.inst.get().SetManifest(m)

--- a/python/src/addons/KeyOnlyDictionaryCompiler.pyx
+++ b/python/src/addons/KeyOnlyDictionaryCompiler.pyx
@@ -21,4 +21,4 @@
 
     def SetManifest(self, manifest):
         m = json.dumps(manifest).encode('utf-8')
-        self.inst.get().SetManifestFromString(m)
+        self.inst.get().SetManifest(m)

--- a/python/src/addons/KeyOnlyDictionaryMerger.pyx
+++ b/python/src/addons/KeyOnlyDictionaryMerger.pyx
@@ -2,4 +2,4 @@
 
     def SetManifest(self, manifest):
         m = json.dumps(manifest).encode('utf-8')
-        self.inst.get().SetManifestFromString(m)
+        self.inst.get().SetManifest(m)

--- a/python/src/addons/StringDictionaryCompiler.pyx
+++ b/python/src/addons/StringDictionaryCompiler.pyx
@@ -21,4 +21,4 @@
 
     def SetManifest(self, manifest):
         m = json.dumps(manifest).encode('utf-8')
-        self.inst.get().SetManifestFromString(m)
+        self.inst.get().SetManifest(m)

--- a/python/src/addons/StringDictionaryMerger.pyx
+++ b/python/src/addons/StringDictionaryMerger.pyx
@@ -2,4 +2,4 @@
 
     def SetManifest(self, manifest):
         m = json.dumps(manifest).encode('utf-8')
-        self.inst.get().SetManifestFromString(m)
+        self.inst.get().SetManifest(m)

--- a/python/src/pxds/dictionary_compiler.pxd
+++ b/python/src/pxds/dictionary_compiler.pxd
@@ -12,7 +12,7 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         void __setitem__ (libcpp_utf8_string, int) except +
         void Compile() nogil # wrap-ignore
         void Compile(callback_t, void*) nogil # wrap-ignore
-        void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
+        void SetManifest(libcpp_utf8_string) # wrap-ignore
         void WriteToFile(libcpp_utf8_string) except +
 
     cdef cppclass IntDictionaryCompiler:
@@ -22,7 +22,7 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         void __setitem__ (libcpp_utf8_string, int) except +
         void Compile() nogil # wrap-ignore
         void Compile(callback_t, void*) nogil # wrap-ignore
-        void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
+        void SetManifest(libcpp_utf8_string) # wrap-ignore
         void WriteToFile(libcpp_utf8_string) except +
 
     cdef cppclass KeyOnlyDictionaryCompiler:
@@ -31,7 +31,7 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         void Add(libcpp_utf8_string) except +
         void Compile() nogil # wrap-ignore
         void Compile(callback_t, void*) nogil # wrap-ignore
-        void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
+        void SetManifest(libcpp_utf8_string) # wrap-ignore
         void WriteToFile(libcpp_utf8_string) except +
 
     cdef cppclass JsonDictionaryCompiler:
@@ -41,7 +41,7 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         void __setitem__(libcpp_utf8_string, libcpp_utf8_string) except +
         void Compile() nogil # wrap-ignore
         void Compile(callback_t, void*) nogil # wrap-ignore
-        void SetManifestFromString(libcpp_utf8_string) except + # wrap-ignore
+        void SetManifest(libcpp_utf8_string) except + # wrap-ignore
         void WriteToFile(libcpp_utf8_string) except +
 
     cdef cppclass JsonDictionaryCompilerSmallData:
@@ -51,7 +51,7 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         void __setitem__(libcpp_string, libcpp_string) except +
         void Compile() nogil # wrap-ignore
         void Compile(callback_t, void*) nogil # wrap-ignore
-        void SetManifestFromString(libcpp_utf8_string) except + # wrap-ignore
+        void SetManifest(libcpp_utf8_string) except + # wrap-ignore
         void WriteToFile(libcpp_utf8_string) except +
 
     cdef cppclass StringDictionaryCompiler:
@@ -61,6 +61,6 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         void __setitem__(libcpp_utf8_string, libcpp_utf8_string) except +
         void Compile() nogil # wrap-ignore
         void Compile(callback_t, void*) nogil # wrap-ignore
-        void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
+        void SetManifest(libcpp_utf8_string) # wrap-ignore
         void WriteToFile(libcpp_utf8_string) except +
 

--- a/python/src/pxds/dictionary_merger.pxd
+++ b/python/src/pxds/dictionary_merger.pxd
@@ -10,7 +10,7 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         JsonDictionaryMerger() except +
         JsonDictionaryMerger(libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
         void Add(libcpp_utf8_string) except +
-        void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
+        void SetManifest(libcpp_utf8_string) # wrap-ignore
         void Merge(libcpp_utf8_string) nogil
 
 cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
@@ -18,7 +18,7 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         CompletionDictionaryMerger() except +
         CompletionDictionaryMerger(libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
         void Add(libcpp_utf8_string) except +
-        void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
+        void SetManifest(libcpp_utf8_string) # wrap-ignore
         void Merge(libcpp_utf8_string) nogil
 
 cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
@@ -26,7 +26,7 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         StringDictionaryMerger() except +
         StringDictionaryMerger(libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
         void Add(libcpp_utf8_string) except +
-        void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
+        void SetManifest(libcpp_utf8_string) # wrap-ignore
         void Merge(libcpp_utf8_string) nogil
 
 cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
@@ -34,7 +34,7 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         KeyOnlyDictionaryMerger() except +
         KeyOnlyDictionaryMerger(libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
         void Add(libcpp_utf8_string) except +
-        void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
+        void SetManifest(libcpp_utf8_string) # wrap-ignore
         void Merge(libcpp_utf8_string) nogil
 
 cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
@@ -42,5 +42,5 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         IntDictionaryMerger() except +
         IntDictionaryMerger(libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
         void Add(libcpp_utf8_string) except +
-        void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
+        void SetManifest(libcpp_utf8_string) # wrap-ignore
         void Merge(libcpp_utf8_string) nogil


### PR DESCRIPTION
removes SetManifest(boost:ptree) in favor of SetManifest(std::string), the first wasn't in use, so it is IMHO safe to remove.

relates #80 