### PR TITLE
update examples to python 3

### DIFF
--- a/doc/usage/Building keyvi dictionaries with python.md
+++ b/doc/usage/Building keyvi dictionaries with python.md
@@ -10,7 +10,7 @@ The compiler is also available from python keyvi:
     
     # finally compile
     compiler.Compile()
-    compiler.WriteToFile("/tmp/test.keyvi")
+    compiler.WriteToFile("/tmp/test.kv")
 
 Other available Compiler in `keyvi.compiler`
 

--- a/doc/usage/Building keyvi dictionaries.md
+++ b/doc/usage/Building keyvi dictionaries.md
@@ -21,7 +21,7 @@ keyvicompiler shall be available now:
 
 To compile simply run for example:
 
-    keyvicompiler -i test.txt -o test.keyvi
+    keyvicompiler -i test.txt -o test.kv
 
 
 #### The different formats
@@ -47,4 +47,4 @@ keyvi dictionary compiler needs more memory to persist the data.
 
 You can use keyviinspector to dump the data:
 
-    keyviinspector -i test.keyvi -o ../test-dump.txt
+    keyviinspector -i test.kv -o ../test-dump.txt

--- a/doc/usage/Crashcourse.md
+++ b/doc/usage/Crashcourse.md
@@ -38,6 +38,8 @@ Check questions:
  
 #### Open the file in python
 
+All python examples assume python 3.
+
 Do:
 
     from keyvi.dictionary import Dictionary
@@ -102,7 +104,7 @@ Go to [lookup examples](/python/examples/lookup)
 
 Compile cities.tsv and run the tester:
     
-    keyvicompiler -i cities.tsv -o cities.keyvi -d key-only
+    keyvicompiler -i cities.tsv -o cities.kv -d key-only
     python text_lookup_tester.py
 
 Try queries like: "Fahrradwerkstatt München", "Berlin Alexanderplatz", "San Francisco Coffee Bar"
@@ -118,7 +120,7 @@ Try python/scripts/compile_json.py and compile your own JSON. The format should 
 Check statistics:
 
 
-     keyviinspector -i your-own.keyvi -s
+     keyviinspector -i your-own.kv -s
 
 
 Check questions:
@@ -128,7 +130,7 @@ Check questions:
      
 With sharding (for distributed data indexes):
 
-     compile_json.py -i your-input -o your-keyvi.keyvi -s 3
+     compile_json.py -i your-input -o your-keyvi.kv -s 3
 
 ### Completion
 
@@ -141,14 +143,14 @@ Have a look at the files completion-nw.tsv, completion.tsv it basically contains
 
 Compile and try:
 
-    keyvicompiler -i completion-nw.tsv -o prefix-completion.keyvi 
+    keyvicompiler -i completion-nw.tsv -o prefix-completion.kv
     python prefix_completion_tester.py
 
 Query: '80s'
  
 Now try:    
 
-    keyvicompiler -i completion.tsv -o prefix-completion.keyvi
+    keyvicompiler -i completion.tsv -o prefix-completion.kv
     python prefix_completion_tester.py
 
 Check questions:
@@ -189,7 +191,7 @@ Go to [normalization examples](/python/examples/normalization)
 
 Compile with:
 
-    keyvicompiler -i normalization.tsv -o normalization.keyvi -d string
+    keyvicompiler -i normalization.tsv -o normalization.kv -d string
     
 and try:
 

--- a/python/examples/completion/multiword_completion_tester.py
+++ b/python/examples/completion/multiword_completion_tester.py
@@ -5,7 +5,7 @@ MULTIWORD_QUERY_SEPARATOR = '\x1b'
 
 query = ""
 
-d=Dictionary("mw-completion.keyvi")
+d=Dictionary("mw-completion.kv")
 c=MultiWordCompletion(d)
 
 def get_lookup_key(query):
@@ -16,6 +16,6 @@ def get_lookup_key(query):
 
 
 while query!="exit":
-    query = raw_input("Query:")
+    query = str(input("Query:"))
     for m in c.GetCompletions(get_lookup_key(query.strip())):
         print("{} {}".format(m.GetMatchedString(), m.GetAttribute("weight")))

--- a/python/examples/completion/multiword_completion_writer.py
+++ b/python/examples/completion/multiword_completion_writer.py
@@ -19,6 +19,7 @@ We do not require "messenger facebook deu" (1 0 3) due to the BOW reordering at 
 """
 
 import sys
+from functools import reduce
 from keyvi.compiler import CompletionDictionaryCompiler
 
 # permutation lookup table, number_of_tokens - > permutations_to_build
@@ -87,7 +88,7 @@ class MultiWordPermutation:
         query_tokens = query.split(" ")
         query_tokens_bow = sorted(query_tokens)
         length = len(query_tokens_bow)
-        if not PERMUTATION_LOOKUP_TABLE.has_key(length):
+        if length not in PERMUTATION_LOOKUP_TABLE:
             yield query
             return
 
@@ -111,4 +112,4 @@ if __name__ == '__main__':
         for q in reduce(lambda x, y: y(x), pipeline, key):
             c.Add(q, int(weight))
     c.Compile()
-    c.WriteToFile("mw-completion.keyvi")
+    c.WriteToFile("mw-completion.kv")

--- a/python/examples/completion/prefix_completion_fuzzy_tester.py
+++ b/python/examples/completion/prefix_completion_fuzzy_tester.py
@@ -3,13 +3,13 @@ from keyvi.completion import PrefixCompletion
 
 query = ""
 
-d=Dictionary("prefix-completion.keyvi")
+d=Dictionary("prefix-completion.kv")
 c=PrefixCompletion(d)
 
 def get_lookup_key(query):
     return query
 
 while query!="exit":
-    query = raw_input("Query:")
+    query = str(input("Query:"))
     for m in c.GetFuzzyCompletions(get_lookup_key(query.strip()), 3):
         print("{} {}".format(m.GetMatchedString(), m.GetAttribute("weight")))

--- a/python/examples/completion/prefix_completion_tester.py
+++ b/python/examples/completion/prefix_completion_tester.py
@@ -3,13 +3,13 @@ from keyvi.completion import PrefixCompletion
 
 query = ""
 
-d=Dictionary("prefix-completion.keyvi")
+d=Dictionary("prefix-completion.kv")
 c=PrefixCompletion(d)
 
 def get_lookup_key(query):
     return query
 
 while query!="exit":
-    query = raw_input("Query:")
+    query = str(input("Query:"))
     for m in c.GetCompletions(get_lookup_key(query.strip())):
         print("{} ({})".format(m.GetMatchedString(), m.GetAttribute("weight")))

--- a/python/examples/lookup/text_lookup_tester.py
+++ b/python/examples/lookup/text_lookup_tester.py
@@ -2,7 +2,7 @@ from keyvi.dictionary import Dictionary
 
 query = ""
 
-d=Dictionary("cities.keyvi")
+d=Dictionary("cities.kv")
 
 def get_lookup_key(query):
     return query

--- a/python/examples/lookup/value_lookup_tester.py
+++ b/python/examples/lookup/value_lookup_tester.py
@@ -2,7 +2,7 @@ from keyvi.dictionary import Dictionary
 
 query = ""
 
-d=Dictionary("your-own.keyvi")
+d=Dictionary("your-own.kv")
 
 def get_lookup_key(query):
     return query

--- a/python/examples/normalization/normalize.py
+++ b/python/examples/normalization/normalize.py
@@ -2,7 +2,7 @@ import sys
 from keyvi.dictionary import Dictionary
 from keyvi.util import FsaTransform
 
-d=Dictionary("normalization.keyvi")
+d=Dictionary("normalization.kv")
 n=FsaTransform(d)
 
 


### PR DESCRIPTION
rewrite examples python 3, use .kv instead of .keyvi as file suffix