### PR TITLE
fix gh style check action

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # fetch all history so multiple commits can be scanned
       - name: install deps
         run: |
           sudo apt-get update
@@ -28,4 +30,9 @@ jobs:
         with:
           packages: cpplint
       - name: run the style script
-        run: ./keyvi/check-style.sh
+        env:
+          GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}
+          GITHUB_PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          ./keyvi/check-style.sh

--- a/keyvi/check-style.sh
+++ b/keyvi/check-style.sh
@@ -2,7 +2,15 @@
 
 clang-format -version
 
-infiles=`git diff --name-only --diff-filter=ACMRT $(echo $TRAVIS_COMMIT_RANGE | sed 's/\.//') | grep -v "3rdparty" | grep -E "\.(cpp|h)$"`
+if [ -n "${GITHUB_PULL_REQUEST_BASE_SHA}" ]; then
+commit_range="${GITHUB_PULL_REQUEST_BASE_SHA}...${GITHUB_SHA}"
+elif [ -n "${GITHUB_PUSH_BASE_SHA}" ]; then
+commit_range="${GITHUB_PUSH_BASE_SHA}...${GITHUB_SHA}"
+else
+commit_range="upstream/master...HEAD"
+fi
+
+infiles=`git diff --name-only --diff-filter=ACMRT $(echo ${commit_range} | sed 's/\.//') | grep -v "3rdparty" | grep -E "\.(cpp|h)$"`
 
 clang_format_files=()
 cpplint_files=()


### PR DESCRIPTION
The style checks was still using a travis env variables which returned an empty set of files, making the check no do anything. This change uses gh action variables instead.