### PR TITLE
implement internal merges without an external process

### DIFF
--- a/keyvi/include/keyvi/index/constants.h
+++ b/keyvi/include/keyvi/index/constants.h
@@ -33,11 +33,13 @@ static const char DEFAULT_MERGE_POLICY[] = "tiered";
 static const char KEYVIMERGER_BIN[] = "keyvimerger_bin";
 static const char INDEX_MAX_SEGMENTS[] = "max_segments";
 static const char SEGMENT_COMPILE_KEY_THRESHOLD[] = "segment_compile_key_threshold";
+static const char SEGMENT_EXTERNAL_MERGE_KEY_THRESHOLD[] = "segment_external_merge_key_threshold";
 static const char MAX_CONCURRENT_MERGES[] = "max_concurrent_merges";
 
 // defaults
 static const size_t DEFAULT_REFRESH_INTERVAL = 1000ul;
 static const size_t DEFAULT_COMPILE_KEY_THRESHOLD = 10000ul;
+static const size_t DEFAULT_EXTERNAL_MERGE_KEY_THRESHOLD = 100000ul;
 static const char DEFAULT_KEYVIMERGER_BIN[] = "keyvimerger";
 
 // spinlock wait time if there are too many segments

--- a/keyvi/include/keyvi/index/internal/index_settings.h
+++ b/keyvi/include/keyvi/index/internal/index_settings.h
@@ -69,6 +69,12 @@ class IndexSettings final {
     } else {
       settings_[INDEX_REFRESH_INTERVAL] = DEFAULT_REFRESH_INTERVAL;
     }
+    if (params.count(SEGMENT_EXTERNAL_MERGE_KEY_THRESHOLD)) {
+      settings_[SEGMENT_EXTERNAL_MERGE_KEY_THRESHOLD] =
+          keyvi::util::mapGet<size_t>(params, SEGMENT_EXTERNAL_MERGE_KEY_THRESHOLD);
+    } else {
+      settings_[SEGMENT_EXTERNAL_MERGE_KEY_THRESHOLD] = DEFAULT_EXTERNAL_MERGE_KEY_THRESHOLD;
+    }
   }
 
   const std::string& GetKeyviMergerBin() const { return boost::get<std::string>(settings_.at(KEYVIMERGER_BIN)); }
@@ -82,6 +88,10 @@ class IndexSettings final {
   const size_t GetMaxConcurrentMerges() const { return boost::get<size_t>(settings_.at(MAX_CONCURRENT_MERGES)); }
 
   const size_t GetRefreshInterval() const { return boost::get<size_t>(settings_.at(INDEX_REFRESH_INTERVAL)); }
+
+  const size_t GetSegmentExternalMergeKeyThreshold() const {
+    return boost::get<size_t>(settings_.at(SEGMENT_EXTERNAL_MERGE_KEY_THRESHOLD));
+  }
 
  private:
   std::unordered_map<std::string, boost::variant<std::string, size_t>> settings_;

--- a/keyvi/include/keyvi/index/internal/index_writer_worker.h
+++ b/keyvi/include/keyvi/index/internal/index_writer_worker.h
@@ -360,7 +360,9 @@ class IndexWriterWorker final {
     }
 
     payload_.merge_jobs_.emplace_back(to_merge, merge_policy_id, p, payload_.settings_);
-    payload_.merge_jobs_.back().Run();
+
+    // force external merge if low on filedescriptors
+    payload_.merge_jobs_.back().Run(payload_.segments_->size() + to_merge.size() + 10 > payload_.max_segments_);
   }
 
   void LoadIndex() {

--- a/keyvi/include/keyvi/index/internal/merge_job.h
+++ b/keyvi/include/keyvi/index/internal/merge_job.h
@@ -69,26 +69,38 @@ class MergeJob final {
 
   ~MergeJob() {
     if (payload_.process_finished_ == false) {
-      EndExternalProcess();
+      FinalizeMerge();
     }
   }
 
   MergeJob(MergeJob&&) = default;
   MergeJob& operator=(MergeJob&&) = default;
 
-  void Run() { DoExternalProcessMerge(); }
+  void Run(bool force_external_merge = false) {
+    uint64_t job_size = 0;
+
+    for (const segment_t segment : payload_.segments_) {
+      job_size += segment->GetDictionaryProperties()->GetNumberOfKeys();
+    }
+
+    if (force_external_merge == false && job_size < payload_.settings_.GetSegmentExternalMergeKeyThreshold()) {
+      DoInternalMerge();
+    } else {
+      DoExternalProcessMerge();
+    }
+  }
 
   bool TryFinalize() {
     // already finished?
     if (payload_.process_finished_ == true) {
       return true;
     }
-    return TryEndExternalProcess();
+    return TryFinalizeMerge();
   }
 
   void Finalize() {
     if (payload_.process_finished_ == false) {
-      EndExternalProcess();
+      FinalizeMerge();
     }
   }
 
@@ -115,6 +127,28 @@ class MergeJob final {
   MergeJobPayload payload_;
   size_t id_;
   std::shared_ptr<TinyProcessLib::Process> external_process_;
+  std::thread internal_merge_;
+
+  void DoInternalMerge() {
+    payload_.start_time_ = std::chrono::system_clock::now();
+
+    internal_merge_ = std::thread([this]() {
+      try {
+        keyvi::util::parameters_t params;
+
+        keyvi::dictionary::JsonDictionaryMerger jsonDictionaryMerger(params);
+        for (const segment_t s : payload_.segments_) {
+          jsonDictionaryMerger.Add(s->GetDictionaryPath().string());
+        }
+
+        jsonDictionaryMerger.Merge(payload_.output_filename_.string());
+        payload_.exit_code_ = 0;
+      } catch (const std::exception& e) {
+        TRACE("internal merge failed with: %s", e.what());
+        payload_.exit_code_ = 1;
+      }
+    });
+  }
 
   void DoExternalProcessMerge() {
     payload_.start_time_ = std::chrono::system_clock::now();
@@ -132,17 +166,28 @@ class MergeJob final {
     external_process_.reset(new TinyProcessLib::Process(command.str()));
   }
 
-  bool TryEndExternalProcess() {
-    if (external_process_->try_get_exit_status(payload_.exit_code_)) {
-      payload_.end_time_ = std::chrono::system_clock::now();
+  bool TryFinalizeMerge() {
+    if (external_process_) {
+      if (external_process_->try_get_exit_status(payload_.exit_code_)) {
+        payload_.process_finished_ = true;
+        return true;
+      }
+    } else if (internal_merge_.joinable()) {
+      internal_merge_.join();
+      // exit code set by merge thread
       payload_.process_finished_ = true;
       return true;
     }
     return false;
   }
 
-  void EndExternalProcess() {
-    payload_.exit_code_ = external_process_->get_exit_status();
+  void FinalizeMerge() {
+    if (external_process_) {
+      payload_.exit_code_ = external_process_->get_exit_status();
+    } else {
+      internal_merge_.join();
+      // exit code set by merge thread
+    }
     payload_.end_time_ = std::chrono::system_clock::now();
     payload_.process_finished_ = true;
   }

--- a/keyvi/include/keyvi/index/internal/merge_job.h
+++ b/keyvi/include/keyvi/index/internal/merge_job.h
@@ -136,6 +136,8 @@ class MergeJob final {
       try {
         keyvi::util::parameters_t params;
 
+        // todo: make this configurable
+        params[MEMORY_LIMIT_KEY] = "5242880";
         keyvi::dictionary::JsonDictionaryMerger jsonDictionaryMerger(params);
         for (const segment_t s : payload_.segments_) {
           jsonDictionaryMerger.Add(s->GetDictionaryPath().string());

--- a/keyvi/tests/keyvi/index/index_test.cpp
+++ b/keyvi/tests/keyvi/index/index_test.cpp
@@ -78,6 +78,10 @@ BOOST_AUTO_TEST_CASE(basic_writer_default) {
   basic_writer_test({{KEYVIMERGER_BIN, get_keyvimerger_bin()}});
 }
 
+BOOST_AUTO_TEST_CASE(basic_writer_external_merge) {
+  basic_writer_test({{KEYVIMERGER_BIN, get_keyvimerger_bin()}, {SEGMENT_EXTERNAL_MERGE_KEY_THRESHOLD, "0"}});
+}
+
 BOOST_AUTO_TEST_CASE(basic_writer_simple_merge_policy) {
   basic_writer_test({{KEYVIMERGER_BIN, get_keyvimerger_bin()}, {MERGE_POLICY, "simple"}});
 }
@@ -125,6 +129,10 @@ BOOST_AUTO_TEST_CASE(basic_writer_bulk_default) {
   basic_writer_bulk_test({{KEYVIMERGER_BIN, get_keyvimerger_bin()}});
 }
 
+BOOST_AUTO_TEST_CASE(basic_writer_bulk_external_merge) {
+  basic_writer_bulk_test({{KEYVIMERGER_BIN, get_keyvimerger_bin()}, {SEGMENT_EXTERNAL_MERGE_KEY_THRESHOLD, "0"}});
+}
+
 BOOST_AUTO_TEST_CASE(basic_writer_bulk_simple_merge_policy) {
   basic_writer_bulk_test({{KEYVIMERGER_BIN, get_keyvimerger_bin()}, {MERGE_POLICY, "simple"}});
 }
@@ -157,6 +165,13 @@ void bigger_feed_test(const keyvi::util::parameters_t& params = keyvi::util::par
 BOOST_AUTO_TEST_CASE(bigger_feed) {
   bigger_feed_test(
       {{"refresh_interval", "100"}, {KEYVIMERGER_BIN, get_keyvimerger_bin()}, {"max_concurrent_merges", "2"}});
+}
+
+BOOST_AUTO_TEST_CASE(bigger_feed_external_merge) {
+  bigger_feed_test({{"refresh_interval", "100"},
+                    {KEYVIMERGER_BIN, get_keyvimerger_bin()},
+                    {"max_concurrent_merges", "2"},
+                    {SEGMENT_EXTERNAL_MERGE_KEY_THRESHOLD, "0"}});
 }
 
 BOOST_AUTO_TEST_CASE(bigger_feed_simple_merge_policy) {

--- a/travis/build_linux.sh
+++ b/travis/build_linux.sh
@@ -8,4 +8,4 @@ cd build
 cmake -DCMAKE_BUILD_TYPE=$CONF ..
 make -j 4
 
-./unit_test_all
+./unit_test_all --log_level=test_suite

--- a/travis/build_osx_package.sh
+++ b/travis/build_osx_package.sh
@@ -6,7 +6,7 @@ cd build
 cmake -DCMAKE_BUILD_TYPE=release -DZLIB_ROOT=/usr/local/opt/zlib ..
 make -j 4
 
-./unit_test_all
+./unit_test_all --log_level=test_suite
 cd ..
 
 


### PR DESCRIPTION
implements internal merges without using an external process, merges of smaller segments are done in-process decided by a static threshold. The threshold decides when to switch to external process based merging.