### PR TITLE
Fix small access issue for near traversal

### DIFF
--- a/keyvi/include/keyvi/dictionary/fsa/state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/state_traverser.h
@@ -153,8 +153,6 @@ class StateTraverser final {
 
   label_t GetStateLabel() const { return current_label_; }
 
-  traversal::TraversalPayload<TransitionT> &GetTraversalPayload() { return stack_.traversal_stack_payload; }
-
   operator bool() const { return !at_end_; }
 
   bool AtEnd() const { return at_end_; }
@@ -172,6 +170,8 @@ class StateTraverser final {
   const traversal::TraversalStack<TransitionT> &GetStack() const { return stack_; }
 
   traversal::TraversalState<transition_t> &GetStates() { return stack_.GetStates(); }
+
+  traversal::TraversalPayload<TransitionT> &GetTraversalPayload() { return stack_.traversal_stack_payload; }
 
   const traversal::TraversalPayload<TransitionT> &GetTraversalPayload() const { return stack_.traversal_stack_payload; }
 };


### PR DESCRIPTION
fixes a small issue in state traverser, there was a public GetTraversalPayload, but that is is not intended. It used by a near traversal which has access via friend. So most likely this is some development leftover (removing the method does not work, it is needed).