### PR TITLE
add a tiered merge policy

### DIFF
--- a/keyvi/CPPLINT.cfg
+++ b/keyvi/CPPLINT.cfg
@@ -1,3 +1,3 @@
 linelength=120
-root=keyvi/include
+root=include
 filter=-build/include_subdir

--- a/keyvi/include/keyvi/dictionary/dictionary_merger.h
+++ b/keyvi/include/keyvi/dictionary/dictionary_merger.h
@@ -32,6 +32,7 @@
 #include <memory>
 #include <queue>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <boost/filesystem.hpp>

--- a/keyvi/include/keyvi/dictionary/dictionary_merger.h
+++ b/keyvi/include/keyvi/dictionary/dictionary_merger.h
@@ -141,7 +141,9 @@ class DictionaryMerger final {
 
     fsa::automata_t fsa;
     if (append_merge_) {
-      fsa.reset(new fsa::Automata(filename, loading_strategy_types::lazy, false));
+      // TODO(hendrik) https://github.com/KeyviDev/keyvi/issues/102
+      fsa.reset(new fsa::Automata(std::make_shared<DictionaryProperties>(DictionaryProperties::FromFile(filename)),
+                                  loading_strategy_types::lazy, false));
     } else {
       fsa.reset(new fsa::Automata(filename));
     }

--- a/keyvi/include/keyvi/dictionary/dictionary_properties.h
+++ b/keyvi/include/keyvi/dictionary/dictionary_properties.h
@@ -28,6 +28,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <fstream>
+#include <memory>
 #include <string>
 
 #include <boost/lexical_cast.hpp>
@@ -300,6 +301,9 @@ class DictionaryProperties {
                                 value_store_properties, manifest);
   }
 };
+
+typedef std::shared_ptr<DictionaryProperties> dictionary_properties_t;
+
 }  // namespace dictionary
 }  // namespace keyvi
 

--- a/keyvi/include/keyvi/index/constants.h
+++ b/keyvi/include/keyvi/index/constants.h
@@ -29,7 +29,7 @@
 
 static const char INDEX_REFRESH_INTERVAL[] = "refresh_interval";
 static const char MERGE_POLICY[] = "merge_policy";
-static const char DEFAULT_MERGE_POLICY[] = "simple";
+static const char DEFAULT_MERGE_POLICY[] = "tiered";
 static const char KEYVIMERGER_BIN[] = "keyvimerger_bin";
 static const char INDEX_MAX_SEGMENTS[] = "max_segments";
 static const char SEGMENT_COMPILE_KEY_THRESHOLD[] = "segment_compile_key_threshold";

--- a/keyvi/include/keyvi/index/internal/merge_policy_selector.h
+++ b/keyvi/include/keyvi/index/internal/merge_policy_selector.h
@@ -32,12 +32,17 @@
 #include "index/internal/simple_merge_policy.h"
 #include "index/internal/tiered_merge_policy.h"
 
+// #define ENABLE_TRACING
+#include "dictionary/util/trace.h"
+
 namespace keyvi {
 namespace index {
 namespace internal {
 
 inline std::shared_ptr<MergePolicy> merge_policy(const std::string& name = "") {
   auto lower_name = name;
+
+  TRACE("Merge Policy: %s", name.c_str());
 
   boost::algorithm::to_lower(lower_name);
   if (lower_name == "simple") {

--- a/keyvi/include/keyvi/index/internal/merge_policy_selector.h
+++ b/keyvi/include/keyvi/index/internal/merge_policy_selector.h
@@ -30,6 +30,7 @@
 
 #include "index/internal/merge_policy.h"
 #include "index/internal/simple_merge_policy.h"
+#include "index/internal/tiered_merge_policy.h"
 
 namespace keyvi {
 namespace index {
@@ -41,15 +42,17 @@ inline std::shared_ptr<MergePolicy> merge_policy(const std::string& name = "") {
   boost::algorithm::to_lower(lower_name);
   if (lower_name == "simple") {
     return std::make_shared<SimpleMergePolicy>();
+  } else if (lower_name == "tiered") {
+    return std::make_shared<TieredMergePolicy>();
   } else {
     throw std::invalid_argument(name + " is not a valid merge policy");
   }
-}
+}  // namespace internal
 
 typedef std::shared_ptr<MergePolicy> merge_policy_t;
 
-} /* namespace internal */
-} /* namespace index */
+}  // namespace internal
+}  // namespace index
 } /* namespace keyvi */
 
 #endif /* KEYVI_INDEX_INTERNAL_MERGE_POLICY_SELECTOR_H_ */

--- a/keyvi/include/keyvi/index/internal/merge_policy_selector.h
+++ b/keyvi/include/keyvi/index/internal/merge_policy_selector.h
@@ -53,6 +53,6 @@ typedef std::shared_ptr<MergePolicy> merge_policy_t;
 
 }  // namespace internal
 }  // namespace index
-} /* namespace keyvi */
+}  // namespace keyvi
 
-#endif /* KEYVI_INDEX_INTERNAL_MERGE_POLICY_SELECTOR_H_ */
+#endif  // KEYVI_INDEX_INTERNAL_MERGE_POLICY_SELECTOR_H_

--- a/keyvi/include/keyvi/index/internal/read_only_segment.h
+++ b/keyvi/include/keyvi/index/internal/read_only_segment.h
@@ -76,7 +76,7 @@ class ReadOnlySegment {
 
   bool HasDeletedKeys() { return has_deleted_keys_; }
 
-  size_t DeletedKeysSize() {
+  size_t DeletedKeysSize() const {
     if (has_deleted_keys_) {
       return deleted_keys_->size();
     }

--- a/keyvi/include/keyvi/index/internal/simple_merge_policy.h
+++ b/keyvi/include/keyvi/index/internal/simple_merge_policy.h
@@ -41,7 +41,7 @@ class SimpleMergePolicy final : public MergePolicy {
     std::vector<segment_t> to_merge;
     for (segment_t& s : *segments) {
       if (!s->MarkedForMerge()) {
-        TRACE("Add to merge list %s", s->GetFilename().c_str());
+        TRACE("Add to merge list %s", s->GetDictionaryFilename().c_str());
         to_merge.push_back(s);
       }
 

--- a/keyvi/include/keyvi/index/internal/tiered_merge_policy.h
+++ b/keyvi/include/keyvi/index/internal/tiered_merge_policy.h
@@ -1,0 +1,155 @@
+//
+// keyvi - A key value store.
+//
+// Copyright 2019 Hendrik Muhs<hendrik.muhs@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/*
+ * tiered_merge_policy.h
+ *
+ *  Created on: Feb 11, 2019
+ *      Author: hendrik
+ */
+
+#ifndef KEYVI_INDEX_INTERNAL_TIERED_MERGE_POLICY_H_
+#define KEYVI_INDEX_INTERNAL_TIERED_MERGE_POLICY_H_
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "index/internal/merge_policy.h"
+#include "index/internal/segment.h"
+
+// #define ENABLE_TRACING
+#include "dictionary/util/trace.h"
+
+namespace keyvi {
+namespace index {
+namespace internal {
+
+/*
+ * Tiered merge policy, inspired by
+ * https://github.com/apache/lucene-solr/blob/master/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
+ *
+ * Some fundamental differences:
+ *
+ * - merge must pick adjacent segments (lucene can pick any segments)
+ * - we use the number of keys not the size
+ */
+class TieredMergePolicy final : public MergePolicy {
+ public:
+  TieredMergePolicy() {}
+
+  inline void MergeFinished(const size_t id) {}
+
+  inline bool SelectMergeSegments(const segments_t& segments, std::vector<segment_t>* elected_segments, size_t* id) {
+    std::vector<segment_t> candidate;
+
+    double best_score = -1;
+    std::vector<segment_t> best_candidate;
+
+    for (size_t start_index = 0; start_index < segments->size(); ++start_index) {
+      size_t totalSizeToMerge = 0;
+      candidate.clear();
+      for (size_t index = start_index; index < segments->size(); ++index) {
+        const segment_t current = (*segments)[index];
+        if (current->MarkedForMerge()) {
+          break;
+        }
+
+        candidate.push_back(current);
+        totalSizeToMerge += current->GetDictionaryProperties()->GetNumberOfKeys();
+
+        if (candidate.size() == MAX_SEGMENT_PER_MERGE) {
+          break;
+        }
+      }
+
+      // skip empty candidate lists
+      if (candidate.size() == 0) {
+        continue;
+      }
+
+      // skip single candidates with no deletes
+      if (candidate.size() == 1 && candidate[0]->HasDeletedKeys() == false) {
+        continue;
+      }
+
+      double score = ScoreCandidate(candidate);
+
+      if (best_score == -1 || score < best_score) {
+        best_score = score;
+        best_candidate.swap(candidate);
+      }
+    }
+
+    if (best_candidate.size() > 0) {
+      elected_segments->swap(best_candidate);
+      return true;
+    }
+
+    return false;
+  }
+
+ private:
+  static const size_t MAX_SEGMENT_PER_MERGE = 20;
+  static const size_t FLOOR_SEGMENT_KEY_SIZE = 10000;
+
+  /*
+   * Score a candidate vector, smaller means better
+   */
+  inline double ScoreCandidate(const std::vector<segment_t>& candidate) {
+    size_t total_size = 0;
+    size_t total_size_floored = 0;
+
+    size_t total_deletes = 0;
+    size_t biggest_segment_key_size = 0;
+
+    for (const segment_t segment : candidate) {
+      size_t segment_key_size = segment->GetDictionaryProperties()->GetNumberOfKeys();
+      total_size += segment_key_size;
+      // floored sizes ensures a minimum size per segment to take fix costs of merging into account
+      size_t segment_key_size_floored = std::max(FLOOR_SEGMENT_KEY_SIZE, segment_key_size);
+      total_size_floored += segment_key_size_floored;
+      total_deletes += segment->DeletedKeysSize();
+      biggest_segment_key_size = std::max(biggest_segment_key_size, segment_key_size);
+    }
+    double skew = static_cast<double>(biggest_segment_key_size) / total_size_floored;
+    double score = skew;
+
+    TRACE("skew: %.18g", total_size, candidate.size(), score);
+
+    // gently favor smaller merges over bigger ones
+    score *= std::pow(total_size, 0.05);
+
+    // boost merges with deletes
+    if (total_deletes > 0) {
+      const double delete_ratio = static_cast<double>(total_size - total_deletes) / total_size;
+      score *= std::pow(delete_ratio, 2);
+    }
+
+    TRACE("Candidate 1st element size %ld total size: %ld, number of segments: %ld score: %.18g",
+          candidate[0]->GetDictionaryProperties()->GetNumberOfKeys(), total_size, candidate.size(), score);
+
+    return score;
+  }
+};
+
+} /* namespace internal */
+} /* namespace index */
+} /* namespace keyvi */
+
+#endif  // KEYVI_INDEX_INTERNAL_TIERED_MERGE_POLICY_H_

--- a/keyvi/include/keyvi/index/internal/tiered_merge_policy.h
+++ b/keyvi/include/keyvi/index/internal/tiered_merge_policy.h
@@ -40,6 +40,9 @@ namespace keyvi {
 namespace index {
 namespace internal {
 
+static const size_t TIERED_MERGE_MAX_SEGMENT_PER_MERGE = 20;
+static const size_t TIERED_MERGE_FLOOR_SEGMENT_KEY_SIZE = 10000;
+
 /*
  * Tiered merge policy, inspired by
  * https://github.com/apache/lucene-solr/blob/master/lucene/core/src/java/org/apache/lucene/index/TieredMergePolicy.java
@@ -73,7 +76,7 @@ class TieredMergePolicy final : public MergePolicy {
         candidate.push_back(current);
         totalSizeToMerge += current->GetDictionaryProperties()->GetNumberOfKeys();
 
-        if (candidate.size() == MAX_SEGMENT_PER_MERGE) {
+        if (candidate.size() == TIERED_MERGE_MAX_SEGMENT_PER_MERGE) {
           break;
         }
       }
@@ -105,9 +108,6 @@ class TieredMergePolicy final : public MergePolicy {
   }
 
  private:
-  static const size_t MAX_SEGMENT_PER_MERGE = 20;
-  static const size_t FLOOR_SEGMENT_KEY_SIZE = 10000;
-
   /*
    * Score a candidate vector, smaller means better
    */
@@ -122,7 +122,7 @@ class TieredMergePolicy final : public MergePolicy {
       size_t segment_key_size = segment->GetDictionaryProperties()->GetNumberOfKeys();
       total_size += segment_key_size;
       // floored sizes ensures a minimum size per segment to take fix costs of merging into account
-      size_t segment_key_size_floored = std::max(FLOOR_SEGMENT_KEY_SIZE, segment_key_size);
+      size_t segment_key_size_floored = std::max(TIERED_MERGE_FLOOR_SEGMENT_KEY_SIZE, segment_key_size);
       total_size_floored += segment_key_size_floored;
       total_deletes += segment->DeletedKeysSize();
       biggest_segment_key_size = std::max(biggest_segment_key_size, segment_key_size);

--- a/keyvi/include/keyvi/index/internal/tiered_merge_policy.h
+++ b/keyvi/include/keyvi/index/internal/tiered_merge_policy.h
@@ -91,7 +91,7 @@ class TieredMergePolicy final : public MergePolicy {
         continue;
       }
 
-      double score = ScoreCandidate(candidate);
+      const double score = ScoreCandidate(candidate);
 
       if (best_score == -1 || score < best_score) {
         best_score = score;
@@ -119,16 +119,17 @@ class TieredMergePolicy final : public MergePolicy {
     size_t biggest_segment_key_size = 0;
 
     for (const segment_t segment : candidate) {
-      size_t segment_key_size = segment->GetDictionaryProperties()->GetNumberOfKeys();
+      const size_t segment_key_size = segment->GetDictionaryProperties()->GetNumberOfKeys();
       total_size += segment_key_size;
       // floored sizes ensures a minimum size per segment to take fix costs of merging into account
-      size_t segment_key_size_floored = std::max(TIERED_MERGE_FLOOR_SEGMENT_KEY_SIZE, segment_key_size);
+      const size_t segment_key_size_floored = std::max(TIERED_MERGE_FLOOR_SEGMENT_KEY_SIZE, segment_key_size);
       total_size_floored += segment_key_size_floored;
       total_deletes += segment->DeletedKeysSize();
       biggest_segment_key_size = std::max(biggest_segment_key_size, segment_key_size);
     }
-    double skew = static_cast<double>(biggest_segment_key_size) / total_size_floored;
-    double score = skew;
+
+    // calculate the skew
+    double score = static_cast<double>(biggest_segment_key_size) / total_size_floored;
 
     TRACE("skew: %.18g", total_size, candidate.size(), score);
 

--- a/keyvi/tests/keyvi/index/index_test.cpp
+++ b/keyvi/tests/keyvi/index/index_test.cpp
@@ -82,16 +82,14 @@ BOOST_AUTO_TEST_CASE(basic_writer_simple_merge_policy) {
   basic_writer_test({{KEYVIMERGER_BIN, get_keyvimerger_bin()}, {MERGE_POLICY, "simple"}});
 }
 
-BOOST_AUTO_TEST_CASE(bigger_feed) {
+void bigger_feed_test(const keyvi::util::parameters_t& params = keyvi::util::parameters_t()) {
   using boost::filesystem::temp_directory_path;
   using boost::filesystem::unique_path;
 
   auto tmp_path = temp_directory_path();
   tmp_path /= unique_path("index-test-temp-index-%%%%-%%%%-%%%%-%%%%");
   {
-    Index writer(
-        tmp_path.string(),
-        {{"refresh_interval", "100"}, {KEYVIMERGER_BIN, get_keyvimerger_bin()}, {"max_concurrent_merges", "2"}});
+    Index writer(tmp_path.string(), params);
 
     for (int i = 0; i < 10000; ++i) {
       writer.Set("a", "{\"id\":" + std::to_string(i) + "}");
@@ -107,6 +105,19 @@ BOOST_AUTO_TEST_CASE(bigger_feed) {
     BOOST_CHECK_EQUAL("{\"id\":9999}", m.GetValueAsString());
   }
   boost::filesystem::remove_all(tmp_path);
+}
+
+BOOST_AUTO_TEST_CASE(bigger_feed) {
+  bigger_feed_test(
+      {{"refresh_interval", "100"}, {KEYVIMERGER_BIN, get_keyvimerger_bin()}, {"max_concurrent_merges", "2"}});
+}
+
+BOOST_AUTO_TEST_CASE(bigger_feed_simple_merge_policy) {
+  bigger_feed_test({{"refresh_interval", "100"},
+                    {KEYVIMERGER_BIN, get_keyvimerger_bin()},
+                    {"max_concurrent_merges", "2"},
+                    {KEYVIMERGER_BIN, get_keyvimerger_bin()},
+                    {MERGE_POLICY, "simple"}});
 }
 
 BOOST_AUTO_TEST_CASE(index_reopen) {

--- a/keyvi/tests/keyvi/index/index_test.cpp
+++ b/keyvi/tests/keyvi/index/index_test.cpp
@@ -47,14 +47,15 @@ namespace keyvi {
 namespace index {
 BOOST_AUTO_TEST_SUITE(IndexTests)
 
-BOOST_AUTO_TEST_CASE(basic_writer) {
+// basic writer test, re-usable for testing different parameters
+void basic_writer_test(const keyvi::util::parameters_t& params = keyvi::util::parameters_t()) {
   using boost::filesystem::temp_directory_path;
   using boost::filesystem::unique_path;
 
   auto tmp_path = temp_directory_path();
   tmp_path /= unique_path();
   {
-    Index writer(tmp_path.string(), {{KEYVIMERGER_BIN, get_keyvimerger_bin()}});
+    Index writer(tmp_path.string(), params);
 
     writer.Set("a", "{\"id\":3}");
 
@@ -71,6 +72,14 @@ BOOST_AUTO_TEST_CASE(basic_writer) {
     BOOST_CHECK(writer.Contains("d"));
   }
   boost::filesystem::remove_all(tmp_path);
+}
+
+BOOST_AUTO_TEST_CASE(basic_writer_default) {
+  basic_writer_test({{KEYVIMERGER_BIN, get_keyvimerger_bin()}});
+}
+
+BOOST_AUTO_TEST_CASE(basic_writer_simple_merge_policy) {
+  basic_writer_test({{KEYVIMERGER_BIN, get_keyvimerger_bin()}, {MERGE_POLICY, "simple"}});
 }
 
 BOOST_AUTO_TEST_CASE(bigger_feed) {
@@ -187,14 +196,14 @@ BOOST_AUTO_TEST_CASE(index_reopen_deleted_keys) {
   }
 }
 
-BOOST_AUTO_TEST_CASE(index_delete_keys) {
+void index_with_deletes(const keyvi::util::parameters_t& params = keyvi::util::parameters_t()) {
   using boost::filesystem::temp_directory_path;
   using boost::filesystem::unique_path;
 
   auto tmp_path = temp_directory_path();
   tmp_path /= unique_path("index-test-temp-index-%%%%-%%%%-%%%%-%%%%");
   {
-    Index index(tmp_path.string(), {{"refresh_interval", "100"}, {KEYVIMERGER_BIN, get_keyvimerger_bin()}});
+    Index index(tmp_path.string(), params);
 
     for (int i = 0; i < 100; ++i) {
       index.Set("a" + std::to_string(i), "{\"id\":" + std::to_string(i) + "}");
@@ -246,6 +255,14 @@ BOOST_AUTO_TEST_CASE(index_delete_keys) {
   }
 
   boost::filesystem::remove_all(tmp_path);
+}
+
+BOOST_AUTO_TEST_CASE(index_delete_keys_defaults) {
+  index_with_deletes({{"refresh_interval", "100"}, {KEYVIMERGER_BIN, get_keyvimerger_bin()}});
+}
+
+BOOST_AUTO_TEST_CASE(index_delete_keys_simple_merge_policy) {
+  index_with_deletes({{"refresh_interval", "100"}, {KEYVIMERGER_BIN, get_keyvimerger_bin()}, {MERGE_POLICY, "simple"}});
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/keyvi/tests/keyvi/index/internal/tiered_merge_policy_test.cpp
+++ b/keyvi/tests/keyvi/index/internal/tiered_merge_policy_test.cpp
@@ -1,0 +1,159 @@
+//
+// keyvi - A key value store.
+//
+// Copyright 2015 Hendrik Muhs<hendrik.muhs@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/*
+ * tiered_merge_policy_test.cpp
+ *
+ *  Created on: Feb 14, 2019
+ *      Author: hendrik
+ */
+
+#include <memory>
+
+#include <boost/test/unit_test.hpp>
+
+#include "dictionary/dictionary_properties.h"
+#include "dictionary/dictionary_types.h"
+#include "index/internal/segment.h"
+#include "index/internal/tiered_merge_policy.h"
+
+namespace keyvi {
+namespace index {
+namespace internal {
+namespace unit_test {
+class SegmentFriend {
+ public:
+  static segment_t CreateSegment(dictionary::dictionary_properties_t properties) {
+    // due to the friend declaration we can not use make_shared in this place
+    return std::shared_ptr<Segment>(new Segment(properties));
+  }
+
+  static void SetDeletedKeys(segment_t segment, std::unordered_set<std::string> keys) {
+    segment->deleted_keys_for_write_ = keys;
+    if (keys.size() > 0) {
+      segment->deletes_loaded = true;
+    }
+  }
+};
+}  // namespace unit_test
+
+BOOST_AUTO_TEST_SUITE(MergePolicySelectorTests)
+
+static dictionary::dictionary_properties_t createDictionaryProperties(const uint64_t number_of_keys,
+                                                                      const uint64_t start_state = 0) {
+  return std::make_shared<dictionary::DictionaryProperties>(0, start_state, number_of_keys, 0,
+                                                            dictionary::dictionary_type_t::KEY_ONLY, 0, 0, "");
+}
+
+BOOST_AUTO_TEST_CASE(one_segment) {
+  TieredMergePolicy tiered_merge_policy;
+
+  segments_t segments{std::make_shared<segment_vec_t>()};
+  std::vector<segment_t> selected_segments;
+  size_t id;
+
+  segments->push_back(unit_test::SegmentFriend::CreateSegment(createDictionaryProperties(1000)));
+
+  tiered_merge_policy.SelectMergeSegments(segments, &selected_segments, &id);
+
+  BOOST_CHECK(selected_segments.empty());
+
+  unit_test::SegmentFriend::SetDeletedKeys((*segments)[0], std::unordered_set<std::string>{"key1"});
+
+  tiered_merge_policy.SelectMergeSegments(segments, &selected_segments, &id);
+
+  BOOST_CHECK(!selected_segments.empty());
+}
+
+BOOST_AUTO_TEST_CASE(segment_mix) {
+  TieredMergePolicy tiered_merge_policy;
+
+  segments_t segments{std::make_shared<segment_vec_t>()};
+  std::vector<segment_t> selected_segments;
+  size_t id;
+
+  segments->emplace_back(unit_test::SegmentFriend::CreateSegment(createDictionaryProperties(1000000, 1)));
+  segments->emplace_back(unit_test::SegmentFriend::CreateSegment(createDictionaryProperties(1000001, 2)));
+  segments->emplace_back(unit_test::SegmentFriend::CreateSegment(createDictionaryProperties(1000002, 3)));
+
+  for (uint64_t i = 100; i < 120; ++i) {
+    segments->emplace_back(unit_test::SegmentFriend::CreateSegment(createDictionaryProperties(100000 + i, i)));
+  }
+
+  for (uint64_t i = 200; i < 220; ++i) {
+    segments->emplace_back(unit_test::SegmentFriend::CreateSegment(createDictionaryProperties(10000 + i, i)));
+  }
+
+  BOOST_CHECK(tiered_merge_policy.SelectMergeSegments(segments, &selected_segments, &id));
+  // expect that smaller 20 segments have been selected
+  BOOST_CHECK_EQUAL(20, selected_segments.size());
+  BOOST_CHECK_EQUAL(200, selected_segments[0]->GetDictionaryProperties()->GetStartState());
+
+  // remove the last 5
+  segments->pop_back();
+  segments->pop_back();
+  segments->pop_back();
+  segments->pop_back();
+  segments->pop_back();
+
+  BOOST_CHECK(tiered_merge_policy.SelectMergeSegments(segments, &selected_segments, &id));
+  // expect that middle 20 segments have been selected
+  BOOST_CHECK_EQUAL(20, selected_segments.size());
+  BOOST_CHECK_EQUAL(100, selected_segments[0]->GetDictionaryProperties()->GetStartState());
+}
+
+BOOST_AUTO_TEST_CASE(segment_with_deletes) {
+  TieredMergePolicy tiered_merge_policy;
+
+  segments_t segments{std::make_shared<segment_vec_t>()};
+  std::vector<segment_t> selected_segments;
+  size_t id;
+
+  // 2 identical sets of segments
+  for (uint64_t i = 0; i < 20; ++i) {
+    segments->emplace_back(unit_test::SegmentFriend::CreateSegment(createDictionaryProperties(100100 + i, i)));
+  }
+
+  for (uint64_t i = 100; i < 120; ++i) {
+    segments->emplace_back(unit_test::SegmentFriend::CreateSegment(createDictionaryProperties(100000 + i, i)));
+  }
+
+  BOOST_CHECK(tiered_merge_policy.SelectMergeSegments(segments, &selected_segments, &id));
+
+  // expect that the 1st set gets selected
+  BOOST_CHECK_EQUAL(20, selected_segments.size());
+  BOOST_CHECK_EQUAL(0, selected_segments[0]->GetDictionaryProperties()->GetStartState());
+
+  // add some deletes to the 2nd set
+  for (uint64_t i = 20; i < 40; ++i) {
+    unit_test::SegmentFriend::SetDeletedKeys((*segments)[i],
+                                             std::unordered_set<std::string>{"key1", "key2", "key3", "key4", "key5"});
+  }
+
+  BOOST_CHECK(tiered_merge_policy.SelectMergeSegments(segments, &selected_segments, &id));
+
+  // expect that the 2nd set gets selected because it scores better with deletes
+  BOOST_CHECK_EQUAL(20, selected_segments.size());
+  BOOST_CHECK_EQUAL(100, selected_segments[0]->GetDictionaryProperties()->GetStartState());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} /* namespace internal */
+} /* namespace index */
+} /* namespace keyvi */


### PR DESCRIPTION
The tiered merge policy is a smarter selection algorithm for selecting segments to merge. It scores sets of segments while prefering similar sized segments while boosting smaller merges and segments with deletes.

The algorithm is inspired by Lucene's tiered merge policy.

This change makes the tiered merge policy the default