### PR TITLE
disable python coverage for debugging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
 
     - BUILD_TYPE=rust       DOCKER_IMAGE=keyvidev/ubuntu-builder
 
-    - BUILD_TYPE=coverage   DOCKER_IMAGE=keyvidev/ubuntu-builder:coverage.16.04
+    - BUILD_TYPE=coverage   DOCKER_IMAGE=keyvidev/ubuntu-builder
 
     - BUILD_TYPE=doc        DOCKER_IMAGE=keyvidev/ubuntu-builder
 

--- a/travis/coverage.sh
+++ b/travis/coverage.sh
@@ -11,13 +11,13 @@ travis/build_python.sh
 
 pip install coveralls-merge cpp-coveralls --upgrade
 
-coveralls   -r . -b build/ -i keyvi \
-            --gcov-options '\-lp' \
-            -E '.*/keyvi/3rdparty/.*' \
-            -e python \
-            -E '.*/keyvi/tests/.*' \
-            -E '.*/keyvi/bin/.*' \
-            --dump keyvi.cov_report > /dev/null
+#coveralls   -r . -b build/ -i keyvi \
+#            --gcov-options '\-lp' \
+#            -E '.*/keyvi/3rdparty/.*' \
+#            -e python \
+#            -E '.*/keyvi/tests/.*' \
+#            -E '.*/keyvi/bin/.*' \
+#            --dump keyvi.cov_report > /dev/null
 
 # workaround for coverage measurement: symlink keyvi
 cd python/

--- a/travis/coverage.sh
+++ b/travis/coverage.sh
@@ -30,10 +30,10 @@ coveralls   -r . -b python/ -i python \
             -E '.*/src/cpp/build-.*/.*' \
             -E '.*/autowrap_includes/autowrap_tools.hpp' \
             -E '.*/src/extra/attributes_converter.h' \
-            -E '.*/_core.cpp' \
-            --dump python.cov_report_tmp > /dev/null
+            -E '.*/_core.cpp'
+ #           --dump python.cov_report_tmp > /dev/null
 
 # workaround: remove 'python' from source path before merge
-sed s/"python\/src\/cpp\/keyvi"/"keyvi"/g python.cov_report_tmp > python.cov_report
+#sed s/"python\/src\/cpp\/keyvi"/"keyvi"/g python.cov_report_tmp > python.cov_report
 
-coveralls-merge python.cov_report
+#coveralls-merge python.cov_report

--- a/travis/coverage.sh
+++ b/travis/coverage.sh
@@ -24,16 +24,18 @@ cd python/
 ln -s ../../../keyvi src/cpp/keyvi
 cd ..
 
-coveralls   -r . -b python/ -i python \
-            --gcov-options '\-lp' \
-            -e python/src/cpp/keyvi/3rdparty \
-            -E '.*/src/cpp/build-.*/.*' \
-            -E '.*/autowrap_includes/autowrap_tools.hpp' \
-            -E '.*/src/extra/attributes_converter.h' \
-            -E '.*/_core.cpp' \
-            --dump python.cov_report_tmp > /dev/null
+#coveralls   -r . -b python/ -i python \
+#            --gcov-options '\-lp' \
+#            -e python/src/cpp/keyvi/3rdparty \
+#            -E '.*/src/cpp/build-.*/.*' \
+#            -E '.*/autowrap_includes/autowrap_tools.hpp' \
+#            -E '.*/src/extra/attributes_converter.h' \
+#            -E '.*/_core.cpp' \
+#            --dump python.cov_report_tmp > /dev/null
 
 # workaround: remove 'python' from source path before merge
-sed s/"python\/src\/cpp\/keyvi"/"keyvi"/g python.cov_report_tmp > python.cov_report
+#sed s/"python\/src\/cpp\/keyvi"/"keyvi"/g python.cov_report_tmp > python.cov_report
 
-coveralls-merge keyvi.cov_report python.cov_report
+coveralls-merge keyvi.cov_report 
+
+#python.cov_report

--- a/travis/coverage.sh
+++ b/travis/coverage.sh
@@ -31,9 +31,10 @@ coveralls   -r . -b python/ -i python \
             -E '.*/autowrap_includes/autowrap_tools.hpp' \
             -E '.*/src/extra/attributes_converter.h' \
             -E '.*/_core.cpp'
- #           --dump python.cov_report_tmp > /dev/null
+            -e build
+            --dump python.cov_report_tmp > /dev/null
 
 # workaround: remove 'python' from source path before merge
-#sed s/"python\/src\/cpp\/keyvi"/"keyvi"/g python.cov_report_tmp > python.cov_report
+sed s/"python\/src\/cpp\/keyvi"/"keyvi"/g python.cov_report_tmp > python.cov_report
 
-#coveralls-merge python.cov_report
+coveralls-merge python.cov_report

--- a/travis/coverage.sh
+++ b/travis/coverage.sh
@@ -24,18 +24,16 @@ cd python/
 ln -s ../../../keyvi src/cpp/keyvi
 cd ..
 
-#coveralls   -r . -b python/ -i python \
-#            --gcov-options '\-lp' \
-#            -e python/src/cpp/keyvi/3rdparty \
-#            -E '.*/src/cpp/build-.*/.*' \
-#            -E '.*/autowrap_includes/autowrap_tools.hpp' \
-#            -E '.*/src/extra/attributes_converter.h' \
-#            -E '.*/_core.cpp' \
-#            --dump python.cov_report_tmp > /dev/null
+coveralls   -r . -b python/ -i python \
+            --gcov-options '\-lp' \
+            -e python/src/cpp/keyvi/3rdparty \
+            -E '.*/src/cpp/build-.*/.*' \
+            -E '.*/autowrap_includes/autowrap_tools.hpp' \
+            -E '.*/src/extra/attributes_converter.h' \
+            -E '.*/_core.cpp' \
+            --dump python.cov_report_tmp > /dev/null
 
 # workaround: remove 'python' from source path before merge
-#sed s/"python\/src\/cpp\/keyvi"/"keyvi"/g python.cov_report_tmp > python.cov_report
+sed s/"python\/src\/cpp\/keyvi"/"keyvi"/g python.cov_report_tmp > python.cov_report
 
-coveralls-merge keyvi.cov_report 
-
-#python.cov_report
+coveralls-merge python.cov_report


### PR DESCRIPTION
coverage reporting is broken after upgrading the docker image(or upgrade of coveralls done as side-effect), just trying to find out why