### PR TITLE
update manylinux docker image base 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,11 @@ env:
 
     - BUILD_TYPE=sdist      DOCKER_IMAGE=keyvidev/ubuntu-builder
 
-    - BUILD_TYPE=manylinux  DOCKER_IMAGE=keyvidev/manylinux-builder         PYTHON_PATH=cp27-cp27mu
-    - BUILD_TYPE=manylinux  DOCKER_IMAGE=keyvidev/manylinux-builder         PYTHON_PATH=cp35-cp35m
-    - BUILD_TYPE=manylinux  DOCKER_IMAGE=keyvidev/manylinux-builder         PYTHON_PATH=cp36-cp36m
-    - BUILD_TYPE=manylinux  DOCKER_IMAGE=keyvidev/manylinux-builder         PYTHON_PATH=cp37-cp37m
-    - BUILD_TYPE=manylinux  DOCKER_IMAGE=keyvidev/manylinux-builder         PYTHON_PATH=cp38-cp38
+    - BUILD_TYPE=manylinux  DOCKER_IMAGE=narekgharibyan/manylinux-builder         PYTHON_PATH=cp27-cp27mu
+    - BUILD_TYPE=manylinux  DOCKER_IMAGE=narekgharibyan/manylinux-builder         PYTHON_PATH=cp35-cp35m
+    - BUILD_TYPE=manylinux  DOCKER_IMAGE=narekgharibyan/manylinux-builder         PYTHON_PATH=cp36-cp36m
+    - BUILD_TYPE=manylinux  DOCKER_IMAGE=narekgharibyan/manylinux-builder         PYTHON_PATH=cp37-cp37m
+    - BUILD_TYPE=manylinux  DOCKER_IMAGE=narekgharibyan/manylinux-builder         PYTHON_PATH=cp38-cp38
 
     #- BUILD_TYPE=rust       DOCKER_IMAGE=keyvidev/ubuntu-builder
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,12 @@ env:
     - BUILD_TYPE=linux      DOCKER_IMAGE=keyvidev/ubuntu-builder      CONF=release
     - BUILD_TYPE=linux      DOCKER_IMAGE=keyvidev/ubuntu-builder      CONF=debug
 
-    - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=2.7.16         CONF=release
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=3.5.7          CONF=release
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=3.6.9          CONF=release
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=3.7.4          CONF=release
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=3.8.0          CONF=release
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=pypy2.7-7.2.0  CONF=release
 
-    - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=2.7.16         CONF=debug
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=3.5.7          CONF=debug
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=3.6.9          CONF=debug
     - BUILD_TYPE=python     DOCKER_IMAGE=keyvidev/ubuntu-builder      PYTHON_VERSION=3.7.4          CONF=debug
@@ -37,11 +35,10 @@ env:
 
     - BUILD_TYPE=sdist      DOCKER_IMAGE=keyvidev/ubuntu-builder
 
-    - BUILD_TYPE=manylinux  DOCKER_IMAGE=narekgharibyan/manylinux-builder         PYTHON_PATH=cp27-cp27mu
-    - BUILD_TYPE=manylinux  DOCKER_IMAGE=narekgharibyan/manylinux-builder         PYTHON_PATH=cp35-cp35m
-    - BUILD_TYPE=manylinux  DOCKER_IMAGE=narekgharibyan/manylinux-builder         PYTHON_PATH=cp36-cp36m
-    - BUILD_TYPE=manylinux  DOCKER_IMAGE=narekgharibyan/manylinux-builder         PYTHON_PATH=cp37-cp37m
-    - BUILD_TYPE=manylinux  DOCKER_IMAGE=narekgharibyan/manylinux-builder         PYTHON_PATH=cp38-cp38
+    - BUILD_TYPE=manylinux  DOCKER_IMAGE=keyvidev/manylinux-builder         PYTHON_PATH=cp35-cp35m
+    - BUILD_TYPE=manylinux  DOCKER_IMAGE=keyvidev/manylinux-builder         PYTHON_PATH=cp36-cp36m
+    - BUILD_TYPE=manylinux  DOCKER_IMAGE=keyvidev/manylinux-builder         PYTHON_PATH=cp37-cp37m
+    - BUILD_TYPE=manylinux  DOCKER_IMAGE=keyvidev/manylinux-builder         PYTHON_PATH=cp38-cp38
 
     #- BUILD_TYPE=rust       DOCKER_IMAGE=keyvidev/ubuntu-builder
 
@@ -56,10 +53,6 @@ env:
 
 matrix:
   include:
-    - os: osx
-      osx_image: xcode9.4
-      compiler: clang
-      env: BUILD_TYPE=osx PYTHON_VERSION=2.7.16
     - os: osx
       osx_image: xcode9.4
       compiler: clang

--- a/docker/manylinux-builder/Dockerfile
+++ b/docker/manylinux-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux1_x86_64
+FROM quay.io/pypa/manylinux2014_x86_64
 
 RUN yum -y update; yum clean all
 
@@ -6,8 +6,6 @@ RUN yum -y install  bzip2-devel \
                     snappy-devel \
                     python-devel && \
                     yum clean all
-
-RUN yum remove cmake28 -y
 
 ENV ZLIB_MAJOR=1 ZLIB_MINOR=2 ZLIB_PATCH=11
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -354,7 +354,6 @@ with symlink_keyvi() as (pykeyvi_source_path, keyvi_source_path):
             'Programming Language :: C++',
             'Programming Language :: Cython',
             'Programming Language :: Python',
-            'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
 - updated manylinux base image to `quay.io/pypa/manylinux2014_x86_64`, more info here: https://www.python.org/dev/peps/pep-0599/
 - dropped python 2.7 support 
 
