### PR TITLE
portable c-char in dictionary.rs

### DIFF
--- a/rust/src/dictionary.rs
+++ b/rust/src/dictionary.rs
@@ -80,7 +80,7 @@ impl Dictionary {
         let ptr = unsafe {
             root::keyvi_dictionary_get_prefix_completions(
                 self.dict,
-                key.as_ptr() as *const i8,
+                key.as_ptr() as *const ::std::os::raw::c_char,
                 key.len() as u64,
                 cutoff,
             )
@@ -92,7 +92,7 @@ impl Dictionary {
         let ptr = unsafe {
             root::keyvi_dictionary_get_fuzzy(
                 self.dict,
-                key.as_ptr() as *const i8,
+                key.as_ptr() as *const ::std::os::raw::c_char,
                 key.len() as u64,
                 max_edit_distance,
             )
@@ -104,7 +104,7 @@ impl Dictionary {
         let ptr = unsafe {
             root::keyvi_dictionary_get_multi_word_completions(
                 self.dict,
-                key.as_ptr() as *const i8,
+                key.as_ptr() as *const ::std::os::raw::c_char,
                 key.len() as u64,
                 cutoff,
             )


### PR DESCRIPTION
`char` type is not specifically defined. It can be signed or unsigned depends
on architecture.

On x86 `char` is signed but on some ARM platforms char can be signed or unsigned.

```

int main() {
  char c = -1;

  if (c > 0)
      printf("c is positive \n");  // Docker container on Apple M1
  else
      printf("c is negative \n");  // Native Apple M1
}

```

The output will be "c is negative" on Apple M1 and "c is positibe" on linux
docker container on Apple M1.

Let's use `c_char` which is portable.

More details:
https://developer.arm.com/documentation/den0013/d/Porting/Miscellaneous-C-porting-issues/unsigned-char-and-signed-char
https://doc.rust-lang.org/std/os/raw/type.c_char.html

<!--
Thank you for contributing to keyvi!

Before submission, please ensure that you have read and agree to our 
contributor guidelines: https://github.com/KeyviDev/keyvi/blob/master/CONTRIBUTING.md.

Please delete these lines.
-->
