### PR TITLE
ZipStateTraverser: support state traversal with inner weights

### DIFF
--- a/keyvi/include/keyvi/dictionary/fsa/comparable_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/comparable_state_traverser.h
@@ -49,7 +49,11 @@ class ZipStateTraverser;
  * - track/record all states
  * - compare 2 traverser objects based on lexicographic order
  *
- * This traverser ignores inner weights, wrapping weighted state traverser for comparison is unspecified
+ * Specializations:
+ * - inner weights: compare 2 traverser objects based on inner weights
+ *
+ * Unsupported (yet):
+ * - near traverser
  */
 template <class innerTraverserType>
 class ComparableStateTraverser final {

--- a/keyvi/include/keyvi/dictionary/fsa/comparable_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/comparable_state_traverser.h
@@ -40,6 +40,9 @@ namespace keyvi {
 namespace dictionary {
 namespace fsa {
 
+template <class zipInnerTraverserType>
+class ZipStateTraverser;
+
 /**
  * Traverser wrapper that can be used to
  *
@@ -150,12 +153,14 @@ class ComparableStateTraverser final {
 
   traversal::TraversalPayload<transition_t> &GetTraversalPayload() { return state_traverser_.GetTraversalPayload(); }
 
-  traversal::TraversalState<transition_t> &GetStates() { return state_traverser_.GetStates(); }
-
  private:
   innerTraverserType state_traverser_;
   std::vector<label_t> label_stack_;
   size_t order_;
+
+  template <class zipInnerTraverserType>
+  friend class ZipStateTraverser;
+  traversal::TraversalState<transition_t> &GetStates() { return state_traverser_.GetStates(); }
 };
 
 inline bool CompareWeights(const traversal::TraversalState<traversal::WeightedTransition> &i,

--- a/keyvi/include/keyvi/dictionary/fsa/comparable_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/comparable_state_traverser.h
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "keyvi/dictionary/fsa/automata.h"
+#include "keyvi/dictionary/fsa/traverser_types.h"
 
 // #define ENABLE_TRACING
 #include "keyvi/dictionary/util/trace.h"
@@ -51,6 +52,7 @@ template <class innerTraverserType>
 class ComparableStateTraverser final {
  public:
   using label_t = typename innerTraverserType::label_t;
+  using transition_t = typename innerTraverserType::transition_t;
 
   explicit ComparableStateTraverser(const innerTraverserType &&traverser, const bool advance = true,
                                     const size_t order = 0)
@@ -135,7 +137,10 @@ class ComparableStateTraverser final {
 
   uint64_t GetStateId() const { return state_traverser_.GetStateId(); }
 
-  void Prune() { state_traverser_.Prune(); }
+  void Prune() {
+    state_traverser_.Prune();
+    label_stack_.pop_back();
+  }
 
   label_t GetStateLabel() const { return state_traverser_.GetStateLabel(); }
 
@@ -143,11 +148,51 @@ class ComparableStateTraverser final {
 
   size_t GetOrder() const { return order_; }
 
+  traversal::TraversalPayload<transition_t> &GetTraversalPayload() { return state_traverser_.GetTraversalPayload(); }
+
+  traversal::TraversalState<transition_t> &GetStates() { return state_traverser_.GetStates(); }
+
  private:
   innerTraverserType state_traverser_;
   std::vector<label_t> label_stack_;
   size_t order_;
 };
+
+inline bool CompareWeights(const traversal::TraversalState<traversal::WeightedTransition> &i,
+                           const traversal::TraversalState<traversal::WeightedTransition> &j) {
+  return i.GetNextInnerWeight() == j.GetNextInnerWeight();
+}
+
+template <>
+inline bool ComparableStateTraverser<WeightedStateTraverser>::operator<(const ComparableStateTraverser &rhs) const {
+  TRACE("operator< (weighted state specialization)");
+
+  TRACE("depth %ld %ld", state_traverser_.GetDepth(), rhs.state_traverser_.GetDepth());
+
+  if (state_traverser_.GetDepth() > 0 && rhs.state_traverser_.GetDepth() > 0) {
+    auto compare_weights = std::mismatch(state_traverser_.GetStack().traversal_states.begin(),
+                                         state_traverser_.GetStack().traversal_states.begin() +
+                                             std::min(state_traverser_.GetDepth(), rhs.state_traverser_.GetDepth()) - 1,
+                                         rhs.state_traverser_.GetStack().traversal_states.begin(), CompareWeights);
+    if ((*compare_weights.first).GetNextInnerWeight() != (*compare_weights.second).GetNextInnerWeight()) {
+      return (*compare_weights.first).GetNextInnerWeight() > (*compare_weights.second).GetNextInnerWeight();
+    }
+  }
+
+  int compare = std::memcmp(label_stack_.data(), rhs.label_stack_.data(),
+                            std::min(label_stack_.size(), rhs.label_stack_.size()) * sizeof(label_t));
+  if (compare != 0) {
+    return compare < 0;
+  }
+
+  if (label_stack_.size() != rhs.label_stack_.size()) {
+    TRACE("different sizes %ld vs %ld", label_stack_.size(), rhs.label_stack_.size());
+    return label_stack_.size() < rhs.label_stack_.size();
+  }
+
+  return order_ > rhs.order_;
+}
+
 } /* namespace fsa */
 } /* namespace dictionary */
 } /* namespace keyvi */

--- a/keyvi/include/keyvi/dictionary/fsa/state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/state_traverser.h
@@ -37,6 +37,9 @@ namespace keyvi {
 namespace dictionary {
 namespace fsa {
 
+template <class innerTraverserType>
+class ComparableStateTraverser;
+
 template <class TransitionT = traversal::Transition>
 class StateTraverser final {
  public:
@@ -152,12 +155,6 @@ class StateTraverser final {
 
   traversal::TraversalPayload<TransitionT> &GetTraversalPayload() { return stack_.traversal_stack_payload; }
 
-  // todo: maybe make it private/friend?
-  traversal::TraversalState<transition_t> &GetStates() { return stack_.GetStates(); }
-
-  // todo: only for comparable traverser, make private/friend?
-  const traversal::TraversalStack<TransitionT> &GetStack() const { return stack_; }
-
   operator bool() const { return !at_end_; }
 
   bool AtEnd() const { return at_end_; }
@@ -169,6 +166,12 @@ class StateTraverser final {
   label_t current_label_;
   bool at_end_;
   traversal::TraversalStack<TransitionT> stack_;
+
+  template <class innerTraverserType>
+  friend class ComparableStateTraverser;
+  const traversal::TraversalStack<TransitionT> &GetStack() const { return stack_; }
+
+  traversal::TraversalState<transition_t> &GetStates() { return stack_.GetStates(); }
 };
 
 } /* namespace fsa */

--- a/keyvi/include/keyvi/dictionary/fsa/state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/state_traverser.h
@@ -41,6 +41,7 @@ template <class TransitionT = traversal::Transition>
 class StateTraverser final {
  public:
   using label_t = unsigned char;
+  using transition_t = TransitionT;
 
   explicit StateTraverser(automata_t f)
       : fsa_(f), current_state_(f->GetStartState()), current_weight_(0), current_label_(0), at_end_(false), stack_() {
@@ -150,6 +151,12 @@ class StateTraverser final {
   label_t GetStateLabel() const { return current_label_; }
 
   traversal::TraversalPayload<TransitionT> &GetTraversalPayload() { return stack_.traversal_stack_payload; }
+
+  // todo: maybe make it private/friend?
+  traversal::TraversalState<transition_t> &GetStates() { return stack_.GetStates(); }
+
+  // todo: only for comparable traverser, make private/friend?
+  const traversal::TraversalStack<TransitionT> &GetStack() const { return stack_; }
 
   operator bool() const { return !at_end_; }
 

--- a/keyvi/include/keyvi/dictionary/fsa/traversal/traversal_base.h
+++ b/keyvi/include/keyvi/dictionary/fsa/traversal/traversal_base.h
@@ -114,6 +114,10 @@ struct TraversalStack {
 
   TraversalState<TransitionT>& GetStates() { return traversal_states[traversal_stack_payload.current_depth]; }
 
+  const TraversalState<TransitionT>& GetStates() const {
+    return traversal_states[traversal_stack_payload.current_depth];
+  }
+
   size_t GetDepth() const { return traversal_stack_payload.current_depth; }
 
   size_t& operator++() {

--- a/keyvi/include/keyvi/dictionary/fsa/zip_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/zip_state_traverser.h
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <cstring>
 #include <initializer_list>
+#include <map>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -36,6 +37,7 @@
 
 #include "keyvi/dictionary/fsa/automata.h"
 #include "keyvi/dictionary/fsa/comparable_state_traverser.h"
+#include "keyvi/dictionary/fsa/traverser_types.h"
 
 // #define ENABLE_TRACING
 #include "keyvi/dictionary/util/trace.h"
@@ -63,6 +65,7 @@ class ZipStateTraverser final {
 
  public:
   using label_t = typename innerTraverserType::label_t;
+  using transition_t = typename innerTraverserType::transition_t;
   using heap_t =
       boost::heap::skew_heap<traverser_t, boost::heap::compare<TraverserCompare>, boost::heap::mutable_<true>>;
   explicit ZipStateTraverser(const std::vector<automata_t> &fsas, const bool advance = true) {
@@ -133,10 +136,12 @@ class ZipStateTraverser final {
   void operator++(int) {
     TRACE("iterator++, forwarding %ld inner traversers", equal_states_);
 
+    PreIncrement();
+
     while (equal_states_ > 0) {
       // get the top element
       auto it = traverser_queue_.begin();
-
+      TRACE("++ iterator: %ld", (*it)->GetOrder());
       // advance the inner traverser and update or remove it from the queue
       (*it)->operator++(0);
       if (*(*it)) {
@@ -177,6 +182,7 @@ class ZipStateTraverser final {
       (*it++)->Prune();
       --to_prune;
     }
+    pruned = true;
   }
 
   label_t GetStateLabel() const { return state_label_; }
@@ -192,9 +198,13 @@ class ZipStateTraverser final {
   size_t order_;
   automata_t fsa_;
   size_t equal_states_ = 1;
+  bool pruned = false;
+
+  inline void PreIncrement() {}
 
   void FillInValues() {
     TRACE("fill in values");
+    pruned = false;
 
     if (!traverser_queue_.empty()) {
       const traverser_t &t = traverser_queue_.top();
@@ -216,7 +226,7 @@ class ZipStateTraverser final {
       it++;
 
       while (traverser_queue_.size() > equal_states_ && *t == *(*it)) {
-        TRACE("dedup");
+        TRACE("dedup top: %ld dup: %ld", order_, (*it)->GetOrder());
         equal_states_++;
         // if not final yet check if other states are final
         if (!final_ && (*it)->IsFinalState()) {
@@ -226,12 +236,9 @@ class ZipStateTraverser final {
           order_ = t->GetOrder();
         }
 
-        // take the max from inner weights
-        if ((*it)->GetInnerWeight() > inner_weight_) {
-          inner_weight_ = (*it)->GetInnerWeight();
-        }
         it++;
       }
+
     } else {
       // reset values
       final_ = false;
@@ -245,8 +252,228 @@ class ZipStateTraverser final {
   }
 };
 
-} /* namespace fsa */
-} /* namespace dictionary */
-} /* namespace keyvi */
+template <>
+inline void ZipStateTraverser<WeightedStateTraverser>::PreIncrement() {
+  TRACE("preincrement weighted state specialization");
+
+  // don't patch weight if prune has been called before
+  if (pruned) {
+    TRACE("prune called before, skipping");
+    return;
+  }
+
+  // patch weights if necessary
+  if (equal_states_ > 1) {
+    std::map<label_t, uint32_t> global_weights;
+
+    // 1st pass
+    auto it = traverser_queue_.ordered_begin();
+    size_t steps = equal_states_;
+
+    while (steps > 0) {
+      for (const transition_t &transition : (*it)->GetStates().traversal_state_payload.transitions) {
+        if (global_weights.count(transition.label) == 0 || global_weights.at(transition.label) < transition.weight) {
+          global_weights[transition.label] = transition.weight;
+        }
+      }
+      it++;
+      --steps;
+    }
+
+    // 2nd pass
+    it = traverser_queue_.ordered_begin();
+    steps = equal_states_;
+    while (steps > 0) {
+      for (transition_t &transition : (*it)->GetStates().traversal_state_payload.transitions) {
+        transition.weight = global_weights.at(transition.label);
+      }
+      // re-sort transitions
+      (*it)->GetStates().PostProcess(&(*it)->GetTraversalPayload());
+      it++;
+      --steps;
+    }
+  }
+}
+
+template <>
+inline ZipStateTraverser<WeightedStateTraverser>::ZipStateTraverser(const std::initializer_list<automata_t> fsas,
+                                                                    const bool advance) {
+  TRACE("construct  (weighted state specialization)");
+  size_t order = 0;
+
+  if (fsas.size() < 2) {
+    for (auto f : fsas) {
+      traverser_t traverser = std::make_shared<ComparableStateTraverser<WeightedStateTraverser>>(f, advance, order++);
+      // the traverser could be exhausted after it has been advanced
+      if (*traverser) {
+        traverser_queue_.push(traverser);
+      }
+    }
+  } else {
+    std::map<label_t, uint32_t> global_weights;
+    std::vector<traverser_t> traversers;
+
+    for (auto f : fsas) {
+      traverser_t traverser = std::make_shared<ComparableStateTraverser<WeightedStateTraverser>>(f, false, order++);
+      traversers.push_back(traverser);
+    }
+
+    // 1st pass collect all weights per label
+    for (const auto &t : traversers) {
+      for (const transition_t &transition : t->GetStates().traversal_state_payload.transitions) {
+        if (global_weights.count(transition.label) == 0 || global_weights.at(transition.label) < transition.weight) {
+          global_weights[transition.label] = transition.weight;
+        }
+      }
+    }
+    // 2nd pass apply global weights
+    for (const auto &t : traversers) {
+      for (transition_t &transition : t->GetStates().traversal_state_payload.transitions) {
+        transition.weight = global_weights.at(transition.label);
+      }
+      // re-sort transitions
+      t->GetStates().PostProcess(&t->GetTraversalPayload());
+
+      // now advance?
+      if (advance) {
+        t->operator++(0);
+      }
+      // the traverser could be exhausted after it has been advanced
+      if (*t) {
+        traverser_queue_.push(t);
+      }
+    }
+  }
+
+  FillInValues();
+}
+
+template <>
+inline ZipStateTraverser<WeightedStateTraverser>::ZipStateTraverser(const std::vector<automata_t> &fsas,
+                                                                    const bool advance) {
+  TRACE("construct  (weighted state specialization)");
+  size_t order = 0;
+
+  if (fsas.size() < 2) {
+    for (auto f : fsas) {
+      traverser_t traverser = std::make_shared<ComparableStateTraverser<WeightedStateTraverser>>(f, advance, order++);
+      // the traverser could be exhausted after it has been advanced
+      if (*traverser) {
+        traverser_queue_.push(traverser);
+      }
+    }
+  } else {
+    std::map<label_t, uint32_t> global_weights;
+    std::vector<traverser_t> traversers;
+
+    for (auto f : fsas) {
+      traverser_t traverser = std::make_shared<ComparableStateTraverser<WeightedStateTraverser>>(f, false, order++);
+      traversers.push_back(traverser);
+    }
+
+    // 1st pass collect all weights per label
+    for (const auto &t : traversers) {
+      for (const transition_t &transition : t->GetStates().traversal_state_payload.transitions) {
+        if (global_weights.count(transition.label) == 0 || global_weights.at(transition.label) < transition.weight) {
+          global_weights[transition.label] = transition.weight;
+        }
+      }
+    }
+    // 2nd pass apply global weights
+    for (const auto &t : traversers) {
+      for (transition_t &transition : t->GetStates().traversal_state_payload.transitions) {
+        transition.weight = global_weights.at(transition.label);
+      }
+      // re-sort transitions
+      t->GetStates().PostProcess(&t->GetTraversalPayload());
+
+      // now advance?
+      if (advance) {
+        t->operator++(0);
+      }
+      // the traverser could be exhausted after it has been advanced
+      if (*t) {
+        traverser_queue_.push(t);
+      }
+    }
+  }
+
+  FillInValues();
+}
+
+template <>
+inline ZipStateTraverser<WeightedStateTraverser>::ZipStateTraverser(
+    const std::vector<std::pair<automata_t, uint64_t>> &fsa_start_state_pairs, const bool advance) {
+  TRACE("construct  (weighted state specialization)");
+  size_t order = 0;
+
+  if (fsa_start_state_pairs.size() < 2) {
+    for (auto f : fsa_start_state_pairs) {
+      if (f.second > 0) {
+        traverser_t traverser =
+            std::make_shared<ComparableStateTraverser<WeightedStateTraverser>>(f.first, f.second, advance, order++);
+        // the traverser could be exhausted after it has been advanced
+        if (*traverser) {
+          traverser_queue_.push(traverser);
+        }
+      }
+    }
+  } else {
+    std::map<label_t, uint32_t> global_weights;
+    std::vector<traverser_t> traversers;
+    for (auto f : fsa_start_state_pairs) {
+      if (f.second > 0) {
+        TRACE("create traverser %ld %ld", f.first->GetStartState(), f.second);
+        traverser_t traverser =
+            std::make_shared<ComparableStateTraverser<WeightedStateTraverser>>(f.first, f.second, false, order++);
+        traversers.push_back(traverser);
+      }
+    }
+    TRACE("1st pass");
+    // 1st pass collect all weights per label
+    for (const auto &t : traversers) {
+      TRACE("reading %ld", t->GetOrder());
+
+      for (const transition_t &transition : t->GetStates().traversal_state_payload.transitions) {
+        if (global_weights.count(transition.label) == 0 || global_weights.at(transition.label) < transition.weight) {
+          global_weights[transition.label] = transition.weight;
+        }
+      }
+    }
+    TRACE("2nd pass");
+    // 2nd pass apply global weights
+    for (const auto &t : traversers) {
+      TRACE("patching %ld", t->GetOrder());
+
+      for (transition_t &transition : t->GetStates().traversal_state_payload.transitions) {
+        TRACE("patching %c from %ld to %ld", transition.label, transition.weight, global_weights.at(transition.label));
+        transition.weight = global_weights.at(transition.label);
+      }
+      TRACE("resort %ld", t->GetOrder());
+
+      // re-sort transitions
+      t->GetStates().PostProcess(&t->GetTraversalPayload());
+
+      // now advance?
+      if (advance) {
+        t->operator++(0);
+      }
+      TRACE("push %ld", t->GetOrder());
+
+      // the traverser could be exhausted after it has been advanced
+      if (*t) {
+        TRACE("push now %ld", t->GetOrder());
+        traverser_queue_.push(t);
+      }
+      TRACE("done push %ld", t->GetOrder());
+    }
+  }
+  TRACE("constructed");
+  FillInValues();
+}
+
+}  // namespace fsa
+}  // namespace dictionary
+}  // namespace keyvi
 
 #endif  // KEYVI_DICTIONARY_FSA_ZIP_STATE_TRAVERSER_H_

--- a/keyvi/tests/keyvi/dictionary/fsa/comparable_state_traverser_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fsa/comparable_state_traverser_test.cpp
@@ -125,12 +125,16 @@ BOOST_AUTO_TEST_CASE(StateTraverserCompatSomeTraversalWithPrune) {
   BOOST_CHECK_EQUAL(3, s.GetDepth());
 
   s.Prune();
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  BOOST_CHECK_EQUAL(2, s.GetStateLabels().size());
   s++;
 
   BOOST_CHECK_EQUAL('b', s.GetStateLabel());
   BOOST_CHECK_EQUAL(3, s.GetDepth());
 
   s.Prune();
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  BOOST_CHECK_EQUAL(2, s.GetStateLabels().size());
   s++;
   BOOST_CHECK(!s.AtEnd());
 
@@ -138,6 +142,8 @@ BOOST_AUTO_TEST_CASE(StateTraverserCompatSomeTraversalWithPrune) {
   BOOST_CHECK_EQUAL(3, s.GetDepth());
 
   s.Prune();
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  BOOST_CHECK_EQUAL(2, s.GetStateLabels().size());
   s++;
 
   BOOST_CHECK_EQUAL('b', s.GetStateLabel());
@@ -148,6 +154,8 @@ BOOST_AUTO_TEST_CASE(StateTraverserCompatSomeTraversalWithPrune) {
   s++;
 
   s.Prune();
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  BOOST_CHECK_EQUAL(2, s.GetStateLabels().size());
   s++;
 
   // traverser shall be exhausted

--- a/keyvi/tests/keyvi/dictionary/fsa/zip_state_traverser_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fsa/zip_state_traverser_test.cpp
@@ -683,6 +683,547 @@ BOOST_AUTO_TEST_CASE(after_prefix) {
   BOOST_CHECK_EQUAL_COLLECTIONS(actual2.begin(), actual2.end(), expected2.begin(), expected2.end());
 }
 
+BOOST_AUTO_TEST_CASE(weightedTraversal) {
+  std::vector<std::pair<std::string, uint32_t>> test_data1 = {
+      {"aabc", 412},
+      {"aabde", 22},
+      {"efde", 24},
+  };
+  testing::TempDictionary dictionary1(&test_data1);
+  automata_t f1 = dictionary1.GetFsa();
+
+  std::vector<std::pair<std::string, uint32_t>> test_data2 = {
+      {"cdbde", 444},
+      {"cdef", 34},
+      {"cdzzz", 56},
+      {"efde", 10},
+  };
+  testing::TempDictionary dictionary2(&test_data2);
+  automata_t f2 = dictionary2.GetFsa();
+
+  ZipStateTraverser<WeightedStateTraverser> s({f1, f2});
+
+  // we should get 'c' first
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('z', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('z', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('z', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('f', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('f', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  // traverser at the end
+  BOOST_CHECK_EQUAL(0, s.GetStateLabel());
+}
+
+BOOST_AUTO_TEST_CASE(weightedTraversal2) {
+  std::vector<std::pair<std::string, uint32_t>> test_data1 = {
+      {"aabc", 412},
+      {"aabde", 22},
+      {"efde", 24},
+  };
+  testing::TempDictionary dictionary1(&test_data1);
+  automata_t f1 = dictionary1.GetFsa();
+
+  std::vector<std::pair<std::string, uint32_t>> test_data2 = {
+      {"cdbde", 444},
+      {"cdef", 34},
+      {"cdzzz", 56},
+      {"efde", 10},
+  };
+  testing::TempDictionary dictionary2(&test_data2);
+  automata_t f2 = dictionary2.GetFsa();
+
+  std::vector<std::pair<std::string, uint32_t>> test_data3 = {
+      {"xyz", 99},
+      {"efde", 18},
+  };
+  testing::TempDictionary dictionary3(&test_data3);
+  automata_t f3 = dictionary3.GetFsa();
+
+  std::vector<std::pair<std::string, uint32_t>> test_data4 = {
+      {"pag", 2},
+      {"efde", 10},
+  };
+  testing::TempDictionary dictionary4(&test_data4);
+  automata_t f4 = dictionary4.GetFsa();
+
+  std::vector<std::pair<std::string, uint32_t>> test_data5 = {
+      {"efac", 21},
+  };
+  testing::TempDictionary dictionary5(&test_data5);
+  automata_t f5 = dictionary5.GetFsa();
+
+  ZipStateTraverser<WeightedStateTraverser> s({f1, f2, f3, f4, f5});
+
+  // we should get 'c' first
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+  s++;
+
+  BOOST_CHECK_EQUAL('z', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+  s++;
+
+  BOOST_CHECK_EQUAL('z', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+  s++;
+
+  BOOST_CHECK_EQUAL('z', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+  s++;
+
+  BOOST_CHECK_EQUAL('f', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+  s++;
+
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('x', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('y', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('z', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('f', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('p', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('g', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  // traverser at the end
+  BOOST_CHECK_EQUAL(0, s.GetStateLabel());
+}
+
+BOOST_AUTO_TEST_CASE(weightedTraversal3) {
+  std::vector<std::pair<std::string, uint32_t>> test_data1 = {
+      {"aabc", 42},
+      {"aabde", 42},
+      {"efde", 42},
+  };
+  testing::TempDictionary dictionary1(&test_data1);
+  automata_t f1 = dictionary1.GetFsa();
+
+  std::vector<std::pair<std::string, uint32_t>> test_data2 = {
+      {"cdbde", 42},
+      {"cdef", 42},
+      {"cdzzz", 42},
+      {"efde", 10},
+  };
+  testing::TempDictionary dictionary2(&test_data2);
+  automata_t f2 = dictionary2.GetFsa();
+
+  ZipStateTraverser<WeightedStateTraverser> s({f1, f2});
+
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('f', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('z', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('z', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('z', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('f', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  // traverser at the end
+  BOOST_CHECK_EQUAL(0, s.GetStateLabel());
+}
+
+BOOST_AUTO_TEST_CASE(weightedTraversal4) {
+  std::vector<std::pair<std::string, uint32_t>> test_data1 = {
+      {"aabc", 42},
+      {"aabde", 42},
+      {"efde", 42},
+  };
+  testing::TempDictionary dictionary1(&test_data1);
+  automata_t f1 = dictionary1.GetFsa();
+
+  std::vector<std::pair<std::string, uint32_t>> test_data2 = {
+      {"aabc", 99},
+      {"aabde", 99},
+      {"efde", 99},
+  };
+  testing::TempDictionary dictionary2(&test_data2);
+  automata_t f2 = dictionary2.GetFsa();
+
+  ZipStateTraverser<WeightedStateTraverser> s({f1, f2});
+
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('f', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  // traverser at the end
+  BOOST_CHECK_EQUAL(0, s.GetStateLabel());
+}
+
+BOOST_AUTO_TEST_CASE(weightedTraversal_with_prune) {
+  std::vector<std::pair<std::string, uint32_t>> test_data1 = {
+      {"aabc", 412},
+      {"aabde", 22},
+      {"efde", 24},
+  };
+  testing::TempDictionary dictionary1(&test_data1);
+  automata_t f1 = dictionary1.GetFsa();
+
+  std::vector<std::pair<std::string, uint32_t>> test_data2 = {
+      {"cdbde", 444},
+      {"cdef", 10},
+      {"cdzzz", 56},
+      {"efde", 5},
+  };
+  testing::TempDictionary dictionary2(&test_data2);
+  automata_t f2 = dictionary2.GetFsa();
+
+  std::vector<std::pair<std::string, uint32_t>> test_data3 = {
+      {"cdbde", 333},
+      {"cdef", 34},
+      {"cdzzz", 15},
+      {"efde", 10},
+  };
+  testing::TempDictionary dictionary3(&test_data3);
+  automata_t f3 = dictionary3.GetFsa();
+
+  std::vector<std::pair<std::string, uint32_t>> test_data4 = {
+      {"aabc", 1}, {"aabde", 2}, {"cdbde", 3}, {"cdef", 4}, {"cdzzz", 5}, {"efde", 6},
+  };
+  testing::TempDictionary dictionary4(&test_data4);
+  automata_t f4 = dictionary4.GetFsa();
+
+  ZipStateTraverser<WeightedStateTraverser> s({f1, f2, f3, f4});
+
+  // we should get 'c' first
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('z', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  s.Prune();
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  s.Prune();
+  s++;
+
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  s++;
+
+  s.Prune();
+  s++;
+
+  BOOST_CHECK_EQUAL('d', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('e', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+
+  BOOST_CHECK_EQUAL('f', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+
+  s.Prune();
+  s++;
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 } /* namespace fsa */


### PR DESCRIPTION
This change add support for weighted state traversal in comparable/zip state traverser. This is the 1st step in order to support completions with inner weights from keyvi indexes.

When combining the traversers, inner weights have to be normalized, that means a global weight map has to be created and transitions need to be sorted the same way for all inner traversers. This can be expensive, however as segments get merged quite quickly, this is probably only a problem for the 1st levels in the tree.