### PR TITLE
Added missing include and link dir to make CI green again 

### DIFF
--- a/keyvi/include/keyvi/util/os_utils.h
+++ b/keyvi/include/keyvi/util/os_utils.h
@@ -31,6 +31,7 @@
 #endif
 
 #include <cstddef>
+#include <fstream>
 #include <stdexcept>
 #include <string>
 #include <vector>

--- a/python/setup.py
+++ b/python/setup.py
@@ -213,7 +213,10 @@ with symlink_keyvi() as (pykeyvi_source_path, keyvi_source_path):
     if pykeyvi_source_path is not None:
         additional_compile_flags += ' -fdebug-prefix-map={}={}'.format(pykeyvi_source_path, keyvi_source_path)
 
-    link_library_dirs = [keyvi_build_dir]
+    link_library_dirs = [
+        keyvi_build_dir,
+        '/usr/local/lib/',
+    ]
 
     #########################
     # Custom 'build' command

--- a/python/setup.py
+++ b/python/setup.py
@@ -215,7 +215,7 @@ with symlink_keyvi() as (pykeyvi_source_path, keyvi_source_path):
 
     link_library_dirs = [
         keyvi_build_dir,
-        '/usr/local/lib/',
+        '/usr/local/lib/',  # as of 17/07/2022 Python 3.10 build on GH actions needs this link library dir
     ]
 
     #########################

--- a/python/setup.py
+++ b/python/setup.py
@@ -215,7 +215,7 @@ with symlink_keyvi() as (pykeyvi_source_path, keyvi_source_path):
 
     link_library_dirs = [
         keyvi_build_dir,
-        '/usr/local/lib/',  # as of 17/07/2022 Python 3.10 build on GH actions needs this link library dir
+        '/usr/local/lib/',  # as of 17/07/2022 Python 3.10 build on GH actions needs '/usr/local/lib/' link library dir
     ]
 
     #########################


### PR DESCRIPTION
<!--
Thank you for contributing to keyvi!

Before submission, please ensure that you have read and agree to our 
contributor guidelines: https://github.com/KeyviDev/keyvi/blob/master/CONTRIBUTING.md.

Please delete these lines.
-->


This PR adds missing:
 - `#include` statement 
 - link library dir for python 3.10

to make CI green again. 
