### PR TITLE
Fix memory limit calculation for memory limits > 99272 MB

### DIFF
--- a/keyvi/include/keyvi/dictionary/fsa/internal/lru_generation_cache.h
+++ b/keyvi/include/keyvi/dictionary/fsa/internal/lru_generation_cache.h
@@ -80,7 +80,7 @@ class LeastRecentlyUsedGenerationsCache final {
    */
   void Add(EntryT key) {
     if (current_generation_->Size() >= size_per_generation_) {
-      MinimizationHash<EntryT> *newGeneration = NULL;
+      MinimizationHash<EntryT> *newGeneration = nullptr;
       if (generations_.size() + 1 == max_number_of_generations_) {
         // remove(free) the first generation
         newGeneration = generations_[0];
@@ -90,7 +90,7 @@ class LeastRecentlyUsedGenerationsCache final {
 
       generations_.push_back(current_generation_);
 
-      if (newGeneration == NULL) {
+      if (newGeneration == nullptr) {
         newGeneration = new MinimizationHash<EntryT>();
       }
 

--- a/keyvi/include/keyvi/dictionary/fsa/internal/lru_generation_cache.h
+++ b/keyvi/include/keyvi/dictionary/fsa/internal/lru_generation_cache.h
@@ -48,9 +48,7 @@ class LeastRecentlyUsedGenerationsCache final {
   explicit LeastRecentlyUsedGenerationsCache(size_t memory_limit) {
     current_generation_ = new MinimizationHash<EntryT>();
 
-    auto memoryConfiguration =
-
-        current_generation_->FindMemoryLimitConfiguration(memory_limit, 3, 6);
+    auto memoryConfiguration = current_generation_->FindMemoryLimitConfigurationForLRUCache(memory_limit, 3, 6);
 
     size_per_generation_ = memoryConfiguration.best_fit_maximum_number_of_items_per_table;
     max_number_of_generations_ = memoryConfiguration.best_fit_generations;
@@ -68,21 +66,21 @@ class LeastRecentlyUsedGenerationsCache final {
 
   ~LeastRecentlyUsedGenerationsCache() {
     delete current_generation_;
-    for (MinimizationHash<EntryT>* generation : generations_) {
+    for (MinimizationHash<EntryT> *generation : generations_) {
       delete generation;
     }
   }
 
   LeastRecentlyUsedGenerationsCache() = delete;
-  LeastRecentlyUsedGenerationsCache& operator=(LeastRecentlyUsedGenerationsCache const&) = delete;
-  LeastRecentlyUsedGenerationsCache(const LeastRecentlyUsedGenerationsCache& that) = delete;
+  LeastRecentlyUsedGenerationsCache &operator=(LeastRecentlyUsedGenerationsCache const &) = delete;
+  LeastRecentlyUsedGenerationsCache(const LeastRecentlyUsedGenerationsCache &that) = delete;
 
   /** Add this object.
    * @param key The key to add
    */
   void Add(EntryT key) {
     if (current_generation_->Size() >= size_per_generation_) {
-      MinimizationHash<EntryT>* newGeneration = NULL;
+      MinimizationHash<EntryT> *newGeneration = NULL;
       if (generations_.size() + 1 == max_number_of_generations_) {
         // remove(free) the first generation
         newGeneration = generations_[0];
@@ -103,7 +101,7 @@ class LeastRecentlyUsedGenerationsCache final {
   }
 
   template <typename EqualityType>
-  const EntryT Get(EqualityType& key) {  // NOLINT
+  const EntryT Get(EqualityType &key) {  // NOLINT
     EntryT state = current_generation_->Get(key);
 
     if (!state.IsEmpty()) {
@@ -128,7 +126,7 @@ class LeastRecentlyUsedGenerationsCache final {
    */
   void Clear() {
     current_generation_->Clear();
-    for (MinimizationHash<EntryT>* generation : generations_) {
+    for (MinimizationHash<EntryT> *generation : generations_) {
       delete generation;
     }
     generations_.clear();
@@ -150,8 +148,8 @@ class LeastRecentlyUsedGenerationsCache final {
  private:
   size_t size_per_generation_;
   size_t max_number_of_generations_;
-  MinimizationHash<EntryT>* current_generation_;
-  std::vector<MinimizationHash<EntryT>*> generations_;
+  MinimizationHash<EntryT> *current_generation_;
+  std::vector<MinimizationHash<EntryT> *> generations_;
 };
 
 } /* namespace internal */

--- a/keyvi/include/keyvi/dictionary/fsa/internal/minimization_hash.h
+++ b/keyvi/include/keyvi/dictionary/fsa/internal/minimization_hash.h
@@ -95,7 +95,7 @@ class MinimizationHash final {
 
     if (min_memory_limit > memory_limit) {
       throw std::invalid_argument("memory limit too low, for the given parameters the limit must be at least " +
-                                  std::to_string(min_memory_limit));
+                                  std::to_string(min_memory_limit) + " bytes");
     }
 
     // try to find a good number of generations (between given minimum and maximum) with equal size given the memory

--- a/keyvi/include/keyvi/dictionary/fsa/internal/minimization_hash.h
+++ b/keyvi/include/keyvi/dictionary/fsa/internal/minimization_hash.h
@@ -26,6 +26,7 @@
 #define KEYVI_DICTIONARY_FSA_INTERNAL_MINIMIZATION_HASH_H_
 
 #include <algorithm>
+#include <stdexcept>
 
 // #define ENABLE_TRACING
 #include "keyvi/dictionary/util/trace.h"
@@ -82,11 +83,20 @@ class MinimizationHash final {
     }
   }
 
-  MemoryLimitConfiguration FindMemoryLimitConfiguration(const size_t memory_limit, const size_t min,
-                                                        const size_t max) const {
+  MemoryLimitConfiguration FindMemoryLimitConfigurationForLRUCache(const size_t memory_limit, const size_t min,
+                                                                   const size_t max) const {
     size_t best_fit_memory_limit = 0;
     size_t best_fit_generations = 0;
     size_t best_fit_maximum_number_of_items_per_table = 0;
+
+    const size_t min_memory_limit =
+        (hash_size_step_table_[hash_min_size_step_] + (hash_size_step_table_[hash_min_size_step_] >> 2)) * sizeof(T) *
+        min;
+
+    if (min_memory_limit > memory_limit) {
+      throw std::invalid_argument("memory limit too low, for the given parameters the limit must be at least " +
+                                  std::to_string(min_memory_limit));
+    }
 
     // try to find a good number of generations (between given minimum and maximum) with equal size given the memory
     // Limit
@@ -94,7 +104,7 @@ class MinimizationHash final {
       size_t maximum_number_of_items = 0;
 
       // find the value that fits to it in the HashmapSteptable
-      for (size_t step = 3; step < hash_max_size_step_; ++step) {
+      for (size_t step = hash_min_size_step_ + 1; step < hash_max_size_step_; ++step) {
         // the memory usage is the size of the hashtable itself and the size of the array for the overflow buckets which
         // is the number of buckets divided by 4.
         size_t item_forecast_for_hashtable =
@@ -113,12 +123,15 @@ class MinimizationHash final {
       if (usage > best_fit_memory_limit) {
         best_fit_memory_limit = usage;
         best_fit_generations = i;
-        best_fit_maximum_number_of_items_per_table = static_cast<int>(maximum_number_of_items * load_factor_);
+        best_fit_maximum_number_of_items_per_table = static_cast<size_t>(maximum_number_of_items * load_factor_);
       }
     }
 
     if (best_fit_maximum_number_of_items_per_table == 0) {
-      // todo: exception?
+      size_t maximum_number_of_items = hash_size_step_table_[hash_max_size_step_ - 1];
+      best_fit_memory_limit = (maximum_number_of_items + (maximum_number_of_items >> 2)) * sizeof(T) * max;
+      best_fit_generations = max;
+      best_fit_maximum_number_of_items_per_table = static_cast<size_t>(maximum_number_of_items * load_factor_);
     }
 
     return MemoryLimitConfiguration(best_fit_memory_limit, best_fit_generations,
@@ -167,7 +180,7 @@ class MinimizationHash final {
    * @return the equal state or an empty value
    */
   template <typename EqualityType>
-  inline const T Get(EqualityType& key) const {  // NOLINT
+  inline const T Get(EqualityType &key) const {  // NOLINT
     size_t hash = key.GetHashcode() & 0x7fffffff;
     size_t bucket = hash % hash_size_;
 
@@ -196,7 +209,7 @@ class MinimizationHash final {
    * @return the equal state or an empty value
    */
   template <typename EqualityType>
-  inline const T GetAndMove(EqualityType& key, MinimizationHash<T>* other) {  // NOLINT
+  inline const T GetAndMove(EqualityType &key, MinimizationHash<T> *other) {  // NOLINT
     size_t hash = key.GetHashcode() & 0x7fffffff;
     size_t bucket = hash % hash_size_;
     T entry = entries_[bucket];
@@ -285,15 +298,19 @@ class MinimizationHash final {
 
  private:
   /// magic constants definition of good hash table sizes
-  const size_t hash_size_step_table_[22] = {
-      997,     2029,    4079,    8171,     16363,    32749,    65519,     131041,    262127,    524269,     1048559,
-      2097133, 4194287, 8388587, 16777199, 33554393, 67108837, 134217689, 268435399, 536870879, 1073741789, 2147483629};
+  const size_t hash_size_step_table_[23] = {997,       2029,      4079,       8171,       16363,     32749,
+                                            65519,     131041,    262127,     524269,     1048559,   2097133,
+                                            4194287,   8388587,   16777199,   33554393,   67108837,  134217689,
+                                            268435399, 536870879, 1073741789, 2147483629, 4294967291};
 
   /// Load factor of the hash table, used to calculate the rehashLimit.
   const float load_factor_ = 0.6;
 
+  /// minimum size of the hash_table
+  const size_t hash_min_size_step_ = 1;
+
   /// maximum size of the hash table
-  const size_t hash_max_size_step_ = 21;
+  const size_t hash_max_size_step_ = 22;
 
   /// Size of hash table at construction
   size_t original_hash_size_step_ = 0;
@@ -308,10 +325,10 @@ class MinimizationHash final {
   size_t rehash_limit_ = 0;
 
   /// the actual data storage
-  T* entries_ = 0;
+  T *entries_ = 0;
 
   /// overflow data storage for colliding entries
-  T* overflow_entries_ = 0;
+  T *overflow_entries_ = 0;
 
   /// number of items in the data
   size_t count_ = 0;
@@ -382,10 +399,10 @@ class MinimizationHash final {
     hash_size_ = hash_size_step_table_[hash_size_step_];
     rehash_limit_ = static_cast<int>(hash_size_ * load_factor_);
 
-    T* old_entries = entries_;
+    T *old_entries = entries_;
     entries_ = new T[hash_size_];
 
-    T* old_overflow_entries = overflow_entries_;
+    T *old_overflow_entries = overflow_entries_;
     overflow_entries_size_ = std::min(hash_size_ >> 2, max_cookie_size_);
     overflow_entries_ = new T[overflow_entries_size_];
 

--- a/keyvi/tests/keyvi/dictionary/fsa/internal/json_value_store_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fsa/internal/json_value_store_test.cpp
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(minimization_largevalues) {
 
 BOOST_AUTO_TEST_CASE(minimization_largevalue_small_memory) {
   // combination of small value store and large values, spawning more than 1 chunk
-  JsonValueStore values(keyvi::util::parameters_t{{TEMPORARY_PATH_KEY, "/tmp"}, {"memory_limit", "50000"}});
+  JsonValueStore values(keyvi::util::parameters_t{{TEMPORARY_PATH_KEY, "/tmp"}, {"memory_limit", "500000"}});
   bool no_minimization = false;
   // create a value that almost fills the 1st chunk
   std::string padding_value = "{\"";


### PR DESCRIPTION
For memory limits > 99272 MB a bug in memory calculation triggered, resulting in super slow execution and loss of minimization. This change fixes the bug, ensuring the maximum possible configuration is returned and not configuration with `0`. It also allows creating an even bigger hashtable by adding another prime. LBNL the minimum memory limit is checked and an exception is thrown.

fixes #205 