### PR TITLE
Fix Segment invalidation issue

### DIFF
--- a/keyvi/include/keyvi/dictionary/dictionary_properties.h
+++ b/keyvi/include/keyvi/dictionary/dictionary_properties.h
@@ -101,7 +101,7 @@ class DictionaryProperties {
     std::ifstream file_stream(file_name, std::ios::binary);
 
     if (!file_stream.good()) {
-      throw std::invalid_argument("file not found");
+      throw std::invalid_argument("dictionary file not found");
     }
 
     char magic[KEYVI_FILE_MAGIC_LEN];

--- a/keyvi/include/keyvi/index/index.h
+++ b/keyvi/include/keyvi/index/index.h
@@ -50,6 +50,9 @@
 
 namespace keyvi {
 namespace index {
+namespace unit_test {
+class IndexFriend;
+}
 
 class Index final : public internal::BaseIndexReader<internal::IndexWriterWorker, internal::Segment> {
  public:
@@ -103,11 +106,21 @@ class Index final : public internal::BaseIndexReader<internal::IndexWriterWorker
     Payload().FlushAsync();
   }
 
+  void ForceMerge(const size_t max_segments = 1) {
+    if (max_segments < 1) {
+      throw std::invalid_argument("max_segments must be > 1");
+    }
+    Payload().ForceMerge(max_segments);
+  }
+
  private:
   boost::filesystem::path index_directory_;
   boost::filesystem::path index_toc_file_;
   std::ofstream lock_file_;
   boost::interprocess::file_lock index_lock_;
+
+  // friend for unit testing only
+  friend class unit_test::IndexFriend;
 };
 
 } /* namespace index */

--- a/keyvi/include/keyvi/index/internal/base_index_reader.h
+++ b/keyvi/include/keyvi/index/internal/base_index_reader.h
@@ -35,6 +35,9 @@
 
 namespace keyvi {
 namespace index {
+namespace unit_test {
+class IndexFriend;
+}
 namespace internal {
 
 template <class PayloadT, class SegmentT = ReadOnlySegment>
@@ -77,6 +80,9 @@ class BaseIndexReader {
 
  private:
   PayloadT payload_;
+
+  // friend for unit testing only
+  friend class keyvi::index::unit_test::IndexFriend;
 };
 
 } /* namespace internal */

--- a/keyvi/include/keyvi/index/internal/index_reader_worker.h
+++ b/keyvi/include/keyvi/index/internal/index_reader_worker.h
@@ -144,7 +144,7 @@ class IndexReaderWorker final {
     TRACE("rereading %s", index_toc_file_.string().c_str());
 
     if (!toc_fstream.good()) {
-      throw std::invalid_argument("file not found");
+      throw std::invalid_argument("toc file not found");
     }
 
     rapidjson::Document index_toc;

--- a/keyvi/include/keyvi/index/internal/segment.h
+++ b/keyvi/include/keyvi/index/internal/segment.h
@@ -130,6 +130,11 @@ class Segment final : public ReadOnlySegment {
 
   bool MarkedForMerge() const { return in_merge_; }
 
+  void Load() {
+    LazyLoadDictionary();
+    LazyLoadDeletedKeys();
+  }
+
   void RemoveFiles() {
     // delete files, not all files might exist, therefore ignore the output
     std::remove(GetDictionaryPath().c_str());

--- a/keyvi/include/keyvi/vector/vector_file.h
+++ b/keyvi/include/keyvi/vector/vector_file.h
@@ -166,7 +166,7 @@ class VectorFile {
  private:
   void CheckValidity(std::ifstream* in_stream) const {
     if (!in_stream->good()) {
-      throw std::invalid_argument("file not found");
+      throw std::invalid_argument("vector file not found");
     }
     char magic_start[KEYVI_VECTOR_BEGIN_LEN];
     in_stream->read(magic_start, KEYVI_VECTOR_BEGIN_LEN);


### PR DESCRIPTION
- fix segment vector caching: due to lazy loading of the dictionary file, the file might have been deleted already at the time of a lookup (issue seen on CI)
- fix segment invalidation: the cache never got invalidated in case of a constant stream of lookups (the reference count of the cache never reached 0), invalidation is now enforced for every new segment and after a merge
- implement force merge: the force merge command blocks until segments are merged down to the given number of segments

Notes:
 - force merge was implemented for testing the invalidation/caching problem, there is no "force" right now, but it blocks until merges are done automatically, however in future force merge could do a real "force"
 - it's also called "force merge" in lucene: common wording

