### PR TITLE
Fix near traversal for non ascii characters

### DIFF
--- a/keyvi/include/keyvi/dictionary/fsa/traversal/near_traversal.h
+++ b/keyvi/include/keyvi/dictionary/fsa/traversal/near_traversal.h
@@ -79,10 +79,11 @@ template <>
 inline void TraversalState<NearTransition>::Add(uint64_t s, unsigned char l,
                                                 TraversalPayload<NearTransition>* payload) {
   // check exact match
-  TRACE("Add %c depth %d, exact %c", l, payload->current_depth, payload->lookup_key[payload->current_depth]);
+  TRACE("Add %d depth %d, exact %d", l, payload->current_depth,
+        static_cast<const unsigned char>(payload->lookup_key->operator[](payload->current_depth)));
 
   if (payload->exact && payload->current_depth < payload->lookup_key->size() &&
-      payload->lookup_key->operator[](payload->current_depth) == l) {
+      static_cast<const unsigned char>(payload->lookup_key->operator[](payload->current_depth)) == l) {
     // fill in and set position 0, so that we start traversal there
     TRACE("Found exact match");
     traversal_state_payload.position = 0;

--- a/keyvi/tests/keyvi/dictionary/fsa/traversal/near_traversal_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fsa/traversal/near_traversal_test.cpp
@@ -143,6 +143,65 @@ BOOST_AUTO_TEST_CASE(someTraversalNoPrune) {
   BOOST_CHECK_EQUAL(0, s.GetDepth());
 }
 
+BOOST_AUTO_TEST_CASE(nonAscii) {
+  std::vector<std::string> test_data = {"aaaa", "aa\xa0\x62\x62", "aa\xff\x62\x63"};
+  testing::TempDictionary dictionary(&test_data);
+  automata_t f = dictionary.GetFsa();
+
+  std::shared_ptr<std::string> near_key = std::make_shared<std::string>("aa\xa0\x63\x64");
+  auto payload = traversal::TraversalPayload<traversal::NearTransition>(near_key);
+
+  StateTraverser<traversal::NearTransition> s(f, f->GetStartState(), std::move(payload));
+
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+  BOOST_CHECK_EQUAL(0xa0, s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+  s++;
+  BOOST_CHECK_EQUAL(0xff, s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+
+  s++;
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+
+  // traverser shall be exhausted
+  s++;
+  BOOST_CHECK_EQUAL(0, s.GetStateLabel());
+  BOOST_CHECK_EQUAL(0, s.GetDepth());
+  s++;
+  BOOST_CHECK_EQUAL(0, s.GetStateLabel());
+  BOOST_CHECK_EQUAL(0, s.GetDepth());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 } /* namespace fsa */

--- a/keyvi/tests/keyvi/dictionary/fsa/zip_state_traverser_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fsa/zip_state_traverser_test.cpp
@@ -1261,6 +1261,90 @@ BOOST_AUTO_TEST_CASE(nearTraversal) {
   s++;
 }
 
+BOOST_AUTO_TEST_CASE(nonAscii) {
+  std::vector<std::string> test_data1 = {"aaaa", "aa\xa0\x62\x62"};
+  testing::TempDictionary dictionary1(&test_data1);
+  automata_t f1 = dictionary1.GetFsa();
+
+  std::vector<std::string> test_data2 = {"abbb", "aa\xff\x62\x63"};
+  testing::TempDictionary dictionary2(&test_data2);
+  automata_t f2 = dictionary2.GetFsa();
+
+  std::shared_ptr<std::string> near_key = std::make_shared<std::string>("aa\xa0\x63\x64");
+
+  auto payload1 = traversal::TraversalPayload<traversal::NearTransition>(near_key);
+  auto payload2 = traversal::TraversalPayload<traversal::NearTransition>(near_key);
+
+  std::vector<std::tuple<automata_t, uint64_t, traversal::TraversalPayload<traversal::NearTransition>>> v;
+
+  v.emplace_back(f1, f1->GetStartState(), std::move(payload1));
+  v.emplace_back(f2, f2->GetStartState(), std::move(payload2));
+
+  ZipStateTraverser<NearStateTraverser> s(std::move(v));
+
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(1, s.GetDepth());
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  s++;
+  BOOST_CHECK_EQUAL(0xa0, s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+  s++;
+  BOOST_CHECK_EQUAL('a', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+  s++;
+  BOOST_CHECK_EQUAL(0xff, s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+  s++;
+  BOOST_CHECK_EQUAL('c', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(5, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(2, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(3, s.GetDepth());
+  BOOST_CHECK(!s.IsFinalState());
+  s++;
+  BOOST_CHECK_EQUAL('b', s.GetStateLabel());
+  BOOST_CHECK_EQUAL(4, s.GetDepth());
+  BOOST_CHECK(s.IsFinalState());
+
+  // traverser shall be exhausted
+  s++;
+  BOOST_CHECK_EQUAL(0, s.GetStateLabel());
+  BOOST_CHECK_EQUAL(0, s.GetDepth());
+  s++;
+  BOOST_CHECK_EQUAL(0, s.GetStateLabel());
+  BOOST_CHECK_EQUAL(0, s.GetDepth());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 } /* namespace fsa */


### PR DESCRIPTION
near traversal did not follow the exact path for non-ascii characters due to a type mismatch when comparing: unsigned char vs char