### PR TITLE
cargo fmt

### DIFF
--- a/rust/build.rs
+++ b/rust/build.rs
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 /*
  *  build.rs
  *
@@ -25,29 +24,31 @@
  *          Subu <subu@cliqz.com>
  */
 
-
 extern crate bindgen;
 extern crate cmake;
 
 use std::env;
 use std::path::PathBuf;
+
 use cmake::Config;
 
 fn main() {
-    let dst = Config::new("keyvi_core/")
-        .build_target("keyvi_c")
-        .build();
+    let dst = Config::new("keyvi_core/").build_target("keyvi_c").build();
 
     // Tell cargo to tell rustc to link keyvi
     println!("cargo:rustc-link-lib=dylib=keyvi_c");
-    println!("cargo:rustc-link-search=native={}", dst.join("build").display());
+    println!(
+        "cargo:rustc-link-search=native={}",
+        dst.join("build").display()
+    );
 
     println!("Starting to generate bindings..");
 
     let bindings = bindgen::Builder::default()
         // The input header we would like to generate bindings for.
         .header("keyvi_core/keyvi/include/keyvi/c_api/c_api.h")
-        .clang_arg("-x").clang_arg("c++")
+        .clang_arg("-x")
+        .clang_arg("c++")
         .enable_cxx_namespaces()
         .layout_tests(true)
         // Finish the builder and generate the bindings.

--- a/rust/src/dictionary.rs
+++ b/rust/src/dictionary.rs
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 /*
  *  dictionary.rs
  *
@@ -25,12 +24,12 @@
  *          Subu <subu@cliqz.com>
  */
 
-
 use std::ffi::CString;
-use keyvi_string::KeyviString;
+
+use bindings::*;
 use keyvi_match::KeyviMatch;
 use keyvi_match_iterator::KeyviMatchIterator;
-use bindings::*;
+use keyvi_string::KeyviString;
 
 pub struct Dictionary {
     dict: *mut root::keyvi_dictionary,
@@ -52,7 +51,8 @@ impl Dictionary {
     }
 
     pub fn statistics(&self) -> String {
-        let c_buf: *mut ::std::os::raw::c_char = unsafe { root::keyvi_dictionary_get_statistics(self.dict) };
+        let c_buf: *mut ::std::os::raw::c_char =
+            unsafe { root::keyvi_dictionary_get_statistics(self.dict) };
         KeyviString::new(c_buf).to_owned()
     }
 

--- a/rust/src/keyvi_match.rs
+++ b/rust/src/keyvi_match.rs
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 /*
  *  keyvi_match.rs
  *
@@ -27,10 +26,10 @@
 
 use std::slice;
 
-use keyvi_string::KeyviString;
-use bindings::*;
-
 use serde_json;
+
+use bindings::*;
+use keyvi_string::KeyviString;
 
 pub struct KeyviMatch {
     match_ptr_: *mut root::keyvi_match,
@@ -38,7 +37,9 @@ pub struct KeyviMatch {
 
 impl KeyviMatch {
     pub fn new(match_ptr: *mut root::keyvi_match) -> KeyviMatch {
-        KeyviMatch { match_ptr_: match_ptr }
+        KeyviMatch {
+            match_ptr_: match_ptr,
+        }
     }
 
     pub fn get_value(&self) -> serde_json::Value {

--- a/rust/src/keyvi_match_iterator.rs
+++ b/rust/src/keyvi_match_iterator.rs
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 /*
  *  keyvi_match_iterator.rs
  *
@@ -24,7 +23,6 @@
  *  Author: Narek Gharibyan <narekgharibyan@gmail.com>
  *          Subu <subu@cliqz.com>
  */
-
 
 use bindings::*;
 use keyvi_match::KeyviMatch;
@@ -47,7 +45,9 @@ impl Iterator for KeyviMatchIterator {
         if empty {
             return None;
         } else {
-            let ret = Some(KeyviMatch::new(unsafe { root::keyvi_match_iterator_dereference(self.ptr_) }));
+            let ret = Some(KeyviMatch::new(unsafe {
+                root::keyvi_match_iterator_dereference(self.ptr_)
+            }));
             unsafe { root::keyvi_match_iterator_increment(self.ptr_) };
             return ret;
         }

--- a/rust/src/keyvi_string.rs
+++ b/rust/src/keyvi_string.rs
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 /*
  *  keyvi_string.rs
  *
@@ -25,11 +24,10 @@
  *          Subu <subu@cliqz.com>
  */
 
-
 use std::ffi::CStr;
 use std::ops::Deref;
-use bindings::*;
 
+use bindings::*;
 
 pub struct KeyviString {
     str_: *mut ::std::os::raw::c_char,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 /*
  * lib.rs
  *
@@ -25,7 +24,6 @@
  *          Subu <subu@cliqz.com>
  */
 
-
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
@@ -33,9 +31,8 @@
 
 extern crate serde_json;
 
-
+mod bindings;
 pub mod dictionary;
-pub mod keyvi_string;
 pub mod keyvi_match;
 pub mod keyvi_match_iterator;
-mod bindings;
+pub mod keyvi_string;

--- a/rust/tests/tests.rs
+++ b/rust/tests/tests.rs
@@ -1,16 +1,17 @@
-extern crate serde_json;
-extern crate rayon;
 extern crate rand;
-extern crate keyvi;
+extern crate rayon;
+extern crate serde_json;
 
+extern crate keyvi;
 
 #[cfg(test)]
 mod tests {
-    use keyvi::dictionary;
-    use serde_json::Value;
     use rand;
     use rand::Rng;
     use rayon::prelude::*;
+    use serde_json::Value;
+
+    use keyvi::dictionary;
 
     #[test]
     fn dictionary_error() {
@@ -26,16 +27,20 @@ mod tests {
 
     #[test]
     fn match_string() {
-        let m = dictionary::Dictionary::new("test_data/test.kv").unwrap().get("a");
+        let m = dictionary::Dictionary::new("test_data/test.kv")
+            .unwrap()
+            .get("a");
         assert_eq!(m.matched_string(), "a");
     }
 
     #[test]
     fn match_value_int() {
-        let m = dictionary::Dictionary::new("test_data/completion_test.kv").unwrap().get("mozilla footprint");
+        let m = dictionary::Dictionary::new("test_data/completion_test.kv")
+            .unwrap()
+            .get("mozilla footprint");
         match m.get_value() {
             Value::Number(n) => assert_eq!(n.as_i64().unwrap(), 30),
-            _ => assert!(false)
+            _ => assert!(false),
         }
     }
 
@@ -49,10 +54,12 @@ mod tests {
 
     #[test]
     fn match_value_array() {
-        let m = dictionary::Dictionary::new("test_data/test.kv").unwrap().get("a");
+        let m = dictionary::Dictionary::new("test_data/test.kv")
+            .unwrap()
+            .get("a");
         match m.get_value() {
             Value::Array(n) => assert_eq!(n, vec![12, 13]),
-            _ => assert!(false)
+            _ => assert!(false),
         }
     }
 
@@ -74,25 +81,33 @@ mod tests {
 
     #[test]
     fn match_value() {
-        let m = dictionary::Dictionary::new("test_data/test.kv").unwrap().get("a");
+        let m = dictionary::Dictionary::new("test_data/test.kv")
+            .unwrap()
+            .get("a");
         assert_eq!(m.get_value_as_string(), "[12,13]");
     }
 
     #[test]
     fn match_is_empty() {
-        let m = dictionary::Dictionary::new("test_data/test.kv").unwrap().get("a");
+        let m = dictionary::Dictionary::new("test_data/test.kv")
+            .unwrap()
+            .get("a");
         assert_eq!(m.is_empty(), false);
     }
 
     #[test]
     fn match_iterator_count() {
-        let mit = dictionary::Dictionary::new("test_data/test.kv").unwrap().get_prefix_completions("a", 10);
+        let mit = dictionary::Dictionary::new("test_data/test.kv")
+            .unwrap()
+            .get_prefix_completions("a", 10);
         assert_eq!(mit.count(), 1);
     }
 
     #[test]
     fn match_iterator_values() {
-        let mit = dictionary::Dictionary::new("test_data/test.kv").unwrap().get_prefix_completions("a", 10);
+        let mit = dictionary::Dictionary::new("test_data/test.kv")
+            .unwrap()
+            .get_prefix_completions("a", 10);
         for m in mit {
             assert_eq!(m.matched_string(), "a");
             assert_eq!(m.get_value_as_string(), "[12,13]");
@@ -101,13 +116,16 @@ mod tests {
 
     #[test]
     fn match_iterator_into() {
-        for m in dictionary::Dictionary::new("test_data/test.kv").unwrap().get_prefix_completions("a", 10) {
+        for m in dictionary::Dictionary::new("test_data/test.kv")
+            .unwrap()
+            .get_prefix_completions("a", 10)
+        {
             let (k, v) = m.into();
             assert_eq!(k, "a");
 
             match v {
                 Value::Array(n) => assert_eq!(n, vec![12, 13]),
-                _ => assert!(false)
+                _ => assert!(false),
             }
         }
     }
@@ -118,13 +136,20 @@ mod tests {
             ("80", "mozilla firefox"),
             ("43", "mozilla fans"),
             ("30", "mozilla footprint"),
-            ("12", "mozilla firebird")
+            ("12", "mozilla firebird"),
         ];
         values.sort();
-        let new_values: Vec<(String, String)> = values.into_iter().map(|(x, y)| (x.into(), y.into())).collect();
+        let new_values: Vec<(String, String)> = values
+            .into_iter()
+            .map(|(x, y)| (x.into(), y.into()))
+            .collect();
 
-        let mit = dictionary::Dictionary::new("test_data/completion_test.kv").unwrap().get_multi_word_completions("mozilla f", 10);
-        let mut a: Vec<(String, String)> = mit.map(|m| (m.get_value_as_string(), m.matched_string())).collect();
+        let mit = dictionary::Dictionary::new("test_data/completion_test.kv")
+            .unwrap()
+            .get_multi_word_completions("mozilla f", 10);
+        let mut a: Vec<(String, String)> = mit
+            .map(|m| (m.get_value_as_string(), m.matched_string()))
+            .collect();
         a.sort();
 
         assert_eq!(new_values, a);
@@ -132,14 +157,19 @@ mod tests {
 
     #[test]
     fn multi_word_completions_cutoff() {
-        let mut values = vec![
-            ("80", "mozilla firefox"),
-        ];
+        let mut values = vec![("80", "mozilla firefox")];
         values.sort();
-        let new_values: Vec<(String, String)> = values.into_iter().map(|(x, y)| (x.into(), y.into())).collect();
+        let new_values: Vec<(String, String)> = values
+            .into_iter()
+            .map(|(x, y)| (x.into(), y.into()))
+            .collect();
 
-        let mit = dictionary::Dictionary::new("test_data/completion_test.kv").unwrap().get_multi_word_completions("mozilla f", 1);
-        let mut a: Vec<(String, String)> = mit.map(|m| (m.get_value_as_string(), m.matched_string())).collect();
+        let mit = dictionary::Dictionary::new("test_data/completion_test.kv")
+            .unwrap()
+            .get_multi_word_completions("mozilla f", 1);
+        let mut a: Vec<(String, String)> = mit
+            .map(|m| (m.get_value_as_string(), m.matched_string()))
+            .collect();
         a.sort();
 
         assert_eq!(new_values, a);
@@ -147,15 +177,19 @@ mod tests {
 
     #[test]
     fn fuzzy_completions() {
-        let mut values = vec![
-            ("22", "aabc"),
-            ("55", "aabcül")
-        ];
+        let mut values = vec![("22", "aabc"), ("55", "aabcül")];
         values.sort();
-        let new_values: Vec<(String, String)> = values.into_iter().map(|(x, y)| (x.into(), y.into())).collect();
+        let new_values: Vec<(String, String)> = values
+            .into_iter()
+            .map(|(x, y)| (x.into(), y.into()))
+            .collect();
 
-        let mit = dictionary::Dictionary::new("test_data/fuzzy.kv").unwrap().get_fuzzy("aafcül", 3);
-        let mut a: Vec<(String, String)> = mit.map(|m| (m.get_value_as_string(), m.matched_string())).collect();
+        let mit = dictionary::Dictionary::new("test_data/fuzzy.kv")
+            .unwrap()
+            .get_fuzzy("aafcül", 3);
+        let mut a: Vec<(String, String)> = mit
+            .map(|m| (m.get_value_as_string(), m.matched_string()))
+            .collect();
         a.sort();
 
         assert_eq!(new_values, a);
@@ -167,13 +201,20 @@ mod tests {
             ("10188", "tüv in"),
             ("331", "tüv i"),
             ("45901", "tüv süd"),
-            ("46052", "tüv nord")
+            ("46052", "tüv nord"),
         ];
         values.sort();
-        let new_values: Vec<(String, String)> = values.into_iter().map(|(x, y)| (x.into(), y.into())).collect();
+        let new_values: Vec<(String, String)> = values
+            .into_iter()
+            .map(|(x, y)| (x.into(), y.into()))
+            .collect();
 
-        let mit = dictionary::Dictionary::new("test_data/fuzzy_non_ascii.kv").unwrap().get_fuzzy("tüc", 6);
-        let mut a: Vec<(String, String)> = mit.map(|m| (m.get_value_as_string(), m.matched_string())).collect();
+        let mit = dictionary::Dictionary::new("test_data/fuzzy_non_ascii.kv")
+            .unwrap()
+            .get_fuzzy("tüc", 6);
+        let mut a: Vec<(String, String)> = mit
+            .map(|m| (m.get_value_as_string(), m.matched_string()))
+            .collect();
         a.sort();
 
         assert_eq!(new_values, a);
@@ -181,19 +222,28 @@ mod tests {
 
     #[test]
     fn fuzzy_completions_with_score() {
-        let mut values = vec![
-            ("22", "aabc", "3.0"),
-            ("55", "aabcül", "1.0")
-        ];
+        let mut values = vec![("22", "aabc", "3.0"), ("55", "aabcül", "1.0")];
         values.sort();
-        let new_values: Vec<(String, String, String)> = values.into_iter().map(|(x, y, z)| (x.into(), y.into(), z.into())).collect();
+        let new_values: Vec<(String, String, String)> = values
+            .into_iter()
+            .map(|(x, y, z)| (x.into(), y.into(), z.into()))
+            .collect();
 
-        let mit = dictionary::Dictionary::new("test_data/fuzzy.kv").unwrap().get_fuzzy("aafcül", 3);
-        let mut a: Vec<(String, String, String)> = mit.map(|m| (m.get_value_as_string(), m.matched_string(), format!("{:.*}", 1, m.get_score()))).collect();
+        let mit = dictionary::Dictionary::new("test_data/fuzzy.kv")
+            .unwrap()
+            .get_fuzzy("aafcül", 3);
+        let mut a: Vec<(String, String, String)> = mit
+            .map(|m| {
+                (
+                    m.get_value_as_string(),
+                    m.matched_string(),
+                    format!("{:.*}", 1, m.get_score()),
+                )
+            })
+            .collect();
         a.sort();
         assert_eq!(new_values, a);
     }
-
 
     #[test]
     fn dictionary_parallel_test() {
@@ -206,8 +256,14 @@ mod tests {
 
         let dictionary = dictionary::Dictionary::new("test_data/test.kv").unwrap();
 
-        let sequential_values: Vec<Value> = keys.iter().map(|key| dictionary.get(key).get_value()).collect();
-        let parallel_values: Vec<Value> = keys.par_iter().map(|key| dictionary.get(key).get_value()).collect();
+        let sequential_values: Vec<Value> = keys
+            .iter()
+            .map(|key| dictionary.get(key).get_value())
+            .collect();
+        let parallel_values: Vec<Value> = keys
+            .par_iter()
+            .map(|key| dictionary.get(key).get_value())
+            .collect();
 
         assert_eq!(sequential_values, parallel_values);
     }


### PR DESCRIPTION
run `cargo fmt` to format our rust code base, to have consistent style
