### PR TITLE
enable builds for all branches

### DIFF
--- a/.github/workflows/keyvi.yml
+++ b/.github/workflows/keyvi.yml
@@ -6,7 +6,6 @@ name: Build keyvi
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,7 +5,6 @@ name: Build python bindings
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -6,7 +6,6 @@ name: check style
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
Tested this on my fork, it enables builds on all branches. Which is especially handy for development. 