### PR TITLE
install openssl via homebrew on osx

### DIFF
--- a/travis/setup_osx.sh
+++ b/travis/setup_osx.sh
@@ -7,11 +7,14 @@ df -h
 brew update
 brew install zlib
 brew install snappy
+brew install openssl@1.1
 
 brew upgrade pyenv
 
 export PATH="${HOME}/.pyenv/shims/:/root/.pyenv/bin:${PATH}"
 
+CFLAGS="-I$(brew --prefix openssl)/include" \
+LDFLAGS="-L$(brew --prefix openssl)/lib" \
 pyenv install ${PYTHON_VERSION}
 pyenv global ${PYTHON_VERSION}
 


### PR DESCRIPTION
install openssl ourselves to fix osx problem for python 3.4.10