### PR TITLE
add ZipStateTraverser

### DIFF
--- a/keyvi/include/keyvi/dictionary/dictionary.h
+++ b/keyvi/include/keyvi/dictionary/dictionary.h
@@ -386,7 +386,7 @@ class Dictionary final {
 
   MatchIterator::MatchIteratorPair GetFuzzy(const std::string& query, size_t max_edit_distance) const {
     auto data = std::make_shared<matching::FuzzyMatching<>>(
-        matching::FuzzyMatching<>::FromSingleDictionary(fsa_, query, max_edit_distance));
+        matching::FuzzyMatching<>::FromSingleFsa(fsa_, query, max_edit_distance));
 
     auto func = [data]() { return data->NextMatch(); };
     return MatchIterator::MakeIteratorPair(func, data->FirstMatch());

--- a/keyvi/include/keyvi/dictionary/dictionary.h
+++ b/keyvi/include/keyvi/dictionary/dictionary.h
@@ -385,7 +385,9 @@ class Dictionary final {
   }
 
   MatchIterator::MatchIteratorPair GetFuzzy(const std::string& query, size_t max_edit_distance) const {
-    auto data = std::make_shared<matching::FuzzyMatching>(fsa_, query, max_edit_distance);
+    auto data = std::make_shared<matching::FuzzyMatching<>>(
+        matching::FuzzyMatching<>::FromSingleDictionary(fsa_, query, max_edit_distance));
+
     auto func = [data]() { return data->NextMatch(); };
     return MatchIterator::MakeIteratorPair(func, data->FirstMatch());
   }

--- a/keyvi/include/keyvi/dictionary/fsa/codepoint_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/codepoint_state_traverser.h
@@ -51,8 +51,7 @@ class CodePointStateTraverser final {
     this->operator++(0);
   }
 
-  explicit CodePointStateTraverser(innerTraverserType&& traverser)
-      : wrapped_state_traverser_(std::move(traverser)) {
+  explicit CodePointStateTraverser(innerTraverserType&& traverser) : wrapped_state_traverser_(std::move(traverser)) {
     this->operator++(0);
   }
 

--- a/keyvi/include/keyvi/dictionary/fsa/codepoint_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/codepoint_state_traverser.h
@@ -51,6 +51,11 @@ class CodePointStateTraverser final {
     this->operator++(0);
   }
 
+  explicit CodePointStateTraverser(const innerTraverserType&& traverser)
+      : wrapped_state_traverser_(std::move(traverser)) {
+    this->operator++(0);
+  }
+
   CodePointStateTraverser() = delete;
   CodePointStateTraverser& operator=(CodePointStateTraverser const&) = delete;
   CodePointStateTraverser(const CodePointStateTraverser& that) = delete;

--- a/keyvi/include/keyvi/dictionary/fsa/codepoint_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/codepoint_state_traverser.h
@@ -51,7 +51,7 @@ class CodePointStateTraverser final {
     this->operator++(0);
   }
 
-  explicit CodePointStateTraverser(const innerTraverserType&& traverser)
+  explicit CodePointStateTraverser(innerTraverserType&& traverser)
       : wrapped_state_traverser_(std::move(traverser)) {
     this->operator++(0);
   }

--- a/keyvi/include/keyvi/dictionary/fsa/codepoint_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/codepoint_state_traverser.h
@@ -41,6 +41,8 @@ namespace fsa {
 template <class innerTraverserType>
 class CodePointStateTraverser final {
  public:
+  using label_t = int;
+
   explicit CodePointStateTraverser(automata_t f) : wrapped_state_traverser_(f, f->GetStartState(), false) {
     this->operator++(0);
   }
@@ -67,7 +69,7 @@ class CodePointStateTraverser final {
     int remaining_bytes = 0;
     do {
       wrapped_state_traverser_++;
-      int label = wrapped_state_traverser_.GetStateLabel();
+      label_t label = wrapped_state_traverser_.GetStateLabel();
 
       TRACE("CP traverser: wrapped traverser %x %d", label, wrapped_state_traverser_.GetDepth());
 
@@ -120,7 +122,7 @@ class CodePointStateTraverser final {
     PruneHistory(wrapped_state_traverser_.GetDepth());
   }
 
-  int GetStateLabel() { return codepoint_; }
+  label_t GetStateLabel() { return codepoint_; }
 
   operator bool() const { return wrapped_state_traverser_; }
 
@@ -128,7 +130,7 @@ class CodePointStateTraverser final {
   innerTraverserType wrapped_state_traverser_;
   std::vector<int> transitions_stack_;
   std::vector<int> utf8_length_stack_;
-  int codepoint_ = 0;
+  label_t codepoint_ = 0;
   size_t current_depth_ = 0;
 
   void PruneHistory(size_t new_history_top) {

--- a/keyvi/include/keyvi/dictionary/fsa/comparable_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/comparable_state_traverser.h
@@ -59,12 +59,15 @@ class ComparableStateTraverser final {
     }
   }
 
-  explicit ComparableStateTraverser(const automata_t f, bool advance = true, size_t order = 0)
-      : state_traverser_(f, f->GetStartState(), false), order_(order) {
+  explicit ComparableStateTraverser(const automata_t f, uint64_t start_state, bool advance = true, size_t order = 0)
+      : state_traverser_(f, start_state, false), order_(order) {
     if (advance) {
       this->operator++(0);
     }
   }
+
+  explicit ComparableStateTraverser(const automata_t f, bool advance = true, size_t order = 0)
+      : ComparableStateTraverser(f, f->GetStartState(), advance, order) {}
 
   ComparableStateTraverser() = delete;
   ComparableStateTraverser &operator=(ComparableStateTraverser const &) = delete;
@@ -115,6 +118,8 @@ class ComparableStateTraverser final {
       label_stack_.push_back(state_traverser_.GetStateLabel());
     }
   }
+
+  automata_t GetFsa() const { return state_traverser_.GetFsa(); }
 
   bool IsFinalState() const { return state_traverser_.IsFinalState(); }
 

--- a/keyvi/include/keyvi/dictionary/fsa/comparable_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/comparable_state_traverser.h
@@ -111,6 +111,8 @@ class ComparableStateTraverser final {
 
   operator bool() const { return state_traverser_; }
 
+  bool AtEnd() const { return state_traverser_.AtEnd(); }
+
   void operator++(int) {
     state_traverser_++;
     if (state_traverser_) {

--- a/keyvi/include/keyvi/dictionary/fsa/comparable_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/comparable_state_traverser.h
@@ -1,0 +1,146 @@
+/* * keyvi - A key value store.
+ *
+ * Copyright 2020 Hendrik Muhs<hendrik.muhs@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * comparable_state_traverser.h
+ *
+ *  Created on: Dec 20, 2020
+ *      Author: hendrik
+ */
+
+#ifndef KEYVI_DICTIONARY_FSA_COMPARABLE_STATE_TRAVERSER_H_
+#define KEYVI_DICTIONARY_FSA_COMPARABLE_STATE_TRAVERSER_H_
+
+#include <algorithm>
+#include <cstring>
+#include <utility>
+#include <vector>
+
+#include "keyvi/dictionary/fsa/automata.h"
+
+// #define ENABLE_TRACING
+#include "keyvi/dictionary/util/trace.h"
+
+namespace keyvi {
+namespace dictionary {
+namespace fsa {
+
+/**
+ * Traverser wrapper that can be used to
+ *
+ * - track/record all states
+ * - compare 2 traverser objects based on lexicographic order
+ *
+ * This traverser ignores inner weights, wrapping weighted state traverser for comparison is unspecified
+ */
+template <class innerTraverserType>
+class ComparableStateTraverser final {
+ public:
+  using label_t = typename innerTraverserType::label_t;
+
+  explicit ComparableStateTraverser(const innerTraverserType &&traverser, bool advance = true, size_t order = 0)
+      : state_traverser_(std::move(traverser)), order_(order) {
+    if (advance) {
+      this->operator++(0);
+    }
+  }
+
+  explicit ComparableStateTraverser(const automata_t f, bool advance = true, size_t order = 0)
+      : state_traverser_(f, f->GetStartState(), false), order_(order) {
+    if (advance) {
+      this->operator++(0);
+    }
+  }
+
+  ComparableStateTraverser() = delete;
+  ComparableStateTraverser &operator=(ComparableStateTraverser const &) = delete;
+  ComparableStateTraverser(const ComparableStateTraverser &that) = delete;
+
+  /**
+   * Comparison of the state traverser for the purpose of ordering them
+   */
+  bool operator<(const ComparableStateTraverser &rhs) const {
+    int compare = std::memcmp(label_stack_.data(), rhs.label_stack_.data(),
+                              std::min(label_stack_.size(), rhs.label_stack_.size()) * sizeof(label_t));
+    if (compare != 0) {
+      return compare < 0;
+    }
+
+    if (label_stack_.size() != rhs.label_stack_.size()) {
+      return label_stack_.size() < rhs.label_stack_.size();
+    }
+
+    return order_ > rhs.order_;
+  }
+
+  bool operator>(const ComparableStateTraverser &rhs) const { return rhs.operator<(*this); }
+
+  bool operator<=(const ComparableStateTraverser &rhs) const { return !operator>(rhs); }
+
+  bool operator>=(const ComparableStateTraverser &rhs) const { return !operator<(rhs); }
+
+  /**
+   * Compare traverser with another one, _ignoring_ the order value
+   */
+  bool operator==(const ComparableStateTraverser &rhs) const {
+    if (label_stack_.size() != rhs.label_stack_.size()) {
+      return false;
+    }
+
+    return std::memcmp(label_stack_.data(), rhs.label_stack_.data(), label_stack_.size() * sizeof(label_t)) == 0;
+  }
+
+  bool operator!=(const ComparableStateTraverser &rhs) { return !operator==(rhs); }
+
+  operator bool() const { return state_traverser_; }
+
+  void operator++(int) {
+    state_traverser_++;
+    if (state_traverser_) {
+      label_stack_.resize(state_traverser_.GetDepth() - 1);
+      label_stack_.push_back(state_traverser_.GetStateLabel());
+    }
+  }
+
+  bool IsFinalState() const { return state_traverser_.IsFinalState(); }
+
+  size_t GetDepth() const { return state_traverser_.GetDepth(); }
+
+  uint64_t GetStateValue() const { return state_traverser_.GetStateValue(); }
+
+  uint32_t GetInnerWeight() { return state_traverser_.GetInnerWeight(); }
+
+  uint64_t GetStateId() const { return state_traverser_.GetStateId(); }
+
+  void Prune() { state_traverser_.Prune(); }
+
+  label_t GetStateLabel() const { return state_traverser_.GetStateLabel(); }
+
+  const std::vector<label_t> &GetStateLabels() const { return label_stack_; }
+
+  size_t GetOrder() const { return order_; }
+
+ private:
+  innerTraverserType state_traverser_;
+  std::vector<label_t> label_stack_;
+  size_t order_;
+};
+} /* namespace fsa */
+} /* namespace dictionary */
+} /* namespace keyvi */
+
+#endif  // KEYVI_DICTIONARY_FSA_COMPARABLE_STATE_TRAVERSER_H_

--- a/keyvi/include/keyvi/dictionary/fsa/comparable_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/comparable_state_traverser.h
@@ -52,14 +52,16 @@ class ComparableStateTraverser final {
  public:
   using label_t = typename innerTraverserType::label_t;
 
-  explicit ComparableStateTraverser(const innerTraverserType &&traverser, bool advance = true, size_t order = 0)
+  explicit ComparableStateTraverser(const innerTraverserType &&traverser, const bool advance = true,
+                                    const size_t order = 0)
       : state_traverser_(std::move(traverser)), order_(order) {
     if (advance) {
       this->operator++(0);
     }
   }
 
-  explicit ComparableStateTraverser(const automata_t f, uint64_t start_state, bool advance = true, size_t order = 0)
+  explicit ComparableStateTraverser(const automata_t f, uint64_t start_state, const bool advance = true,
+                                    const size_t order = 0)
       : state_traverser_(f, start_state, false), order_(order) {
     if (advance) {
       this->operator++(0);
@@ -107,7 +109,7 @@ class ComparableStateTraverser final {
     return std::memcmp(label_stack_.data(), rhs.label_stack_.data(), label_stack_.size() * sizeof(label_t)) == 0;
   }
 
-  bool operator!=(const ComparableStateTraverser &rhs) { return !operator==(rhs); }
+  bool operator!=(const ComparableStateTraverser &rhs) const { return !operator==(rhs); }
 
   operator bool() const { return state_traverser_; }
 

--- a/keyvi/include/keyvi/dictionary/fsa/state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/state_traverser.h
@@ -40,6 +40,8 @@ namespace fsa {
 template <class TransitionT = traversal::Transition>
 class StateTraverser final {
  public:
+  using label_t = unsigned char;
+
   explicit StateTraverser(automata_t f)
       : fsa_(f), current_state_(f->GetStartState()), current_weight_(0), current_label_(0), at_end_(false), stack_() {
     TRACE("StateTraverser starting with Start state %d", current_state_);
@@ -48,7 +50,7 @@ class StateTraverser final {
     this->operator++(0);
   }
 
-  StateTraverser(automata_t f, uint64_t start_state, traversal::TraversalPayload<TransitionT>* payload,
+  StateTraverser(automata_t f, uint64_t start_state, traversal::TraversalPayload<TransitionT> *payload,
                  bool advance = true)
       : fsa_(f), current_weight_(0), current_label_(0), at_end_(false), stack_(*payload) {
     current_state_ = start_state;
@@ -72,10 +74,10 @@ class StateTraverser final {
   }
 
   StateTraverser() = delete;
-  StateTraverser& operator=(StateTraverser const&) = delete;
-  StateTraverser(const StateTraverser& that) = delete;
+  StateTraverser &operator=(StateTraverser const &) = delete;
+  StateTraverser(const StateTraverser &that) = delete;
 
-  StateTraverser(StateTraverser&& other)
+  StateTraverser(StateTraverser &&other)
       : fsa_(other.fsa_),
         current_state_(other.current_state_),
         current_weight_(other.current_weight_),
@@ -145,9 +147,9 @@ class StateTraverser final {
     TRACE("found %ld outgoing states", stack_.GetStates().size());
   }
 
-  unsigned char GetStateLabel() const { return current_label_; }
+  label_t GetStateLabel() const { return current_label_; }
 
-  traversal::TraversalPayload<TransitionT>& GetTraversalPayload() { return stack_.traversal_stack_payload; }
+  traversal::TraversalPayload<TransitionT> &GetTraversalPayload() { return stack_.traversal_stack_payload; }
 
   operator bool() const { return !at_end_; }
 
@@ -157,7 +159,7 @@ class StateTraverser final {
   automata_t fsa_;
   uint64_t current_state_;
   uint32_t current_weight_;
-  unsigned char current_label_;
+  label_t current_label_;
   bool at_end_;
   traversal::TraversalStack<TransitionT> stack_;
 };

--- a/keyvi/include/keyvi/dictionary/fsa/state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/state_traverser.h
@@ -50,8 +50,8 @@ class StateTraverser final {
     this->operator++(0);
   }
 
-  StateTraverser(automata_t f, uint64_t start_state, traversal::TraversalPayload<TransitionT> *payload,
-                 bool advance = true)
+  StateTraverser(automata_t f, const uint64_t start_state, traversal::TraversalPayload<TransitionT> *payload,
+                 const bool advance = true)
       : fsa_(f), current_weight_(0), current_label_(0), at_end_(false), stack_(*payload) {
     current_state_ = start_state;
 
@@ -63,7 +63,7 @@ class StateTraverser final {
     }
   }
 
-  StateTraverser(automata_t f, uint64_t start_state, bool advance = true)
+  StateTraverser(automata_t f, const uint64_t start_state, const bool advance = true)
       : fsa_(f), current_state_(start_state), current_weight_(0), current_label_(0), at_end_(false), stack_() {
     TRACE("StateTraverser starting with Start state %d", current_state_);
     f->GetOutGoingTransitions(start_state, &stack_.GetStates(), &stack_.traversal_stack_payload);
@@ -99,7 +99,7 @@ class StateTraverser final {
 
   uint64_t GetStateValue() const { return fsa_->GetStateValue(current_state_); }
 
-  uint32_t GetInnerWeight() { return current_weight_; }
+  uint32_t GetInnerWeight() const { return current_weight_; }
 
   uint64_t GetStateId() const { return current_state_; }
 

--- a/keyvi/include/keyvi/dictionary/fsa/zip_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/zip_state_traverser.h
@@ -1,0 +1,164 @@
+/* keyvi - A key value store.
+ *
+ * Copyright 2020 Hendrik Muhs<hendrik.muhs@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * zip_state_traverser.h
+ *
+ *  Created on: Dec 16, 2020
+ *      Author: hendrik
+ */
+
+#ifndef KEYVI_DICTIONARY_FSA_ZIP_STATE_TRAVERSER_H_
+#define KEYVI_DICTIONARY_FSA_ZIP_STATE_TRAVERSER_H_
+
+#include <algorithm>
+#include <cstring>
+#include <initializer_list>
+#include <memory>
+#include <vector>
+
+#include <boost/heap/skew_heap.hpp>
+
+#include "keyvi/dictionary/fsa/automata.h"
+#include "keyvi/dictionary/fsa/comparable_state_traverser.h"
+
+// #define ENABLE_TRACING
+#include "keyvi/dictionary/util/trace.h"
+
+namespace keyvi {
+namespace dictionary {
+namespace fsa {
+
+template <class innerTraverserType>
+class ZipStateTraverser final {
+ private:
+  using traverser_t = std::shared_ptr<ComparableStateTraverser<innerTraverserType>>;
+
+  struct TraverserCompare {
+    bool operator()(const traverser_t &t1, const traverser_t &t2) const { return *t1 > *t2; }
+  };
+
+ public:
+  using label_t = typename innerTraverserType::label_t;
+  using heap_t =
+      boost::heap::skew_heap<traverser_t, boost::heap::compare<TraverserCompare>, boost::heap::mutable_<true>>;
+  explicit ZipStateTraverser(const std::vector<automata_t> &fsas, bool advance = true) {
+    size_t order = 0;
+    for (const automata_t &f : fsas) {
+      traverser_queue_.emplace(std::make_shared<ComparableStateTraverser<innerTraverserType>>(f, true, order++));
+    }
+
+    if (advance) {
+      this->operator++(0);
+    }
+  }
+
+  explicit ZipStateTraverser(const std::initializer_list<automata_t> fsas, bool advance = true) {
+    size_t order = 0;
+    for (auto f : fsas) {
+      traverser_queue_.emplace(std::make_shared<ComparableStateTraverser<innerTraverserType>>(f, true, order++));
+    }
+
+    if (advance) {
+      this->operator++(0);
+    }
+  }
+
+  ZipStateTraverser() = delete;
+  ZipStateTraverser &operator=(ZipStateTraverser const &) = delete;
+  ZipStateTraverser(const ZipStateTraverser &that) = delete;
+
+  void operator++(int) {
+    TRACE("iterator++");
+
+    if (!traverser_queue_.empty()) {
+      const traverser_t &t = traverser_queue_.top();
+      auto it = traverser_queue_.begin();
+      it++;
+
+      final_ = t->IsFinalState();
+      depth_ = t->GetDepth();
+      state_value_ = t->GetStateValue();
+      inner_weight_ = t->GetInnerWeight();
+      state_id_ = t->GetStateId();
+      state_label_ = t->GetStateLabel();
+
+      while (it != traverser_queue_.end() && *t == *(*it)) {
+        TRACE("advance 2nd: %ld", (*it)->GetOrder());
+
+        // if not final yet check if other states are final
+        if (!final_ && (*it)->IsFinalState()) {
+          final_ = true;
+          state_value_ = (*it)->GetStateValue();
+        }
+
+        // take the max from inner weights
+        if ((*it)->GetInnerWeight() > inner_weight_) {
+          inner_weight_ = (*it)->GetInnerWeight();
+        }
+
+        (*it)->operator++(0);
+        if (*(*it)) {
+          traverser_queue_.decrease(heap_t::s_handle_from_iterator(it));
+        } else {
+          traverser_queue_.erase(heap_t::s_handle_from_iterator(it));
+        }
+        it = traverser_queue_.begin();
+        it++;
+      }
+
+      t->operator++(0);
+      if (*t) {
+        traverser_queue_.decrease(heap_t::s_handle_from_iterator(traverser_queue_.begin()));
+      } else {
+        traverser_queue_.erase(heap_t::s_handle_from_iterator(traverser_queue_.begin()));
+      }
+    }
+  }
+
+  operator bool() const { return !traverser_queue_.empty(); }
+
+  bool IsFinalState() const { return final_; }
+
+  size_t GetDepth() const { return depth_; }
+
+  uint64_t GetStateValue() const { return state_value_; }
+
+  uint32_t GetInnerWeight() const { return inner_weight_; }
+
+  uint64_t GetStateId() const { return state_id_; }
+
+  void Prune() { /*todo*/
+  }
+
+  label_t GetStateLabel() const { return state_label_; }
+
+ private:
+  heap_t traverser_queue_;
+  bool final_ = false;
+  size_t depth_ = 0;
+  uint64_t state_value_ = 0;
+  uint32_t inner_weight_ = 0;
+  uint64_t state_id_ = 0;
+  label_t state_label_ = 0;
+};
+
+} /* namespace fsa */
+} /* namespace dictionary */
+} /* namespace keyvi */
+
+#endif  // KEYVI_DICTIONARY_FSA_ZIP_STATE_TRAVERSER_H_

--- a/keyvi/include/keyvi/dictionary/fsa/zip_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/zip_state_traverser.h
@@ -44,6 +44,14 @@ namespace keyvi {
 namespace dictionary {
 namespace fsa {
 
+/**
+ * A traverser that wraps a list of inner traversers to traverse them as if they would be 1 traverser
+ *
+ * The order of inner traversers define the precedence. If 2 traversers have share a common traversal stack,
+ * the later dictionary is taken for reading out the value/weight etc.
+ *
+ * Note: wrapping weighted state traverser is not supported yet
+ */
 template <class innerTraverserType>
 class ZipStateTraverser final {
  private:
@@ -57,7 +65,7 @@ class ZipStateTraverser final {
   using label_t = typename innerTraverserType::label_t;
   using heap_t =
       boost::heap::skew_heap<traverser_t, boost::heap::compare<TraverserCompare>, boost::heap::mutable_<true>>;
-  explicit ZipStateTraverser(const std::vector<automata_t> &fsas, bool advance = true) {
+  explicit ZipStateTraverser(const std::vector<automata_t> &fsas, const bool advance = true) {
     size_t order = 0;
     for (const automata_t &f : fsas) {
       traverser_t traverser = std::make_shared<ComparableStateTraverser<innerTraverserType>>(f, advance, order++);
@@ -69,7 +77,7 @@ class ZipStateTraverser final {
     FillInValues();
   }
 
-  explicit ZipStateTraverser(const std::initializer_list<automata_t> fsas, bool advance = true) {
+  explicit ZipStateTraverser(const std::initializer_list<automata_t> fsas, const bool advance = true) {
     size_t order = 0;
     for (auto f : fsas) {
       traverser_t traverser = std::make_shared<ComparableStateTraverser<innerTraverserType>>(f, advance, order++);
@@ -82,7 +90,7 @@ class ZipStateTraverser final {
   }
 
   explicit ZipStateTraverser(const std::vector<std::pair<automata_t, uint64_t>> &fsa_start_state_pairs,
-                             bool advance = true) {
+                             const bool advance = true) {
     size_t order = 0;
     for (auto f : fsa_start_state_pairs) {
       if (f.second > 0) {

--- a/keyvi/include/keyvi/dictionary/fsa/zip_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/zip_state_traverser.h
@@ -110,6 +110,27 @@ class ZipStateTraverser final {
   ZipStateTraverser &operator=(ZipStateTraverser const &) = delete;
   ZipStateTraverser(const ZipStateTraverser &that) = delete;
 
+  ZipStateTraverser(ZipStateTraverser &&other)
+      : traverser_queue_(std::move(other.traverser_queue_)),
+        final_(other.final_),
+        depth_(other.depth_),
+        state_value_(other.state_value_),
+        inner_weight_(other.inner_weight_),
+        state_id_(other.state_id_),
+        state_label_(other.state_label_),
+        order_(other.order_),
+        fsa_(std::move(other.fsa_)),
+        equal_states_(other.equal_states_) {
+    other.final_ = false;
+    other.depth_ = 0;
+    other.state_value_ = 0;
+    other.inner_weight_ = 0;
+    other.state_id_ = 0;
+    other.state_label_ = 0;
+    other.order_ = 0;
+    other.equal_states_ = 1;
+  }
+
   void operator++(int) {
     TRACE("iterator++, forwarding %ld inner traversers", equal_states_);
 
@@ -130,6 +151,8 @@ class ZipStateTraverser final {
   }
 
   operator bool() const { return !traverser_queue_.empty(); }
+
+  automata_t GetFsa() const { return fsa_; }
 
   bool IsFinalState() const { return final_; }
 

--- a/keyvi/include/keyvi/dictionary/fsa/zip_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/zip_state_traverser.h
@@ -47,8 +47,8 @@ namespace fsa {
 /**
  * A traverser that wraps a list of inner traversers to traverse them as if they would be 1 traverser
  *
- * The order of inner traversers define the precedence. If 2 traversers have share a common traversal stack,
- * the later dictionary is taken for reading out the value/weight etc.
+ * The order of inner traversers define the precedence. If 2 traversers have a common traversal stack,
+ * the later dictionary is taken for reading out the values/weights etc.
  *
  * Note: wrapping weighted state traverser is not supported yet
  */

--- a/keyvi/include/keyvi/dictionary/matching/fuzzy_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/fuzzy_matching.h
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "utf8.h"
@@ -35,49 +36,131 @@
 #include "keyvi/dictionary/fsa/automata.h"
 #include "keyvi/dictionary/fsa/codepoint_state_traverser.h"
 #include "keyvi/dictionary/fsa/traverser_types.h"
+#include "keyvi/dictionary/fsa/zip_state_traverser.h"
 #include "keyvi/dictionary/match.h"
 #include "keyvi/dictionary/util/utf8_utils.h"
 #include "keyvi/stringdistance/levenshtein.h"
+
+// #define ENABLE_TRACING
+#include "keyvi/dictionary/util/trace.h"
 
 namespace keyvi {
 namespace dictionary {
 namespace matching {
 
+template <class codepointInnterTraverserType = fsa::WeightedStateTraverser>
 class FuzzyMatching final {
  public:
-  FuzzyMatching(const fsa::automata_t& fsa, const std::string& query, int32_t max_edit_distance)
-      : fsa_(fsa), query_(query), max_edit_distance_(max_edit_distance), first_match_() {
+  FuzzyMatching(std::unique_ptr<fsa::CodePointStateTraverser<codepointInnterTraverserType>>&& traverser,
+                std::unique_ptr<stringdistance::Levenshtein>&& metric, Match&& first_match,
+                const size_t minimum_exact_prefix, int32_t max_edit_distance)
+      : metric_ptr_(std::move(metric)),
+        traverser_ptr_(std::move(traverser)),
+        minimum_exact_prefix_(minimum_exact_prefix),
+        max_edit_distance_(max_edit_distance),
+        first_match_(std::move(first_match)) {}
+
+  template <class innerTraverserType = fsa::WeightedStateTraverser>
+  static FuzzyMatching FromSingleDictionary(const fsa::automata_t& fsa, const std::string& query,
+                                            const int32_t max_edit_distance, const size_t minimum_exact_prefix = 2) {
+    std::unique_ptr<stringdistance::Levenshtein> metric;
+    std::unique_ptr<fsa::CodePointStateTraverser<innerTraverserType>> traverser;
+    Match first_match;
+
     std::vector<uint32_t> codepoints;
     utf8::unchecked::utf8to32(query.begin(), query.end(), back_inserter(codepoints));
 
-    query_char_length_ = codepoints.size();
-    if (query_char_length_ < MINIMUM_EXACT_PREFIX_IN_CHARS) {
-      return;
+    size_t query_char_length = codepoints.size();
+    if (query_char_length < minimum_exact_prefix) {
+      TRACE("query lengh < minimum exact prefix, returning empty iterator");
+      return FuzzyMatching<>(std::move(traverser), std::move(metric), std::move(first_match), minimum_exact_prefix,
+                             max_edit_distance);
     }
-    metric_ptr_.reset(new stringdistance::Levenshtein(codepoints, 20, max_edit_distance_));
+    metric.reset(new stringdistance::Levenshtein(codepoints, 20, max_edit_distance));
 
     // match exact prefix
-    uint64_t state = fsa_->GetStartState();
+    uint64_t state = fsa->GetStartState();
     size_t depth = 0;
     size_t utf8_depth = 0;
-    while (state != 0 && depth < MINIMUM_EXACT_PREFIX_IN_CHARS) {
+    while (state != 0 && depth < minimum_exact_prefix) {
       const size_t code_point_length = util::Utf8Utils::GetCharLength(query[utf8_depth]);
       for (size_t i = 0; i < code_point_length; ++i, ++utf8_depth) {
-        state = fsa_->TryWalkTransition(state, query[utf8_depth]);
+        state = fsa->TryWalkTransition(state, query[utf8_depth]);
         if (0 == state) {
           break;
         }
       }
-      metric_ptr_->Put(codepoints[depth], depth);
+      metric->Put(codepoints[depth], depth);
       ++depth;
     }
 
     if (state) {
-      if (depth == query_char_length_ && fsa_->IsFinalState(state)) {
-        first_match_ = Match(0, query_char_length_, query, 0, fsa_, fsa_->GetStateValue(state));
+      if (depth == query_char_length && fsa->IsFinalState(state)) {
+        first_match = Match(0, query_char_length, query, 0, fsa, fsa->GetStateValue(state));
       }
-      traverser_ptr_.reset(new fsa::CodePointStateTraverser<fsa::WeightedStateTraverser>(fsa_, state));
+      traverser.reset(new fsa::CodePointStateTraverser<innerTraverserType>(fsa, state));
     }
+
+    TRACE("create iterator");
+    return FuzzyMatching<>(std::move(traverser), std::move(metric), std::move(first_match), minimum_exact_prefix,
+                           max_edit_distance);
+  }
+
+  template <class innerTraverserType = fsa::WeightedStateTraverser>
+  static FuzzyMatching FromDictionaries(const std::vector<fsa::automata_t>& fsas, const std::string& query,
+                                        const int32_t max_edit_distance, const size_t minimum_exact_prefix = 2) {
+    std::unique_ptr<stringdistance::Levenshtein> metric;
+    std::unique_ptr<fsa::CodePointStateTraverser<innerTraverserType>> traverser;
+    Match first_match;
+
+    std::vector<uint32_t> codepoints;
+    utf8::unchecked::utf8to32(query.begin(), query.end(), back_inserter(codepoints));
+
+    size_t query_char_length = codepoints.size();
+    if (query_char_length < minimum_exact_prefix) {
+      TRACE("query lengh < minimum exact prefix, returning empty iterator");
+      return FuzzyMatching<>(std::move(traverser), std::move(metric), std::move(first_match), minimum_exact_prefix,
+                             max_edit_distance);
+    }
+
+    metric.reset(new stringdistance::Levenshtein(codepoints, 20, max_edit_distance));
+
+    std::vector<std::pair<fsa::automata_t, uint64_t>> fsa_start_state_pairs;
+
+    for (const fsa::automata_t& fsa : fsas) {
+      uint64_t state = fsa->GetStartState();
+      size_t depth = 0;
+      size_t utf8_depth = 0;
+      while (state != 0 && depth < minimum_exact_prefix) {
+        const size_t code_point_length = util::Utf8Utils::GetCharLength(query[utf8_depth]);
+        for (size_t i = 0; i < code_point_length; ++i, ++utf8_depth) {
+          state = fsa->TryWalkTransition(state, query[utf8_depth]);
+          if (0 == state) {
+            break;
+          }
+        }
+        metric->Put(codepoints[depth], depth);
+        ++depth;
+      }
+
+      if (state) {
+        if (depth == query_char_length && fsa->IsFinalState(state) && first_match.IsEmpty() == false) {
+          first_match = Match(0, query_char_length, query, 0, fsa, fsa->GetStateValue(state));
+        }
+
+        fsa_start_state_pairs.emplace_back(fsa, state);
+      }
+    }
+
+    if (fsa_start_state_pairs.size() > 0) {
+      fsa::ZipStateTraverser<innerTraverserType> zip_state_traverser(fsa_start_state_pairs);
+      traverser.reset(
+          new fsa::CodePointStateTraverser<fsa::ZipStateTraverser<innerTraverserType>>(zip_state_traverser));
+    }
+
+    TRACE("create iterator");
+    return FuzzyMatching<>(std::move(traverser), std::move(metric), std::move(first_match), minimum_exact_prefix,
+                           max_edit_distance);
   }
 
   Match FirstMatch() const { return first_match_; }
@@ -86,12 +169,12 @@ class FuzzyMatching final {
     for (; traverser_ptr_ && *traverser_ptr_; (*traverser_ptr_)++) {
       const int32_t intermediate_score = metric_ptr_->Put(traverser_ptr_->GetStateLabel(), candidate_length() - 1);
       // don't consider subtrees which can not be matched anyways
-      if (query_char_length_ > candidate_length() && intermediate_score > max_edit_distance_) {
+      if (metric_ptr_->GetInputSequence().size() > candidate_length() && intermediate_score > max_edit_distance_) {
         traverser_ptr_->Prune();
         continue;
       }
 
-      if (query_char_length_ + max_edit_distance_ < candidate_length()) {
+      if (metric_ptr_->GetInputSequence().size() + max_edit_distance_ < candidate_length()) {
         traverser_ptr_->Prune();
         continue;
       }
@@ -109,22 +192,15 @@ class FuzzyMatching final {
  private:
   size_t candidate_length() const {
     assert(traverser_ptr_);
-    return MINIMUM_EXACT_PREFIX_IN_CHARS + traverser_ptr_->GetDepth();
+    return minimum_exact_prefix_ + traverser_ptr_->GetDepth();
   }
 
  private:
-  fsa::automata_t fsa_;
-  std::string query_;
-  const int32_t max_edit_distance_;
-
-  size_t query_char_length_ = 0;
-
-  Match first_match_;
-
   std::unique_ptr<stringdistance::Levenshtein> metric_ptr_;
-  std::unique_ptr<fsa::CodePointStateTraverser<fsa::WeightedStateTraverser>> traverser_ptr_;
-
-  const size_t MINIMUM_EXACT_PREFIX_IN_CHARS = 2;
+  std::unique_ptr<fsa::CodePointStateTraverser<codepointInnterTraverserType>> traverser_ptr_;
+  const size_t minimum_exact_prefix_;
+  const int32_t max_edit_distance_;
+  Match first_match_;
 };
 
 } /* namespace matching */

--- a/keyvi/include/keyvi/dictionary/matching/fuzzy_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/fuzzy_matching.h
@@ -146,7 +146,8 @@ class FuzzyMatching final {
       }
 
       if (state) {
-        if (depth == query_char_length && fsa->IsFinalState(state) && first_match.IsEmpty() == false) {
+        if (depth == query_char_length && fsa->IsFinalState(state) && first_match.IsEmpty()) {
+          TRACE("prefix matched exact");
           first_match = Match(0, query_char_length, query, 0, fsa, fsa->GetStateValue(state));
         }
 
@@ -155,6 +156,8 @@ class FuzzyMatching final {
     }
 
     if (fsa_start_state_pairs.size() > 0) {
+      TRACE("create zip traverser with %ul inner traversers", fsa_start_state_pairs.size());
+
       fsa::ZipStateTraverser<innerTraverserType> zip_state_traverser(fsa_start_state_pairs, false);
       traverser.reset(
           new fsa::CodePointStateTraverser<fsa::ZipStateTraverser<innerTraverserType>>(std::move(zip_state_traverser)));

--- a/keyvi/include/keyvi/stringdistance/needleman_wunsch.h
+++ b/keyvi/include/keyvi/stringdistance/needleman_wunsch.h
@@ -210,6 +210,8 @@ class NeedlemanWunsch final {
     return std::string(utf8result.begin(), utf8result.end());
   }
 
+  const std::vector<uint32_t> GetInputSequence() const { return input_sequence_; }
+
  private:
   int32_t max_distance_ = 0;
   std::vector<uint32_t> compare_sequence_;

--- a/keyvi/tests/keyvi/dictionary/fsa/comparable_state_traverser_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fsa/comparable_state_traverser_test.cpp
@@ -1,0 +1,163 @@
+//
+// keyvi - A key value store.
+//
+// Copyright 2020 Hendrik Muhs<hendrik.muhs@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <boost/test/unit_test.hpp>
+
+#include "keyvi/dictionary/fsa/comparable_state_traverser.h"
+#include "keyvi/dictionary/fsa/state_traverser.h"
+#include "keyvi/testing/temp_dictionary.h"
+
+namespace keyvi {
+namespace dictionary {
+namespace fsa {
+
+BOOST_AUTO_TEST_SUITE(ComparableStateTraverserTests)
+
+BOOST_AUTO_TEST_CASE(same_data) {
+  std::vector<std::string> test_data = {"aaaa", "aabb", "aabc", "aacd", "bbcd"};
+  testing::TempDictionary dictionary(&test_data);
+  automata_t f = dictionary.GetFsa();
+
+  ComparableStateTraverser<StateTraverser<>> t1(f, false, 0);
+  ComparableStateTraverser<StateTraverser<>> t2(f, false, 0);
+  ComparableStateTraverser<StateTraverser<>> t3(f, false, 1);
+  ComparableStateTraverser<StateTraverser<>> t4(f, false, 1);
+
+  BOOST_CHECK((t1 < t2) == false);
+  BOOST_CHECK((t2 < t1) == false);
+  BOOST_CHECK(t2 == t1);
+  BOOST_CHECK(t2 <= t1);
+  BOOST_CHECK(t1 <= t2);
+  BOOST_CHECK(t3 < t1);
+  BOOST_CHECK(t4 < t1);
+  BOOST_CHECK((t3 < t4) == false);
+
+  t1++;
+  BOOST_CHECK_EQUAL('a', t1.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, t1.GetDepth());
+  BOOST_CHECK(t2 < t1);
+  BOOST_CHECK((t1 < t2) == false);
+  BOOST_CHECK(t1 != t2);
+  BOOST_CHECK(t3 < t1);
+  BOOST_CHECK(t4 < t1);
+  BOOST_CHECK((t1 < t3) == false);
+  BOOST_CHECK((t1 < t4) == false);
+
+  t3++;
+  BOOST_CHECK(t3 < t1);
+  BOOST_CHECK((t3 > t1) == false);
+  BOOST_CHECK(t4 < t3);
+
+  t2++;
+  BOOST_CHECK_EQUAL('a', t2.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, t2.GetDepth());
+  BOOST_CHECK((t1 < t2) == false);
+  BOOST_CHECK((t2 < t1) == false);
+  BOOST_CHECK(t3 < t1);
+  BOOST_CHECK(t4 < t1);
+
+  t2++;
+  BOOST_CHECK_EQUAL('a', t2.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, t2.GetDepth());
+  BOOST_CHECK((t2 < t1) == false);
+  BOOST_CHECK(t1 < t2);
+}
+
+BOOST_AUTO_TEST_CASE(interleave1) {
+  std::vector<std::string> test_data1 = {"aaaa", "aabb", "aabc", "aacd", "bbcd"};
+  testing::TempDictionary dictionary1(&test_data1);
+  automata_t f1 = dictionary1.GetFsa();
+
+  std::vector<std::string> test_data2 = {"aabb", "aabd", "abcd", "bbcd"};
+  testing::TempDictionary dictionary2(&test_data2);
+  automata_t f2 = dictionary2.GetFsa();
+
+  ComparableStateTraverser<StateTraverser<>> t1(f1, false, 0);
+  ComparableStateTraverser<StateTraverser<>> t2(f2, false, 1);
+
+  BOOST_CHECK(t2 < t1);
+  BOOST_CHECK_EQUAL(t1, t2);
+  t1++;
+  t2++;
+  BOOST_CHECK_EQUAL('a', t1.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, t1.GetDepth());
+  BOOST_CHECK(t2 < t1);
+  BOOST_CHECK_EQUAL(t1, t2);
+  t1++;
+  t2++;
+  BOOST_CHECK_EQUAL('a', t1.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, t1.GetDepth());
+  BOOST_CHECK(t2 < t1);
+  BOOST_CHECK_EQUAL(t1, t2);
+  BOOST_CHECK_EQUAL(2, t2.GetDepth());
+  t1++;
+  BOOST_CHECK_EQUAL('a', t1.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, t1.GetDepth());
+  BOOST_CHECK(t2 < t1);
+  BOOST_CHECK(t1 != t2);
+  t1++;
+  BOOST_CHECK_EQUAL('a', t1.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, t1.GetDepth());
+  t1++;
+  BOOST_CHECK_EQUAL('b', t1.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, t1.GetDepth());
+  t2++;
+  BOOST_CHECK_EQUAL('b', t2.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, t2.GetDepth());
+  BOOST_CHECK(t1 == t2);
+}
+
+BOOST_AUTO_TEST_CASE(interleave2) {
+  std::vector<std::string> test_data1 = {"aaaa", "aabb", "aabc", "aacd", "bbcd"};
+  testing::TempDictionary dictionary1(&test_data1);
+  automata_t f1 = dictionary1.GetFsa();
+
+  std::vector<std::string> test_data2 = {"aaab", "aabd", "abcd", "bbcd"};
+  testing::TempDictionary dictionary2(&test_data2);
+  automata_t f2 = dictionary2.GetFsa();
+
+  ComparableStateTraverser<StateTraverser<>> t1(f1, false, 0);
+  ComparableStateTraverser<StateTraverser<>> t2(f2, false, 1);
+
+  BOOST_CHECK(t2 < t1);
+  BOOST_CHECK_EQUAL(t1, t2);
+  t1++;
+  BOOST_CHECK(t2 < t1);
+  BOOST_CHECK(t1 != t2);
+  t2++;
+  BOOST_CHECK(t2 < t1);
+  BOOST_CHECK_EQUAL(t1, t2);
+  t2++;
+  BOOST_CHECK(t1 < t2);
+  BOOST_CHECK(t1 != t2);
+  t1++;
+  BOOST_CHECK(t2 < t1);
+  BOOST_CHECK_EQUAL(t1, t2);
+  BOOST_CHECK_EQUAL(2, t2.GetDepth());
+  t1++;
+  t2++;
+  BOOST_CHECK(t2 < t1);
+  BOOST_CHECK_EQUAL(t1, t2);
+  BOOST_CHECK_EQUAL(3, t2.GetDepth());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} /* namespace fsa */
+} /* namespace dictionary */
+} /* namespace keyvi */

--- a/keyvi/tests/keyvi/dictionary/fsa/zip_state_traverser_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fsa/zip_state_traverser_test.cpp
@@ -234,6 +234,53 @@ BOOST_AUTO_TEST_CASE(infixes) {
   BOOST_CHECK_EQUAL_COLLECTIONS(actual.begin(), actual.end(), expected.begin(), expected.end());
 }
 
+BOOST_AUTO_TEST_CASE(after_prefix) {
+  std::vector<std::string> test_data1 = {"aa", "hh", "ii", "kk", "zz"};
+  testing::TempDictionary dictionary1(&test_data1);
+  automata_t f1 = dictionary1.GetFsa();
+  std::vector<std::string> test_data2 = {"bb", "ff", "hh", "jj"};
+  testing::TempDictionary dictionary2(&test_data2);
+  automata_t f2 = dictionary2.GetFsa();
+  std::vector<std::string> test_data3 = {"add", "ee", "jj", "pp", "zz"};
+  testing::TempDictionary dictionary3(&test_data3);
+  automata_t f3 = dictionary3.GetFsa();
+  std::vector<std::string> test_data4 = {"abcc", "aqq", "rr", "tt"};
+  testing::TempDictionary dictionary4(&test_data4);
+  automata_t f4 = dictionary4.GetFsa();
+  std::vector<std::string> test_data5 = {"aaaaaa", "aee", "pp", "zz"};
+  testing::TempDictionary dictionary5(&test_data5);
+  automata_t f5 = dictionary5.GetFsa();
+  std::vector<std::string> test_data6 = {"acjj"};
+  testing::TempDictionary dictionary6(&test_data6);
+  automata_t f6 = dictionary6.GetFsa();
+  std::vector<std::string> test_data7 = {"a"};
+  testing::TempDictionary dictionary7(&test_data7);
+  automata_t f7 = dictionary7.GetFsa();
+
+  ZipStateTraverser<StateTraverser<>> t({{f1, f1->TryWalkTransition(f1->GetStartState(), 'a')},
+                                         {f2, f2->TryWalkTransition(f2->GetStartState(), 'a')},
+                                         {f3, f3->TryWalkTransition(f3->GetStartState(), 'a')},
+                                         {f4, f4->TryWalkTransition(f4->GetStartState(), 'a')},
+                                         {f5, f5->TryWalkTransition(f5->GetStartState(), 'a')},
+                                         {f6, f6->TryWalkTransition(f6->GetStartState(), 'a')},
+                                         {f7, f7->TryWalkTransition(f7->GetStartState(), 'a')}});
+
+  auto actual = GetAllKeys(&t);
+  std::vector<std::string> expected{"a", "aaaaa", "bcc", "cjj", "dd", "ee", "qq"};
+
+  BOOST_CHECK_EQUAL_COLLECTIONS(actual.begin(), actual.end(), expected.begin(), expected.end());
+  ZipStateTraverser<StateTraverser<>> t2({{f1, f1->TryWalkTransition(f1->GetStartState(), 'h')},
+                                          {f2, f2->TryWalkTransition(f2->GetStartState(), 'h')},
+                                          {f3, f3->TryWalkTransition(f3->GetStartState(), 'h')},
+                                          {f4, f4->TryWalkTransition(f4->GetStartState(), 'h')},
+                                          {f5, f5->TryWalkTransition(f5->GetStartState(), 'h')},
+                                          {f6, f6->TryWalkTransition(f6->GetStartState(), 'h')}});
+
+  auto actual2 = GetAllKeys(&t2);
+  std::vector<std::string> expected2{"h"};
+  BOOST_CHECK_EQUAL_COLLECTIONS(actual2.begin(), actual2.end(), expected2.begin(), expected2.end());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 } /* namespace fsa */

--- a/keyvi/tests/keyvi/dictionary/fsa/zip_state_traverser_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fsa/zip_state_traverser_test.cpp
@@ -40,6 +40,408 @@ namespace fsa {
 
 BOOST_AUTO_TEST_SUITE(ZipStateTraverserTests)
 
+BOOST_AUTO_TEST_CASE(StateTraverserCompatibility) {
+  std::vector<std::string> test_data = {"aaaa", "aabb", "aabc", "aacd", "bbcd"};
+  testing::TempDictionary dictionary(&test_data);
+  automata_t f = dictionary.GetFsa();
+
+  ZipStateTraverser<StateTraverser<>> s({f});
+
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  BOOST_CHECK(!s.AtEnd());
+  BOOST_CHECK(s);
+
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+
+  // traverser shall be exhausted
+  s++;
+  BOOST_CHECK_EQUAL(0, s.GetStateLabel());
+  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
+  BOOST_CHECK_EQUAL(0, s.GetDepth());
+  s++;
+  BOOST_CHECK_EQUAL(0, s.GetStateLabel());
+  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK_EQUAL(0, s.GetDepth());
+
+  // with advance == false
+  ZipStateTraverser<StateTraverser<>> s2({f}, false);
+  s2++;
+
+  BOOST_CHECK_EQUAL('a', s2.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s2.GetDepth());
+  BOOST_CHECK(!s2.AtEnd());
+  BOOST_CHECK(s2);
+
+  s2++;
+  BOOST_CHECK_EQUAL('a', s2.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s2.GetDepth());
+  s2++;
+  BOOST_CHECK_EQUAL('a', s2.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s2.GetDepth());
+  BOOST_CHECK(!s2.IsFinalState());
+
+  s2++;
+  BOOST_CHECK_EQUAL('a', s2.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s2.GetDepth());
+  BOOST_CHECK(s2.IsFinalState());
+
+  s2++;
+  BOOST_CHECK_EQUAL('b', s2.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s2.GetDepth());
+  BOOST_CHECK(!s2.IsFinalState());
+
+  s2++;
+  BOOST_CHECK_EQUAL('b', s2.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s2.GetDepth());
+  BOOST_CHECK(s2.IsFinalState());
+
+  s2++;
+  BOOST_CHECK_EQUAL('c', s2.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s2.GetDepth());
+  BOOST_CHECK(s2.IsFinalState());
+
+  s2++;
+  BOOST_CHECK_EQUAL('c', s2.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s2.GetDepth());
+  BOOST_CHECK(!s2.IsFinalState());
+
+  s2++;
+  BOOST_CHECK_EQUAL('d', s2.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s2.GetDepth());
+  BOOST_CHECK(s2.IsFinalState());
+
+  s2++;
+  BOOST_CHECK_EQUAL('b', s2.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s2.GetDepth());
+  BOOST_CHECK(!s2.IsFinalState());
+
+  s2++;
+  BOOST_CHECK_EQUAL('b', s2.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s2.GetDepth());
+  s2++;
+  BOOST_CHECK_EQUAL('c', s2.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s2.GetDepth());
+  s2++;
+  BOOST_CHECK_EQUAL('d', s2.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s2.GetDepth());
+  BOOST_CHECK(s2.IsFinalState());
+
+  // traverser shall be exhausted
+  s2++;
+  BOOST_CHECK_EQUAL(0, s2.GetStateLabel());
+  BOOST_CHECK(s2.AtEnd());
+  BOOST_CHECK(!s2);
+  BOOST_CHECK_EQUAL(0, s2.GetDepth());
+  s2++;
+  BOOST_CHECK_EQUAL(0, s2.GetStateLabel());
+  BOOST_CHECK(s2.AtEnd());
+  BOOST_CHECK_EQUAL(0, s2.GetDepth());
+
+  std::vector<std::string> test_data2 = {"aaaa", "aabb", "bbcd"};
+  testing::TempDictionary dictionary2(&test_data2);
+  automata_t f2 = dictionary2.GetFsa();
+  std::vector<std::string> test_data3 = {"aabc", "aacd"};
+  testing::TempDictionary dictionary3(&test_data3);
+  automata_t f3 = dictionary3.GetFsa();
+
+  // split in 2 dicts and with advance==false
+  ZipStateTraverser<StateTraverser<>> s3({f2, f3}, false);
+  s3++;
+
+  BOOST_CHECK_EQUAL('a', s3.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s3.GetDepth());
+  BOOST_CHECK(!s3.AtEnd());
+  BOOST_CHECK(s3);
+
+  s3++;
+  BOOST_CHECK_EQUAL('a', s3.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s3.GetDepth());
+  s3++;
+  BOOST_CHECK_EQUAL('a', s3.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s3.GetDepth());
+  BOOST_CHECK(!s3.IsFinalState());
+
+  s3++;
+  BOOST_CHECK_EQUAL('a', s3.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s3.GetDepth());
+  BOOST_CHECK(s3.IsFinalState());
+
+  s3++;
+  BOOST_CHECK_EQUAL('b', s3.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s3.GetDepth());
+  BOOST_CHECK(!s3.IsFinalState());
+
+  s3++;
+  BOOST_CHECK_EQUAL('b', s3.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s3.GetDepth());
+  BOOST_CHECK(s3.IsFinalState());
+
+  s3++;
+  BOOST_CHECK_EQUAL('c', s3.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s3.GetDepth());
+  BOOST_CHECK(s3.IsFinalState());
+
+  s3++;
+  BOOST_CHECK_EQUAL('c', s3.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s3.GetDepth());
+  BOOST_CHECK(!s3.IsFinalState());
+
+  s3++;
+  BOOST_CHECK_EQUAL('d', s3.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s3.GetDepth());
+  BOOST_CHECK(s3.IsFinalState());
+
+  s3++;
+  BOOST_CHECK_EQUAL('b', s3.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s3.GetDepth());
+  BOOST_CHECK(!s3.IsFinalState());
+
+  s3++;
+  BOOST_CHECK_EQUAL('b', s3.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s3.GetDepth());
+  s3++;
+  BOOST_CHECK_EQUAL('c', s3.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s3.GetDepth());
+  s3++;
+  BOOST_CHECK_EQUAL('d', s3.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s3.GetDepth());
+  BOOST_CHECK(s3.IsFinalState());
+
+  // traverser shall be exhausted
+  s3++;
+  BOOST_CHECK_EQUAL(0, s3.GetStateLabel());
+  BOOST_CHECK(s3.AtEnd());
+  BOOST_CHECK(!s3);
+  BOOST_CHECK_EQUAL(0, s3.GetDepth());
+  s3++;
+  BOOST_CHECK_EQUAL(0, s3.GetStateLabel());
+  BOOST_CHECK(s3.AtEnd());
+  BOOST_CHECK_EQUAL(0, s3.GetDepth());
+}
+
+BOOST_AUTO_TEST_CASE(someTraversalWithPrune) {
+  std::vector<std::string> test_data1 = {"aaaa", "aabb", "bbcd"};
+  testing::TempDictionary dictionary1(&test_data1);
+  automata_t f1 = dictionary1.GetFsa();
+  std::vector<std::string> test_data2 = {"aabc", "aacd"};
+  testing::TempDictionary dictionary2(&test_data2);
+  automata_t f2 = dictionary2.GetFsa();
+
+  ZipStateTraverser<StateTraverser<>> s({f1, f2});
+
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  BOOST_CHECK(!s.AtEnd());
+
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+
+  s.Prune();
+  s++;
+
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+
+  s.Prune();
+  s++;
+  BOOST_CHECK(!s.AtEnd());
+
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+
+  s.Prune();
+  s++;
+
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+
+  s.Prune();
+  s++;
+
+  // traverser shall be exhausted
+  s++;
+  BOOST_CHECK_EQUAL(0, s.GetStateLabel());
+  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK_EQUAL(0, s.GetDepth());
+  s++;
+  BOOST_CHECK_EQUAL(0, s.GetStateLabel());
+  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK_EQUAL(0, s.GetDepth());
+}
+
+BOOST_AUTO_TEST_CASE(zeroByte) {
+  std::vector<std::string> test_data1 = {
+      std::string("\0aaaa", 5),
+      "aabc",
+  };
+  testing::TempDictionary dictionary1(&test_data1);
+  automata_t f1 = dictionary1.GetFsa();
+  std::vector<std::string> test_data2 = {std::string("aa\0bb", 5), "aacd", std::string("bbcd\0", 5)};
+  testing::TempDictionary dictionary2(&test_data2);
+  automata_t f2 = dictionary2.GetFsa();
+
+  ZipStateTraverser<StateTraverser<>> s({f1, f2});
+
+  BOOST_CHECK_EQUAL('\0', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  BOOST_CHECK(!s.AtEnd());
+
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('\0', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('\0', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+
+  // traverser shall be exhausted
+  s++;
+  BOOST_CHECK_EQUAL(0, s.GetStateLabel());
+  BOOST_CHECK_EQUAL(0, s.GetDepth());
+  BOOST_CHECK(s.AtEnd());
+
+  s++;
+  BOOST_CHECK_EQUAL(0, s.GetStateLabel());
+  BOOST_CHECK_EQUAL(0, s.GetDepth());
+  BOOST_CHECK(s.AtEnd());
+}
+
 BOOST_AUTO_TEST_CASE(basic) {
   std::vector<std::string> test_data1 = {"aaaa", "aabb", "aabc", "aacd", "bbcd"};
   testing::TempDictionary dictionary1(&test_data1);

--- a/keyvi/tests/keyvi/dictionary/fsa/zip_state_traverser_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fsa/zip_state_traverser_test.cpp
@@ -203,6 +203,37 @@ BOOST_AUTO_TEST_CASE(mixed2) {
   BOOST_CHECK_EQUAL_COLLECTIONS(actual.begin(), actual.end(), expected.begin(), expected.end());
 }
 
+BOOST_AUTO_TEST_CASE(infixes) {
+  std::vector<std::string> test_data1 = {"aa", "bbb", "c", "zz"};
+  testing::TempDictionary dictionary1(&test_data1);
+  automata_t f1 = dictionary1.GetFsa();
+  std::vector<std::string> test_data2 = {"aaa", "bb", "hh", "jj"};
+  testing::TempDictionary dictionary2(&test_data2);
+  automata_t f2 = dictionary2.GetFsa();
+  std::vector<std::string> test_data3 = {"aaaa", "b", "ccc", "z"};
+  testing::TempDictionary dictionary3(&test_data3);
+  automata_t f3 = dictionary3.GetFsa();
+
+  ZipStateTraverser<StateTraverser<>> t({f1, f2, f3});
+
+  auto actual = GetAllKeys(&t);
+  std::vector<std::string> expected{"aa", "aaa", "aaaa", "b", "bb", "bbb", "c", "ccc", "hh", "jj", "z", "zz"};
+
+  BOOST_CHECK_EQUAL_COLLECTIONS(actual.begin(), actual.end(), expected.begin(), expected.end());
+
+  ZipStateTraverser<StateTraverser<>> t2({f3, f2, f1});
+  actual = GetAllKeys(&t2);
+  BOOST_CHECK_EQUAL_COLLECTIONS(actual.begin(), actual.end(), expected.begin(), expected.end());
+
+  ZipStateTraverser<StateTraverser<>> t3({f3, f2, f1});
+  actual = GetAllKeys(&t3);
+  BOOST_CHECK_EQUAL_COLLECTIONS(actual.begin(), actual.end(), expected.begin(), expected.end());
+
+  ZipStateTraverser<StateTraverser<>> t4({f3, f2, f1});
+  actual = GetAllKeys(&t4);
+  BOOST_CHECK_EQUAL_COLLECTIONS(actual.begin(), actual.end(), expected.begin(), expected.end());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 } /* namespace fsa */

--- a/keyvi/tests/keyvi/dictionary/fsa/zip_state_traverser_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fsa/zip_state_traverser_test.cpp
@@ -111,13 +111,11 @@ BOOST_AUTO_TEST_CASE(basic) {
 std::vector<std::string> GetAllKeys(ZipStateTraverser<StateTraverser<>> *zip_traverser) {
   std::vector<unsigned char> label_stack;
   std::vector<std::string> keys;
-  std::cout << "get all keys" << std::endl;
 
   while (*zip_traverser) {
     label_stack.resize(zip_traverser->GetDepth() - 1);
     label_stack.push_back(zip_traverser->GetStateLabel());
     if (zip_traverser->IsFinalState()) {
-      std::cout << "final: " << std::string(label_stack.begin(), label_stack.end()) << std::endl;
       keys.emplace_back(label_stack.begin(), label_stack.end());
     }
 

--- a/keyvi/tests/keyvi/dictionary/fsa/zip_state_traverser_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fsa/zip_state_traverser_test.cpp
@@ -1,0 +1,115 @@
+//
+// keyvi - A key value store.
+//
+// Copyright 2020 Hendrik Muhs<hendrik.muhs@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/*
+ * zip_state_traverser_test.cpp
+ *
+ *  Created on: Dev 18, 2020
+ *      Author: hendrik
+ */
+
+#include <memory>
+
+#include <boost/test/unit_test.hpp>
+
+#include "keyvi/dictionary/fsa/state_traverser.h"
+#include "keyvi/dictionary/fsa/zip_state_traverser.h"
+#include "keyvi/testing/temp_dictionary.h"
+
+// #define ENABLE_TRACING
+#include "keyvi/dictionary/util/trace.h"
+
+namespace keyvi {
+namespace dictionary {
+namespace fsa {
+
+BOOST_AUTO_TEST_SUITE(ZipStateTraverserTests)
+
+BOOST_AUTO_TEST_CASE(basic) {
+  std::vector<std::string> test_data1 = {"aaaa", "aabb", "aabc", "aacd", "bbcd"};
+  testing::TempDictionary dictionary1(&test_data1);
+  automata_t f1 = dictionary1.GetFsa();
+
+  std::vector<std::string> test_data2 = {"aaab", "aabb", "aabd", "abcd", "bbcd"};
+  testing::TempDictionary dictionary2(&test_data2);
+  automata_t f2 = dictionary2.GetFsa();
+
+  ZipStateTraverser<StateTraverser<>> t({f1, f2});
+
+  BOOST_CHECK_EQUAL('a', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, t.GetDepth());
+  t++;
+  BOOST_CHECK_EQUAL('a', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, t.GetDepth());
+  t++;
+  BOOST_CHECK_EQUAL('a', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, t.GetDepth());
+  t++;
+  BOOST_CHECK_EQUAL('a', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, t.GetDepth());
+  t++;
+  BOOST_CHECK_EQUAL('b', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, t.GetDepth());
+  t++;
+  BOOST_CHECK_EQUAL('b', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, t.GetDepth());
+  t++;
+  BOOST_CHECK_EQUAL('b', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, t.GetDepth());
+  t++;
+  BOOST_CHECK_EQUAL('c', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, t.GetDepth());
+  t++;
+  BOOST_CHECK_EQUAL('d', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, t.GetDepth());
+  t++;
+  BOOST_CHECK_EQUAL('c', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, t.GetDepth());
+  t++;
+  BOOST_CHECK_EQUAL('d', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, t.GetDepth());
+  t++;
+  BOOST_CHECK_EQUAL('b', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, t.GetDepth());
+  t++;
+  BOOST_CHECK_EQUAL('c', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, t.GetDepth());
+  t++;
+  BOOST_CHECK_EQUAL('d', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, t.GetDepth());
+  t++;
+  BOOST_CHECK_EQUAL('b', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, t.GetDepth());
+  t++;
+  BOOST_CHECK_EQUAL('b', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, t.GetDepth());
+  t++;
+  BOOST_CHECK_EQUAL('c', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, t.GetDepth());
+  t++;
+  BOOST_CHECK_EQUAL('d', t.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, t.GetDepth());
+  t++;
+  BOOST_CHECK(!t);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} /* namespace fsa */
+} /* namespace dictionary */
+} /* namespace keyvi */

--- a/keyvi/tests/keyvi/dictionary/matching/fuzzy_matching_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/matching/fuzzy_matching_test.cpp
@@ -36,6 +36,79 @@ namespace matching {
 
 BOOST_AUTO_TEST_SUITE(FuzzyMatchingTests)
 
+void test_fuzzy_matching(std::vector<std::pair<std::string, uint32_t>>* test_data, const std::string& query,
+                         size_t max_edit_distance, const std::vector<std::string> expected) {
+  testing::TempDictionary dictionary(test_data);
+
+  // test using weights
+  auto matcher_weights = std::make_shared<matching::FuzzyMatching<>>(
+      matching::FuzzyMatching<>::FromSingleFsa<>(dictionary.GetFsa(), query, max_edit_distance));
+
+  MatchIterator::MatchIteratorPair it = MatchIterator::MakeIteratorPair(
+      [matcher_weights]() { return matcher_weights->NextMatch(); }, matcher_weights->FirstMatch());
+
+  auto expected_it = expected.begin();
+  for (auto m : it) {
+    BOOST_CHECK(expected_it != expected.end());
+    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+  }
+
+  // test without weights
+  std::vector<std::string> expected_sorted = expected;
+  std::sort(expected_sorted.begin(), expected_sorted.end());
+
+  auto matcher_no_weights = std::make_shared<matching::FuzzyMatching<fsa::StateTraverser<>>>(
+      matching::FuzzyMatching<fsa::StateTraverser<>>::FromSingleFsa<fsa::StateTraverser<>>(dictionary.GetFsa(), query,
+                                                                                           max_edit_distance));
+  MatchIterator::MatchIteratorPair matcher_no_weights_it = MatchIterator::MakeIteratorPair(
+      [matcher_no_weights]() { return matcher_no_weights->NextMatch(); }, matcher_no_weights->FirstMatch());
+
+  expected_it = expected_sorted.begin();
+  for (auto m : matcher_no_weights_it) {
+    BOOST_CHECK(expected_it != expected_sorted.end());
+    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+  }
+  BOOST_CHECK(expected_it == expected_sorted.end());
+
+  // test with multiple dictionaries
+  // note: weighted traversal with multiple dictionaries is not implemented yet
+
+  // split test matcher_zipped_no_weights into 3 groups with some duplication
+  std::vector<std::pair<std::string, uint32_t>> test_data_1;
+  std::vector<std::pair<std::string, uint32_t>> test_data_2;
+  std::vector<std::pair<std::string, uint32_t>> test_data_3;
+
+  for (size_t i = 0; i < test_data->size(); ++i) {
+    if (i % 1 == 0 || i % 5 == 0) {
+      test_data_1.push_back((*test_data)[i]);
+    }
+    if (i % 2 == 0 || i == 3) {
+      test_data_2.push_back((*test_data)[i]);
+    }
+    if (i % 3 == 0) {
+      test_data_3.push_back((*test_data)[i]);
+    }
+  }
+  testing::TempDictionary d1(&test_data_1);
+  testing::TempDictionary d2(&test_data_2);
+  testing::TempDictionary d3(&test_data_3);
+  std::vector<fsa::automata_t> fsas = {d1.GetFsa(), d2.GetFsa(), d3.GetFsa()};
+
+  auto matcher_zipped_no_weights =
+      std::make_shared<matching::FuzzyMatching<fsa::ZipStateTraverser<fsa::StateTraverser<>>>>(
+          matching::FuzzyMatching<fsa::ZipStateTraverser<fsa::StateTraverser<>>>::FromMulipleFsas<
+              fsa::StateTraverser<>>(fsas, query, max_edit_distance));
+  MatchIterator::MatchIteratorPair matcher_zipped_no_weights_it =
+      MatchIterator::MakeIteratorPair([matcher_zipped_no_weights]() { return matcher_zipped_no_weights->NextMatch(); },
+                                      matcher_zipped_no_weights->FirstMatch());
+  expected_it = expected_sorted.begin();
+  for (auto m : matcher_zipped_no_weights_it) {
+    BOOST_CHECK(expected_it != expected_sorted.end());
+    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+  }
+  BOOST_CHECK(expected_it == expected_sorted.end());
+}
+
 BOOST_AUTO_TEST_CASE(fuzzy_0) {
   std::vector<std::pair<std::string, uint32_t>> test_data = {
       {"türkei news", 23698},
@@ -58,17 +131,8 @@ BOOST_AUTO_TEST_CASE(fuzzy_0) {
       {"tüs rheinland", 39131},
       {"tüs öffnungszeiten", 15999},
   };
-  testing::TempDictionary dictionary(&test_data);
-  dictionary_t d(new Dictionary(dictionary.GetFsa()));
 
-  std::vector<std::string> expected_output = {"tüv i"};
-
-  auto expected_it = expected_output.begin();
-  for (auto m : d->GetFuzzy("tüv i", 0)) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
-  }
-
-  BOOST_CHECK(expected_it == expected_output.end());
+  test_fuzzy_matching(&test_data, "tüv i", 0, std::vector<std::string>{"tüv i"});
 }
 
 BOOST_AUTO_TEST_CASE(fuzzy_1) {
@@ -95,21 +159,8 @@ BOOST_AUTO_TEST_CASE(fuzzy_1) {
       {"tüs rheinland", 39131},
       {"tüs öffnungszeiten", 15999},
   };
-  testing::TempDictionary dictionary(&test_data);
-  dictionary_t d(new Dictionary(dictionary.GetFsa()));
 
-  std::vector<std::string> expected_output = {
-      "tüv i",
-      "tüv ib",
-      "tüv in",
-  };
-
-  auto expected_it = expected_output.begin();
-  for (auto m : d->GetFuzzy("tüv in", 1)) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
-  }
-
-  BOOST_CHECK(expected_it == expected_output.end());
+  test_fuzzy_matching(&test_data, "tüv in", 1, std::vector<std::string>{"tüv i", "tüv ib", "tüv in"});
 }
 
 BOOST_AUTO_TEST_CASE(fuzzy_2) {
@@ -139,20 +190,8 @@ BOOST_AUTO_TEST_CASE(fuzzy_2) {
       {"tüs rheinland", 39131},
       {"tüs öffnungszeiten", 15999},
   };
-  testing::TempDictionary dictionary(&test_data);
-  dictionary_t d(new Dictionary(dictionary.GetFsa()));
 
-  std::vector<std::string> expected_output = {
-      "türkisch",
-      "tülkisc",
-  };
-
-  auto expected_it = expected_output.begin();
-  for (auto m : d->GetFuzzy("türkisch", 2)) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
-  }
-
-  BOOST_CHECK(expected_it == expected_output.end());
+  test_fuzzy_matching(&test_data, "türkisch", 2, std::vector<std::string>{"türkisch", "tülkisc"});
 }
 
 BOOST_AUTO_TEST_CASE(fuzzy_2_exact_minimum_prefix) {
@@ -179,21 +218,8 @@ BOOST_AUTO_TEST_CASE(fuzzy_2_exact_minimum_prefix) {
       {"tüs rheinland", 39131},
       {"tüs öffnungszeiten", 15999},
   };
-  testing::TempDictionary dictionary(&test_data);
-  dictionary_t d(new Dictionary(dictionary.GetFsa()));
 
-  std::vector<std::string> expected_output = {
-      "tü",
-      "tüv i",
-      "tüvk",
-  };
-
-  auto expected_it = expected_output.begin();
-  for (auto m : d->GetFuzzy("tü", 3)) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
-  }
-
-  BOOST_CHECK(expected_it == expected_output.end());
+  test_fuzzy_matching(&test_data, "tü", 3, std::vector<std::string>{"tü", "tüv i", "tüvk"});
 }
 
 BOOST_AUTO_TEST_CASE(fuzzy_5) {
@@ -223,105 +249,20 @@ BOOST_AUTO_TEST_CASE(fuzzy_5) {
       {"tüs rheinland", 39131},
       {"tüs öffnungszeiten", 15999},
       {"abcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", 42}};
-  testing::TempDictionary dictionary(&test_data);
-  dictionary_t d(new Dictionary(dictionary.GetFsa()));
 
-  std::vector<std::string> expected_output = {
-      "tüv i", "tüv ib", "tüv in", "türkei side", "türkisch", "türkisch für", "tülkisc",
-  };
+  test_fuzzy_matching(&test_data, "türkisch", 5,
+                      std::vector<std::string>{
+                          "tüv i",
+                          "tüv ib",
+                          "tüv in",
+                          "türkei side",
+                          "türkisch",
+                          "türkisch für",
+                          "tülkisc",
+                      });
 
-  auto expected_it = expected_output.begin();
-  for (auto m : d->GetFuzzy("türkisch", 5)) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
-  }
-
-  BOOST_CHECK(expected_it == expected_output.end());
-
-  std::vector<std::string> expected_output_long = {
-      "abcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
-  };
-
-  auto expected_it_long = expected_output_long.begin();
-  for (auto m : d->GetFuzzy("abcdefghijXXmnopqrstuvqxyzXXXDEFGHIJKLMNOPQRSTUVWXYZ", 5)) {
-    BOOST_CHECK_EQUAL(*expected_it_long++, m.GetMatchedString());
-  }
-
-  BOOST_CHECK(expected_it_long == expected_output_long.end());
-
-  auto data = std::make_shared<matching::FuzzyMatching<fsa::StateTraverser<>>>(
-      matching::FuzzyMatching<fsa::StateTraverser<>>::FromSingleFsa<fsa::StateTraverser<>>(dictionary.GetFsa(),
-                                                                                           "türkisch", 5));
-
-  auto func = [data]() { return data->NextMatch(); };
-  MatchIterator::MatchIteratorPair it = MatchIterator::MakeIteratorPair(func, data->FirstMatch());
-
-  std::sort(expected_output.begin(), expected_output.end());
-  expected_it = expected_output.begin();
-  for (auto m : it) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
-  }
-  BOOST_CHECK(expected_it == expected_output.end());
-}
-
-BOOST_AUTO_TEST_CASE(fuzzy_5_split) {
-  std::vector<std::pair<std::string, uint32_t>> test_data = {
-      {"türkei news", 23698},
-      {"türkei side", 18838},
-      {"türkei urlaub", 23424},
-      {"türkisch anfänger", 20788},
-      {"türisch anfänger", 20788},
-      {"tülkisc", 21654},
-      {"türkisch für", 21655},
-      {"türkisch für anfänger", 20735},
-      {"türkçe dublaj", 28575},
-      {"tüv nord", 46052},
-      {"tüs rhein", 462},
-      {"tüs rheinland", 39131},
-      {"tüs öffnungszeiten", 15999},
-      {"abcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", 42}};
-  testing::TempDictionary d1(&test_data);
-
-  std::vector<std::pair<std::string, uint32_t>> test_data2 = {
-      {"türkçe dublaj izle", 16391},
-      {"türkçe izle", 19946},
-      {"tüv akademie", 9557},
-      {"tüv hessen", 7744},
-      {"tüv jnohn", 334},
-      {"tüv jnack", 331},
-      {"tüv i", 331},
-      {"tüv in", 10188},
-      {"tüv ib", 10189},
-      {"tüv kosten", 11387},
-      {"tüv nord", 46052},
-      {"tüs rhein", 462},
-      {"abcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", 42}};
-  testing::TempDictionary d2(&test_data2);
-
-  std::vector<std::pair<std::string, uint32_t>> test_data3 = {{"türkisch", 21657},
-                                                              {"türkisch für", 21655},
-                                                              {"türkisch für anfänger", 20735},
-                                                              {"tüs rheinland", 39131},
-                                                              {"tüs öffnungszeiten", 15999}};
-  testing::TempDictionary d3(&test_data3);
-
-  // currenlty fuzzy matching is not possible with weighted traversers
-  std::vector<fsa::automata_t> fsas = {d1.GetFsa(), d2.GetFsa(), d3.GetFsa()};
-  auto data = std::make_shared<matching::FuzzyMatching<fsa::ZipStateTraverser<fsa::StateTraverser<>>>>(
-      matching::FuzzyMatching<fsa::ZipStateTraverser<fsa::StateTraverser<>>>::FromMulipleFsas<fsa::StateTraverser<>>(
-          fsas, "türkisch", 5));
-
-  auto func = [data]() { return data->NextMatch(); };
-  MatchIterator::MatchIteratorPair it = MatchIterator::MakeIteratorPair(func, data->FirstMatch());
-
-  std::vector<std::string> expected_output = {"tülkisc", "türkei side", "türkisch", "türkisch für",
-                                              "tüv i",   "tüv ib",      "tüv in"};
-
-  auto expected_it = expected_output.begin();
-  for (auto m : it) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
-  }
-
-  BOOST_CHECK(expected_it == expected_output.end());
+  test_fuzzy_matching(&test_data, "abcdefghijXXmnopqrstuvqxyzXXXDEFGHIJKLMNOPQRSTUVWXYZ", 5,
+                      std::vector<std::string>{"abcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"});
 }
 
 BOOST_AUTO_TEST_CASE(fuzzy_no_match) {
@@ -346,11 +287,7 @@ BOOST_AUTO_TEST_CASE(fuzzy_no_match) {
       {"tüs rheinland", 39131},
       {"tüs öffnungszeiten", 15999},
   };
-  testing::TempDictionary dictionary(&test_data);
-  dictionary_t d(new Dictionary(dictionary.GetFsa()));
-
-  auto iter = d->GetFuzzy("türkisch", 2);
-  BOOST_CHECK(iter.begin() == iter.end());
+  test_fuzzy_matching(&test_data, "türkisch", 2, std::vector<std::string>{});
 }
 
 BOOST_AUTO_TEST_CASE(fuzzy_empty_input) {
@@ -375,11 +312,7 @@ BOOST_AUTO_TEST_CASE(fuzzy_empty_input) {
       {"tüs rheinland", 39131},
       {"tüs öffnungszeiten", 15999},
   };
-  testing::TempDictionary dictionary(&test_data);
-  dictionary_t d(new Dictionary(dictionary.GetFsa()));
-
-  auto iter = d->GetFuzzy("", 7);
-  BOOST_CHECK(iter.begin() == iter.end());
+  test_fuzzy_matching(&test_data, "", 7, std::vector<std::string>{});
 }
 
 BOOST_AUTO_TEST_CASE(fuzzy_short_prefix) {
@@ -404,14 +337,8 @@ BOOST_AUTO_TEST_CASE(fuzzy_short_prefix) {
       {"üüs rheinland", 39131},
       {"üüs öffnungszeiten", 15999},
   };
-  testing::TempDictionary dictionary(&test_data);
-  dictionary_t d(new Dictionary(dictionary.GetFsa()));
-
-  const auto iter1 = d->GetFuzzy("t", 2);
-  BOOST_CHECK(iter1.begin() == iter1.end());
-
-  const auto iter2 = d->GetFuzzy("ü", 2);
-  BOOST_CHECK(iter2.begin() == iter2.end());
+  test_fuzzy_matching(&test_data, "t", 2, std::vector<std::string>{});
+  test_fuzzy_matching(&test_data, "ü", 2, std::vector<std::string>{});
 }
 
 BOOST_AUTO_TEST_CASE(fuzzy_cjk) {
@@ -422,21 +349,8 @@ BOOST_AUTO_TEST_CASE(fuzzy_cjk) {
   testing::TempDictionary dictionary(&test_data);
   dictionary_t d(new Dictionary(dictionary.GetFsa()));
 
-  std::vector<std::pair<std::string, uint32_t>> expected_output = {
-      {"あsだs", 2},
-      {"あsだsっd", 0},
-      {"あsだsっdさ", 1},
-      {"あsだsdさ", 2},
-  };
-
-  auto expected_it = expected_output.begin();
-  for (auto m : d->GetFuzzy("あsだsっd", 2)) {
-    BOOST_CHECK_EQUAL(expected_it->first, m.GetMatchedString());
-    BOOST_CHECK_EQUAL(expected_it->second, m.GetScore());
-    expected_it++;
-  }
-
-  BOOST_CHECK(expected_it == expected_output.end());
+  test_fuzzy_matching(&test_data, "あsだsっd", 2, std::vector<std::string>{"あsだs",
+      "あsだsっd", "あsだsっdさ", "あsだsdさ"});
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/keyvi/tests/keyvi/dictionary/matching/fuzzy_matching_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/matching/fuzzy_matching_test.cpp
@@ -22,9 +22,12 @@
  *      Author: Narek Gharibyan <narekgharibyan@gmail.com>
  */
 
+#include <algorithm>
+
 #include <boost/test/unit_test.hpp>
 
 #include "keyvi/dictionary/dictionary.h"
+#include "keyvi/dictionary/matching/fuzzy_matching.h"
 #include "keyvi/testing/temp_dictionary.h"
 
 namespace keyvi {
@@ -244,6 +247,81 @@ BOOST_AUTO_TEST_CASE(fuzzy_5) {
   }
 
   BOOST_CHECK(expected_it_long == expected_output_long.end());
+
+  auto data = std::make_shared<matching::FuzzyMatching<fsa::StateTraverser<>>>(
+      matching::FuzzyMatching<fsa::StateTraverser<>>::FromSingleFsa<fsa::StateTraverser<>>(dictionary.GetFsa(),
+                                                                                           "türkisch", 5));
+
+  auto func = [data]() { return data->NextMatch(); };
+  MatchIterator::MatchIteratorPair it = MatchIterator::MakeIteratorPair(func, data->FirstMatch());
+
+  std::sort(expected_output.begin(), expected_output.end());
+  expected_it = expected_output.begin();
+  for (auto m : it) {
+    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+  }
+  BOOST_CHECK(expected_it == expected_output.end());
+}
+
+BOOST_AUTO_TEST_CASE(fuzzy_5_split) {
+  std::vector<std::pair<std::string, uint32_t>> test_data = {
+      {"türkei news", 23698},
+      {"türkei side", 18838},
+      {"türkei urlaub", 23424},
+      {"türkisch anfänger", 20788},
+      {"türisch anfänger", 20788},
+      {"tülkisc", 21654},
+      {"türkisch für", 21655},
+      {"türkisch für anfänger", 20735},
+      {"türkçe dublaj", 28575},
+      {"tüv nord", 46052},
+      {"tüs rhein", 462},
+      {"tüs rheinland", 39131},
+      {"tüs öffnungszeiten", 15999},
+      {"abcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", 42}};
+  testing::TempDictionary d1(&test_data);
+
+  std::vector<std::pair<std::string, uint32_t>> test_data2 = {
+      {"türkçe dublaj izle", 16391},
+      {"türkçe izle", 19946},
+      {"tüv akademie", 9557},
+      {"tüv hessen", 7744},
+      {"tüv jnohn", 334},
+      {"tüv jnack", 331},
+      {"tüv i", 331},
+      {"tüv in", 10188},
+      {"tüv ib", 10189},
+      {"tüv kosten", 11387},
+      {"tüv nord", 46052},
+      {"tüs rhein", 462},
+      {"abcdefghijklmnopqrstuvqxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", 42}};
+  testing::TempDictionary d2(&test_data2);
+
+  std::vector<std::pair<std::string, uint32_t>> test_data3 = {{"türkisch", 21657},
+                                                              {"türkisch für", 21655},
+                                                              {"türkisch für anfänger", 20735},
+                                                              {"tüs rheinland", 39131},
+                                                              {"tüs öffnungszeiten", 15999}};
+  testing::TempDictionary d3(&test_data3);
+
+  // currenlty fuzzy matching is not possible with weighted traversers
+  std::vector<fsa::automata_t> fsas = {d1.GetFsa(), d2.GetFsa(), d3.GetFsa()};
+  auto data = std::make_shared<matching::FuzzyMatching<fsa::ZipStateTraverser<fsa::StateTraverser<>>>>(
+      matching::FuzzyMatching<fsa::ZipStateTraverser<fsa::StateTraverser<>>>::FromMulipleFsas<fsa::StateTraverser<>>(
+          fsas, "türkisch", 5));
+
+  auto func = [data]() { return data->NextMatch(); };
+  MatchIterator::MatchIteratorPair it = MatchIterator::MakeIteratorPair(func, data->FirstMatch());
+
+  std::vector<std::string> expected_output = {"tülkisc", "türkei side", "türkisch", "türkisch für",
+                                              "tüv i",   "tüv ib",      "tüv in"};
+
+  auto expected_it = expected_output.begin();
+  for (auto m : it) {
+    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+  }
+
+  BOOST_CHECK(expected_it == expected_output.end());
 }
 
 BOOST_AUTO_TEST_CASE(fuzzy_no_match) {

--- a/keyvi/tests/keyvi/dictionary/matching/fuzzy_matching_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/matching/fuzzy_matching_test.cpp
@@ -349,8 +349,8 @@ BOOST_AUTO_TEST_CASE(fuzzy_cjk) {
   testing::TempDictionary dictionary(&test_data);
   dictionary_t d(new Dictionary(dictionary.GetFsa()));
 
-  test_fuzzy_matching(&test_data, "あsだsっd", 2, std::vector<std::string>{"あsだs",
-      "あsだsっd", "あsだsっdさ", "あsだsdさ"});
+  test_fuzzy_matching(&test_data, "あsだsっd", 2,
+                      std::vector<std::string>{"あsだs", "あsだsっd", "あsだsっdさ", "あsだsdさ"});
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The current traverser objects only allow to traverse single dictionaries. However indexes consist of several segments==dictionaries. The ZipStateTraverser wraps a collection of traversers(e.g. a traverser per segment) providing a single traverser. Longer term this will allow fuzzy and completion matching on an index.