### PR TITLE
Fix - remove build artifacts between mac os builds

### DIFF
--- a/python/build_macosx_wheels.sh
+++ b/python/build_macosx_wheels.sh
@@ -17,6 +17,9 @@ do
     echo "Installing keyvi python deps..."
     pip install -r requirements.txt
 
+    echo "Removing existing build artifacts..."
+    rm -rf _core.cpp _core.pyi _core.pyx _core_p.cpp .pytest_cache/ build/
+
     echo "Building binary wheels..."
     pip wheel . -w wheelhouse/ --no-deps -vvv
     delocate-wheel wheelhouse/*.whl


### PR DESCRIPTION
Apparently some build artifacts are not compatible between Python version, like Cython generated code. 

This PR removes build artifacts between different versions, so all wheels are build in one script execution.  