### PR TITLE
Use ubuntu 16.04 for coverage build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
 
     - BUILD_TYPE=rust       DOCKER_IMAGE=keyvidev/ubuntu-builder
 
-    - BUILD_TYPE=coverage   DOCKER_IMAGE=keyvidev/ubuntu-builder
+    - BUILD_TYPE=coverage   DOCKER_IMAGE=keyvidev/ubuntu-builder:coverage.16.04
 
     - BUILD_TYPE=doc        DOCKER_IMAGE=keyvidev/ubuntu-builder
 


### PR DESCRIPTION
Image with new `ubuntu:20.04` doesn't produce consistent coverage report. we need to investigate that separately, but no need to block current PRs. so we can use `ubuntu:16.04` base image temporarily. 