### PR TITLE
switch to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake_mo
 
 #### Compiler Flags ####
 
-# configure C++11
-set(CMAKE_CXX_STANDARD 11)
+# configure C++17
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # keyvi specific compile options, definitions and flags
@@ -207,7 +207,7 @@ add_custom_target(bindings
 string(REPLACE ";" " " _KEYVI_INCLUDES "${KEYVI_INCLUDES}")
 
 # compile flags
-set(_KEYVI_CXX_FLAGS_ALL "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE_UPPER}} ${_KEYVI_CXX_FLAGS} ${_KEVYI_COMPILE_OPTIONS} -std=c++11")
+set(_KEYVI_CXX_FLAGS_ALL "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE_UPPER}} ${_KEYVI_CXX_FLAGS} ${_KEVYI_COMPILE_OPTIONS} -std=c++17")
 
 configure_file(keyvi/flags.cmake keyvi/flags)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ##
 [![BuildBadge](https://github.com/KeyviDev/keyvi/workflows/Build%20keyvi/badge.svg)](https://github.com/KeyviDev/keyvi/actions)
-[![C++](https://img.shields.io/badge/C%2B%2B-11-blue.svg)](/keyvi/README.md)
+[![C++](https://img.shields.io/badge/C%2B%2B-17-blue.svg)](/keyvi/README.md)
 [![PythonVersions](https://img.shields.io/pypi/pyversions/keyvi.svg)](https://pypi.python.org/pypi/keyvi/)
 [![PythonImpl](https://img.shields.io/pypi/implementation/keyvi.svg)](https://pypi.python.org/pypi/keyvi/)
 [![PythonFormat](https://img.shields.io/pypi/format/keyvi.svg)](https://pypi.python.org/pypi/keyvi/)

--- a/keyvi/.clang-format
+++ b/keyvi/.clang-format
@@ -2,10 +2,11 @@
 BasedOnStyle: Google
 ColumnLimit: '120'
 Language: Cpp
-Standard: Cpp11
+Standard: c++17
 TabWidth: '2'
 UseTab: Never
 ConstructorInitializerIndentWidth: 4
 AllowShortFunctionsOnASingleLine: Inline
+IncludeBlocks: Preserve
 
 ...

--- a/keyvi/include/keyvi/dictionary/matching/near_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/near_matching.h
@@ -103,10 +103,9 @@ class NearMatching final {
 
     auto payload = fsa::traversal::TraversalPayload<fsa::traversal::NearTransition>(near_key);
 
-    // todo: switch to make_unique, requires C++14
-    std::unique_ptr<fsa::ComparableStateTraverser<fsa::NearStateTraverser>> traverser;
-    traverser.reset(
-        new fsa::ComparableStateTraverser<fsa::NearStateTraverser>(fsa, start_state, std::move(payload), true, 0));
+    std::unique_ptr<fsa::ComparableStateTraverser<fsa::NearStateTraverser>> traverser =
+        std::make_unique<fsa::ComparableStateTraverser<fsa::NearStateTraverser>>(fsa, start_state, std::move(payload),
+                                                                                 true, 0);
 
     return NearMatching(std::move(traverser), std::move(first_match), query.substr(0, exact_prefix), greedy);
   }
@@ -155,9 +154,8 @@ class NearMatching final {
       }
     }
 
-    // todo: switch to make_unique, requires C++14
-    std::unique_ptr<fsa::ZipStateTraverser<fsa::NearStateTraverser>> traverser;
-    traverser.reset(new fsa::ZipStateTraverser<fsa::NearStateTraverser>(std::move(fsa_start_state_payloads)));
+    std::unique_ptr<fsa::ZipStateTraverser<fsa::NearStateTraverser>> traverser =
+        std::make_unique<fsa::ZipStateTraverser<fsa::NearStateTraverser>>(std::move(fsa_start_state_payloads));
 
     return NearMatching<fsa::ZipStateTraverser<fsa::NearStateTraverser>>(std::move(traverser), std::move(first_match),
                                                                          query.substr(0, exact_prefix), greedy);

--- a/keyvi/tests/keyvi/vector/basic_test.cpp
+++ b/keyvi/tests/keyvi/vector/basic_test.cpp
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(wrong_value_store) {
   TempVectorGenerator<JsonVectorGenerator> temp_vector;
   temp_vector.WriteToFile();
 
-  BOOST_CHECK_THROW(std::move(StringVector(temp_vector.filename)), std::invalid_argument);
+  BOOST_CHECK_THROW(StringVector v(temp_vector.filename), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(truncation) {
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(truncation) {
   truncated_file.write(file_content.data(), file_size - 1);
   truncated_file.close();
 
-  BOOST_CHECK_THROW(std::move(JsonVector(truncated_filename)), std::invalid_argument);
+  BOOST_CHECK_THROW(JsonVector v(truncated_filename), std::invalid_argument);
 
   boost::filesystem::remove(truncated_filename);
 }


### PR DESCRIPTION
switches to C++17 to be able to use make_unique and other features from C++14 and beyond.

According to cibuildwheel [docs](https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/) C++17 should be possible with the builders we are using, C++20 however is not supported yet.