### PR TITLE
Bump ubuntu version

### DIFF
--- a/docker/ubuntu-builder/Dockerfile
+++ b/docker/ubuntu-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 # install packages required by pyenv
 RUN set -ex \


### PR DESCRIPTION
This should fix failing Rust builds, the error [here](https://travis-ci.com/github/KeyviDev/keyvi/jobs/419682200) says: 
```
thread 'main' panicked at '`libclang` function not loaded: `clang_Cursor_isFunctionInlined`. This crate requires that `libclang` 3.9 or later be installed on your system.
```
Clang coming with `apt` on `ubuntu 16.04` has version `3.8`. On `ubuntu 20.04` version is `10`
```
root@47e6ed3ca889:/# clang --version
clang version 10.0.0-4ubuntu1 
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin

```