### PR TITLE
Build keyvi for arm as well

### DIFF
--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -48,11 +48,10 @@ jobs:
 
 
       - name: Publish package
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ matrix.manylinux_image }}
-          options: -v ${{ github.workspace }}:/repo -e PYTHON_PATH=${{ matrix.python_path }} PYPI_PASSWORD=${{ secrets.pypi_password }} PYTHON_PATH=${{ matrix.python_path }}
+          options: -v ${{ github.workspace }}:/repo -e PYTHON_PATH=${{ matrix.python_path }} -e PYPI_PASSWORD=${{ secrets.pypi_password }} -e PYTHON_PATH=${{ matrix.python_path }}
           run: |
             PYBIN=/opt/python/${PYTHON_PATH}/bin
-            ${PYBIN}/python -m twine upload -u __token__ -p "${PYPI_PASSWORD}" /repo/python/wheelhouse/*
+            ${PYBIN}/python -m twine upload --repository testpypi -u __token__ -p "${PYPI_PASSWORD}" /repo/python/wheelhouse/*

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -54,4 +54,5 @@ jobs:
           options: -v ${{ github.workspace }}:/repo -e PYTHON_PATH=${{ matrix.python_path }} -e PYPI_PASSWORD=${{ secrets.pypi_password }} -e PYTHON_PATH=${{ matrix.python_path }}
           run: |
             PYBIN=/opt/python/${PYTHON_PATH}/bin
+            ${PYBIN}/pip install twine
             ${PYBIN}/python -m twine upload --repository testpypi -u __token__ -p "${PYPI_PASSWORD}" /repo/python/wheelhouse/*

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python_path: [ cp37-cp37m, cp38-cp38, cp39-cp39, cp310-cp310 ]
-        arch_image: [ keyvidev/manylinux-builder-x86_64 keyvidev/manylinux-builder-aarch64 ]
+        arch_image: [ keyvidev/manylinux-builder-x86_64, keyvidev/manylinux-builder-aarch64 ]
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -11,10 +11,11 @@ jobs:
     strategy:
       matrix:
         python_path: [ cp37-cp37m, cp38-cp38, cp39-cp39, cp310-cp310 ]
+        arch_image: [ keyvidev/manylinux-builder-x86_64 keyvidev/manylinux-builder-aarch64 ]
 
     runs-on: ubuntu-latest
     container:
-      image: keyvidev/manylinux-builder
+      image: ${{ matrix.arch_image }}
       env:
         PYTHON_PATH: ${{ matrix.python_path }}
     steps:

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -48,6 +48,7 @@ jobs:
 
 
       - name: Publish package
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ matrix.manylinux_image }}
@@ -55,4 +56,4 @@ jobs:
           run: |
             PYBIN=/opt/python/${PYTHON_PATH}/bin
             ${PYBIN}/pip install twine
-            ${PYBIN}/python -m twine upload --repository testpypi -u __token__ -p "${PYPI_PASSWORD}" /repo/python/wheelhouse/*
+            ${PYBIN}/python -m twine upload -u __token__ -p "${PYPI_PASSWORD}" /repo/python/wheelhouse/*

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -48,9 +48,10 @@ jobs:
 
       - name: Publish package
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        env:
-          PYPI_PASSWORD: ${{ secrets.pypi_password }}
-          PYTHON_PATH: ${{ matrix.python_path }}
-        run: |
-          PYBIN=/opt/python/${PYTHON_PATH}/bin
-          ${PYBIN}/python -m twine upload -u __token__ -p "${PYPI_PASSWORD}" python/wheelhouse/*
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ matrix.arch_image }}
+          options: -v ${{ github.workspace }}:/repo -e PYTHON_PATH=${{ matrix.python_path }} PYPI_PASSWORD=${{ secrets.pypi_password }} PYTHON_PATH=${{ matrix.python_path }}
+          run: |
+            PYBIN=/opt/python/${PYTHON_PATH}/bin
+            ${PYBIN}/python -m twine upload -u __token__ -p "${PYPI_PASSWORD}" python/wheelhouse/*

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -52,7 +52,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ matrix.manylinux_image }}
-          options: -v ${{ github.workspace }}:/repo -e PYTHON_PATH=${{ matrix.python_path }} -e PYPI_PASSWORD=${{ secrets.pypi_password }} -e PYTHON_PATH=${{ matrix.python_path }}
+          options: -v ${{ github.workspace }}:/repo -e PYTHON_PATH=${{ matrix.python_path }} -e PYPI_PASSWORD=${{ secrets.pypi_password }}
           run: |
             PYBIN=/opt/python/${PYTHON_PATH}/bin
             ${PYBIN}/pip install twine

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -14,39 +14,43 @@ jobs:
         arch_image: [ keyvidev/manylinux-builder-x86_64, keyvidev/manylinux-builder-aarch64 ]
 
     runs-on: ubuntu-latest
-    container:
-      image: ${{ matrix.arch_image }}
-      env:
-        PYTHON_PATH: ${{ matrix.python_path }}
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - uses: actions/checkout@v2
       - name: Build manylinux package
-        run: |
-          cd python
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ${{ matrix.arch_image }}
+          options: -v ${{ github.workspace }}:/repo -e PYTHON_PATH=${{ matrix.python_path }}
 
-          PYBIN=/opt/python/${PYTHON_PATH}/bin
+          run: |
+            cd /repo/python
 
-          ${PYBIN}/pip install -r requirements.txt
+            PYBIN=/opt/python/${PYTHON_PATH}/bin
 
-          # Build
-          ${PYBIN}/python setup.py bdist_wheel -d dist
+            ${PYBIN}/pip install -r requirements.txt
 
-          # Bundle external shared libraries into the wheels
-          for wheel in dist/*.whl; do
-              auditwheel repair ${wheel} -w wheelhouse/
-          done
+            # Build
+            ${PYBIN}/python setup.py bdist_wheel -d dist
 
-          # Install and test
-          ${PYBIN}/pip install keyvi --no-index -f wheelhouse/
+            # Bundle external shared libraries into the wheels
+            for wheel in dist/*.whl; do
+                auditwheel repair ${wheel} -w wheelhouse/
+            done
 
-          cd ~
-          ${PYBIN}/py.test ${GITHUB_WORKSPACE}/python/tests/
-          ${PYBIN}/py.test ${GITHUB_WORKSPACE}/python/integration-tests/
+            # Install and test
+            ${PYBIN}/pip install keyvi --no-index -f wheelhouse/
+
+            cd ~
+            ${PYBIN}/py.test /repo/python/tests/
+            ${PYBIN}/py.test /repo/python/integration-tests/
 
       - name: Publish package
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         env:
           PYPI_PASSWORD: ${{ secrets.pypi_password }}
+          PYTHON_PATH: ${{ matrix.python_path }}
         run: |
           PYBIN=/opt/python/${PYTHON_PATH}/bin
           ${PYBIN}/python -m twine upload -u __token__ -p "${PYPI_PASSWORD}" python/wheelhouse/*

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python_path: [ cp37-cp37m, cp38-cp38, cp39-cp39, cp310-cp310 ]
-        arch_image: [ keyvidev/manylinux-builder-x86_64, keyvidev/manylinux-builder-aarch64 ]
+        manylinux_image: [ keyvidev/manylinux-builder-x86_64, keyvidev/manylinux-builder-aarch64 ]
 
     runs-on: ubuntu-latest
     steps:
@@ -21,7 +21,7 @@ jobs:
       - name: Build manylinux package
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ matrix.arch_image }}
+          image: ${{ matrix.manylinux_image }}
           options: -v ${{ github.workspace }}:/repo -e PYTHON_PATH=${{ matrix.python_path }}
 
           run: |
@@ -46,12 +46,13 @@ jobs:
             ${PYBIN}/py.test /repo/python/tests/
             ${PYBIN}/py.test /repo/python/integration-tests/
 
+
       - name: Publish package
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: addnab/docker-run-action@v3
         with:
-          image: ${{ matrix.arch_image }}
+          image: ${{ matrix.manylinux_image }}
           options: -v ${{ github.workspace }}:/repo -e PYTHON_PATH=${{ matrix.python_path }} PYPI_PASSWORD=${{ secrets.pypi_password }} PYTHON_PATH=${{ matrix.python_path }}
           run: |
             PYBIN=/opt/python/${PYTHON_PATH}/bin
-            ${PYBIN}/python -m twine upload -u __token__ -p "${PYPI_PASSWORD}" python/wheelhouse/*
+            ${PYBIN}/python -m twine upload -u __token__ -p "${PYPI_PASSWORD}" /repo/python/wheelhouse/*


### PR DESCRIPTION
* Use the `aarch64` and `x86_64` images from #254 to actually build `linux/aarch64` and `linux/x86_64` wheels of `keyvi`
* Docker uses [QEMU](https://www.qemu.org) to run containers with images of different architecture, so there's a `docker/setup-qemu-action@v2`
* The docker images used in the build are now specified in the matrix. That's why there's no `container` entry in the job anymore and we need to actually bring the `addnab/docker-run-action@v3` in order to run different images from the matrix in the job