### PR TITLE
improve mset

### DIFF
--- a/keyvi/include/keyvi/index/index.h
+++ b/keyvi/include/keyvi/index/index.h
@@ -94,7 +94,7 @@ class Index final : public internal::BaseIndexReader<internal::IndexWriterWorker
   void Set(const std::string& key, const std::string& value) { Payload().Add(key, value); }
 
   template <typename ContainerType>
-  void MSet(const std::shared_ptr<ContainerType> key_values) {
+  void MSet(const std::shared_ptr<ContainerType>& key_values) {
     Payload().Add(key_values);
   }
 

--- a/keyvi/include/keyvi/index/index.h
+++ b/keyvi/include/keyvi/index/index.h
@@ -31,6 +31,7 @@
 #include <chrono>              //NOLINT
 #include <condition_variable>  //NOLINT
 #include <ctime>
+#include <memory>
 #include <string>
 #include <thread>  //NOLINT
 #include <vector>
@@ -92,18 +93,16 @@ class Index final : public internal::BaseIndexReader<internal::IndexWriterWorker
 
   void Set(const std::string& key, const std::string& value) { Payload().Add(key, value); }
 
-  void MSet(const key_values_ptr_t& key_values) { Payload().Add(key_values); }
+  template <typename ContainerType>
+  void MSet(const std::shared_ptr<ContainerType> key_values) {
+    Payload().Add(key_values);
+  }
 
   void Delete(const std::string& key) { Payload().Delete(key); }
 
-  void Flush() {
+  void Flush(const bool async = false) {
     TRACE("Flush (manually)");
-    Payload().Flush();
-  }
-
-  void FlushAsync() {
-    TRACE("Flush (manually)");
-    Payload().FlushAsync();
+    Payload().Flush(async);
   }
 
   void ForceMerge(const size_t max_segments = 1) {

--- a/python/src/pxds/index.pxd
+++ b/python/src/pxds/index.pxd
@@ -14,6 +14,6 @@ cdef extern from "keyvi/index/index.h" namespace "keyvi::index":
         void MSet(s_shared_ptr[libcpp_vector[libcpp_pair[libcpp_utf8_string, libcpp_utf8_string]]]) # wrap-ignore
         void Delete(libcpp_utf8_string) except+
         void Flush() except+
-        void FlushAsync() except+
+        void Flush(bool) except+
         bool Contains(libcpp_utf8_string) # wrap-ignore
         Match operator[](libcpp_utf8_string) # wrap-ignore


### PR DESCRIPTION
make mset parameter flexible, merge flush and flush async

Note:

the mset change is motivated by protobuf, it allows to use protobuf's map implementation directly