### PR TITLE
drop python 3.4.9 and add 3.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,26 +22,26 @@ env:
     - BUILD_TYPE=linux      DOCKER_IMAGE=keyvidev/ubuntu-builder      CONF=debug
 
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=2.7.16         CONF=release
-    - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=3.4.9          CONF=release
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=3.5.7          CONF=release
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=3.6.9          CONF=release
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=3.7.4          CONF=release
+    - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=3.8.0          CONF=release
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=pypy2.7-7.2.0  CONF=release
 
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=2.7.16         CONF=debug
-    - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=3.4.9          CONF=debug
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=3.5.7          CONF=debug
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=3.6.9          CONF=debug
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=3.7.4          CONF=debug
+    - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=3.8.0          CONF=debug
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=pypy2.7-7.2.0  CONF=debug
 
     - BUILD_TYPE=sdist      DOCKER_IMAGE=keyvidev/ubuntu-builder
 
     - BUILD_TYPE=manylinux  DOCKER_IMAGE=keyvidev/manylinux-builder         PYTHON_PATH=cp27-cp27mu
-    - BUILD_TYPE=manylinux  DOCKER_IMAGE=keyvidev/manylinux-builder         PYTHON_PATH=cp34-cp34m
     - BUILD_TYPE=manylinux  DOCKER_IMAGE=keyvidev/manylinux-builder         PYTHON_PATH=cp35-cp35m
     - BUILD_TYPE=manylinux  DOCKER_IMAGE=keyvidev/manylinux-builder         PYTHON_PATH=cp36-cp36m
     - BUILD_TYPE=manylinux  DOCKER_IMAGE=keyvidev/manylinux-builder         PYTHON_PATH=cp37-cp37m
+    - BUILD_TYPE=manylinux  DOCKER_IMAGE=keyvidev/manylinux-builder         PYTHON_PATH=cp38-cp38
 
     - BUILD_TYPE=rust       DOCKER_IMAGE=keyvidev/ubuntu-builder
 
@@ -63,10 +63,6 @@ matrix:
     - os: osx
       osx_image: xcode7.3
       compiler: clang
-      env: BUILD_TYPE=osx PYTHON_VERSION=3.4.10
-    - os: osx
-      osx_image: xcode7.3
-      compiler: clang
       env: BUILD_TYPE=osx PYTHON_VERSION=3.5.7
     - os: osx
       osx_image: xcode7.3
@@ -76,6 +72,10 @@ matrix:
       osx_image: xcode7.3
       compiler: clang
       env: BUILD_TYPE=osx PYTHON_VERSION=3.7.4
+    - os: osx
+      osx_image: xcode7.3
+      compiler: clang
+      env: BUILD_TYPE=osx PYTHON_VERSION=3.8.0
     - os: osx
       osx_image: xcode7.3
       compiler: clang

--- a/docker/ubuntu-builder/Dockerfile
+++ b/docker/ubuntu-builder/Dockerfile
@@ -22,7 +22,6 @@ ENV PATH "/root/.pyenv/shims/:/root/.pyenv/bin:$PATH"
 
 # install python versions
 RUN pyenv install 2.7.16
-RUN pyenv install 3.4.9
 RUN pyenv install 3.5.7
 RUN pyenv install 3.6.9
 RUN pyenv install 3.7.4


### PR DESCRIPTION
drop python 3.4.9 and add 3.8.0

Note:
 - we should also modernize other parts, e.g. bump XCode, manylinux, linux compilers?, all to be done in follow-ups