### PR TITLE
Implement multiword completions with fuzzy matching support

### DIFF
--- a/keyvi/include/keyvi/dictionary/dictionary.h
+++ b/keyvi/include/keyvi/dictionary/dictionary.h
@@ -400,7 +400,7 @@ class Dictionary final {
 
   MatchIterator::MatchIteratorPair GetFuzzyMultiwordCompletion(const std::string& query,
                                                                const int32_t max_edit_distance,
-                                                               const size_t minimum_exact_prefix = 2,
+                                                               const size_t minimum_exact_prefix = 0,
                                                                const unsigned char multiword_separator = 0x1b) const {
     auto data = std::make_shared<matching::FuzzyMultiwordCompletionMatching<>>(
         matching::FuzzyMultiwordCompletionMatching<>::FromSingleFsa(fsa_, query, max_edit_distance,

--- a/keyvi/include/keyvi/dictionary/dictionary.h
+++ b/keyvi/include/keyvi/dictionary/dictionary.h
@@ -37,6 +37,7 @@
 #include "keyvi/dictionary/match.h"
 #include "keyvi/dictionary/match_iterator.h"
 #include "keyvi/dictionary/matching/fuzzy_matching.h"
+#include "keyvi/dictionary/matching/fuzzy_multiword_completion_matching.h"
 #include "keyvi/dictionary/matching/multiword_completion_matching.h"
 #include "keyvi/dictionary/matching/near_matching.h"
 #include "keyvi/dictionary/matching/prefix_completion_matching.h"
@@ -395,6 +396,20 @@ class Dictionary final {
     return MatchIterator::MakeIteratorPair(
         func, data->FirstMatch(),
         std::bind(&matching::MultiwordCompletionMatching<>::SetMinWeight, &(*data), std::placeholders::_1));
+  }
+
+  MatchIterator::MatchIteratorPair GetFuzzyMultiwordCompletion(const std::string& query,
+                                                               const int32_t max_edit_distance,
+                                                               const size_t minimum_exact_prefix = 2,
+                                                               const unsigned char multiword_separator = 0x1b) const {
+    auto data = std::make_shared<matching::FuzzyMultiwordCompletionMatching<>>(
+        matching::FuzzyMultiwordCompletionMatching<>::FromSingleFsa(fsa_, query, max_edit_distance,
+                                                                    minimum_exact_prefix, multiword_separator));
+
+    auto func = [data]() { return data->NextMatch(); };
+    return MatchIterator::MakeIteratorPair(
+        func, data->FirstMatch(),
+        std::bind(&matching::FuzzyMultiwordCompletionMatching<>::SetMinWeight, &(*data), std::placeholders::_1));
   }
 
   std::string GetManifest() const { return fsa_->GetManifest(); }

--- a/keyvi/include/keyvi/dictionary/fsa/codepoint_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/codepoint_state_traverser.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "keyvi/dictionary/fsa/automata.h"
+#include "keyvi/dictionary/fsa/traverser_types.h"
 #include "keyvi/dictionary/util/utf8_utils.h"
 
 // #define ENABLE_TRACING
@@ -130,6 +131,15 @@ class CodePointStateTraverser final {
 
   operator bool() const { return wrapped_state_traverser_; }
 
+  /**
+   * Set the minimum weight states must be greater or equal to.
+   *
+   * Only available for WeightedTransition specialization.
+   *
+   * @param weight minimum transition weight
+   */
+  inline void SetMinWeight(uint32_t weight) {}
+
  private:
   innerTraverserType wrapped_state_traverser_;
   std::vector<int> transitions_stack_;
@@ -177,6 +187,16 @@ class CodePointStateTraverser final {
     }
   }
 };
+
+/**
+ * Set the minimum weight states must be greater or equal to.
+ *
+ * @param weight minimum transition weight
+ */
+template <>
+inline void CodePointStateTraverser<WeightedStateTraverser>::SetMinWeight(uint32_t weight) {
+  wrapped_state_traverser_.SetMinWeight(weight);
+}
 
 } /* namespace fsa */
 } /* namespace dictionary */

--- a/keyvi/include/keyvi/dictionary/matching/fuzzy_multiword_completion_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/fuzzy_multiword_completion_matching.h
@@ -209,6 +209,11 @@ class FuzzyMultiwordCompletionMatching final {
       uint64_t label = traverser_ptr_->GetStateLabel();
       TRACE("label [%c] prefix length %ld traverser depth: %ld", label, prefix_length_, traverser_ptr_->GetDepth());
 
+      while (token_start_positions_.size() > 0 && traverser_ptr_->GetDepth() <= token_start_positions_.back()) {
+        TRACE("pop token stack");
+        token_start_positions_.pop_back();
+      }
+
       if (label == multiword_separator_) {
         TRACE("found MW boundary at %d", traverser_ptr_->GetDepth());
         if (token_start_positions_.size() != number_of_tokens_ - 1) {
@@ -224,11 +229,6 @@ class FuzzyMultiwordCompletionMatching final {
         // reset the multiword boundary if we went up
         multiword_boundary_ = 0;
         TRACE("reset MW boundary at %d %d", traverser_ptr_->GetDepth(), multiword_boundary_);
-      }
-
-      if (token_start_positions_.size() > 0 && traverser_ptr_->GetDepth() <= token_start_positions_.back()) {
-        TRACE("pop token stack");
-        token_start_positions_.pop_back();
       }
 
       // only match up to the number of tokens in input

--- a/keyvi/include/keyvi/dictionary/matching/fuzzy_multiword_completion_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/fuzzy_multiword_completion_matching.h
@@ -65,7 +65,7 @@ class FuzzyMultiwordCompletionMatching final {
    */
   static FuzzyMultiwordCompletionMatching FromSingleFsa(const fsa::automata_t& fsa, const std::string& query,
                                                         const int32_t max_edit_distance,
-                                                        const size_t minimum_exact_prefix = 2,
+                                                        const size_t minimum_exact_prefix = 0,
                                                         const unsigned char multiword_separator = 0x1b) {
     return FromSingleFsa(fsa, fsa->GetStartState(), query, max_edit_distance, minimum_exact_prefix,
                          multiword_separator);
@@ -181,7 +181,6 @@ class FuzzyMultiwordCompletionMatching final {
       return FuzzyMultiwordCompletionMatching();
     }
 
-    size_t depth = 0;
     // fill the metric
     for (size_t utf8_depth = 0; utf8_depth < minimum_exact_prefix; ++utf8_depth) {
       metric->Put(codepoints[utf8_depth], utf8_depth);

--- a/keyvi/include/keyvi/dictionary/matching/fuzzy_multiword_completion_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/fuzzy_multiword_completion_matching.h
@@ -80,7 +80,7 @@ class FuzzyMultiwordCompletionMatching final {
    */
   static FuzzyMultiwordCompletionMatching FromSingleFsa(const fsa::automata_t& fsa, const uint64_t start_state,
                                                         const std::string& query, const int32_t max_edit_distance,
-                                                        const size_t minimum_exact_prefix = 2,
+                                                        const size_t minimum_exact_prefix = 0,
                                                         const unsigned char multiword_separator = 0x1b) {
     if (start_state == 0) {
       return FuzzyMultiwordCompletionMatching();
@@ -142,7 +142,7 @@ class FuzzyMultiwordCompletionMatching final {
    */
   static FuzzyMultiwordCompletionMatching FromMulipleFsas(const std::vector<fsa::automata_t>& fsas,
                                                           const std::string& query, const int32_t max_edit_distance,
-                                                          const size_t minimum_exact_prefix = 2,
+                                                          const size_t minimum_exact_prefix = 0,
                                                           const unsigned char multiword_separator = 0x1b) {
     size_t number_of_tokens;
     std::string query_bow = util::Transform::BagOfWordsPartial(query, number_of_tokens);

--- a/keyvi/include/keyvi/dictionary/matching/fuzzy_multiword_completion_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/fuzzy_multiword_completion_matching.h
@@ -108,8 +108,7 @@ class FuzzyMultiwordCompletionMatching final {
           break;
         }
       }
-      auto s = metric->Put(codepoints[depth], depth);
-      TRACE("s %d", s);
+      metric->Put(codepoints[depth], depth);
       ++depth;
     }
 

--- a/keyvi/include/keyvi/dictionary/matching/fuzzy_multiword_completion_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/fuzzy_multiword_completion_matching.h
@@ -251,7 +251,7 @@ class FuzzyMultiwordCompletionMatching final {
 
       if (traverser_ptr_->IsFinalState()) {
         std::string match_str = multiword_boundary_ > 0
-                                    ? distance_metric_->GetCandidate().substr(prefix_length_ + multiword_boundary_)
+                                    ? distance_metric_->GetCandidate(prefix_length_ + multiword_boundary_)
                                     : distance_metric_->GetCandidate();
 
         TRACE("found final state at depth %d %s", prefix_length_ + traverser_ptr_->GetDepth(), match_str.c_str());

--- a/keyvi/include/keyvi/dictionary/matching/fuzzy_multiword_completion_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/fuzzy_multiword_completion_matching.h
@@ -1,0 +1,307 @@
+/* keyvi - A key value store.
+ *
+ * Copyright 2024 Hendrik Muhs<hendrik.muhs@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * fuzzy_multiword_completion_matching.h
+ */
+
+#ifndef KEYVI_DICTIONARY_MATCHING_FUZZY_MULTIWORD_COMPLETION_MATCHING_H_
+#define KEYVI_DICTIONARY_MATCHING_FUZZY_MULTIWORD_COMPLETION_MATCHING_H_
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "keyvi/dictionary/fsa/automata.h"
+#include "keyvi/dictionary/fsa/codepoint_state_traverser.h"
+#include "keyvi/dictionary/fsa/traverser_types.h"
+#include "keyvi/dictionary/fsa/zip_state_traverser.h"
+#include "keyvi/dictionary/match.h"
+#include "keyvi/dictionary/util/transform.h"
+#include "keyvi/dictionary/util/utf8_utils.h"
+#include "keyvi/stringdistance/levenshtein.h"
+#include "utf8.h"
+
+// #define ENABLE_TRACING
+#include "keyvi/dictionary/util/trace.h"
+
+namespace keyvi {
+namespace index {
+namespace internal {
+template <class MatcherT, class DeletedT>
+keyvi::dictionary::Match NextFilteredMatchSingle(const MatcherT&, const DeletedT&);
+template <class MatcherT, class DeletedT>
+keyvi::dictionary::Match NextFilteredMatch(const MatcherT&, const DeletedT&);
+}  // namespace internal
+}  // namespace index
+namespace dictionary {
+namespace matching {
+
+template <class innerTraverserType = fsa::CodePointStateTraverser<fsa::WeightedStateTraverser>>
+class FuzzyMultiwordCompletionMatching final {
+ public:
+  /**
+   * Create a fuzzy multiword completer from a single Fsa
+   *
+   * @param fsa the fsa
+   * @param query the query
+   */
+  static FuzzyMultiwordCompletionMatching FromSingleFsa(const fsa::automata_t& fsa, const std::string& query,
+                                                        const int32_t max_edit_distance,
+                                                        const size_t minimum_exact_prefix = 2,
+                                                        const unsigned char multiword_separator = 0x1b) {
+    return FromSingleFsa(fsa, fsa->GetStartState(), query, max_edit_distance, minimum_exact_prefix,
+                         multiword_separator);
+  }
+
+  /**
+   * Create a fuzzy multiword completer from a single Fsa
+   *
+   * @param fsa the fsa
+   * @param start_state the state to start from
+   * @param query the query
+   */
+  static FuzzyMultiwordCompletionMatching FromSingleFsa(const fsa::automata_t& fsa, const uint64_t start_state,
+                                                        const std::string& query, const int32_t max_edit_distance,
+                                                        const size_t minimum_exact_prefix = 2,
+                                                        const unsigned char multiword_separator = 0x1b) {
+    if (start_state == 0) {
+      return FuzzyMultiwordCompletionMatching();
+    }
+    size_t number_of_tokens;
+    std::string query_bow = util::Transform::BagOfWordsPartial(query, number_of_tokens);
+
+    std::vector<uint32_t> codepoints;
+    utf8::unchecked::utf8to32(query_bow.begin(), query_bow.end(), back_inserter(codepoints));
+    const size_t query_length = codepoints.size();
+    size_t exact_prefix = std::min(query_length, minimum_exact_prefix);
+
+    std::unique_ptr<stringdistance::LevenshteinCompletion> metric =
+        std::make_unique<stringdistance::LevenshteinCompletion>(codepoints, 20, max_edit_distance);
+
+    size_t depth = 0;
+    uint64_t state = start_state;
+    size_t utf8_depth = 0;
+    // match exact
+    while (state != 0 && depth != exact_prefix) {
+      const size_t code_point_length = util::Utf8Utils::GetCharLength(query[utf8_depth]);
+      for (size_t i = 0; i < code_point_length; ++i, ++utf8_depth) {
+        state = fsa->TryWalkTransition(state, query[utf8_depth]);
+        if (0 == state) {
+          break;
+        }
+      }
+      auto s = metric->Put(codepoints[depth], depth);
+      TRACE("s %d", s);
+      ++depth;
+    }
+
+    if (state == 0) {
+      return FuzzyMultiwordCompletionMatching();
+    }
+
+    TRACE("matched prefix, length %d", depth);
+
+    std::unique_ptr<innerTraverserType> traverser = std::make_unique<innerTraverserType>(fsa, state);
+
+    Match first_match;
+    if (depth == query_length && fsa->IsFinalState(state)) {
+      TRACE("first_match %d %s", query_length, query);
+      first_match = Match(0, query_length, query, 0, fsa, fsa->GetStateValue(state));
+    }
+
+    return FuzzyMultiwordCompletionMatching(std::move(traverser), std::move(first_match), std::move(metric),
+                                            max_edit_distance, minimum_exact_prefix, number_of_tokens,
+                                            multiword_separator);
+  }
+
+  /**
+   * Create a fuzzy multiword completer from multiple Fsas
+   *
+   * @param fsas a vector of fsas
+   * @param query the query
+   */
+  static FuzzyMultiwordCompletionMatching FromMulipleFsas(const std::vector<fsa::automata_t>& fsas,
+                                                          const std::string& query, const int32_t max_edit_distance,
+                                                          const size_t minimum_exact_prefix = 2,
+                                                          const unsigned char multiword_separator = 0x1b) {
+    size_t number_of_tokens;
+    std::string query_bow = util::Transform::BagOfWordsPartial(query, number_of_tokens);
+
+    std::vector<uint32_t> codepoints;
+    utf8::unchecked::utf8to32(query_bow.begin(), query_bow.end(), back_inserter(codepoints));
+    const size_t query_length = codepoints.size();
+    size_t exact_prefix = std::min(query_length, minimum_exact_prefix);
+
+    std::unique_ptr<stringdistance::LevenshteinCompletion> metric =
+        std::make_unique<stringdistance::LevenshteinCompletion>(codepoints, 20, max_edit_distance);
+
+    std::vector<std::pair<fsa::automata_t, uint64_t>> fsa_start_state_pairs;
+
+    // match the exact prefix on all fsas
+    for (const fsa::automata_t& fsa : fsas) {
+      uint64_t state = fsa->GetStartState();
+      size_t depth, utf8_depth = 0;
+
+      while (state != 0 && depth != exact_prefix) {
+        const size_t code_point_length = util::Utf8Utils::GetCharLength(query[utf8_depth]);
+        for (size_t i = 0; i < code_point_length; ++i, ++utf8_depth) {
+          state = fsa->TryWalkTransition(state, query[utf8_depth]);
+          if (0 == state) {
+            break;
+          }
+        }
+        ++depth;
+      }
+
+      if (state != 0) {
+        fsa_start_state_pairs.emplace_back(fsa, state);
+      }
+    }
+
+    if (fsa_start_state_pairs.size() == 0) {
+      return FuzzyMultiwordCompletionMatching();
+    }
+
+    size_t depth = 0;
+    // fill the metric
+    for (size_t utf8_depth = 0; utf8_depth < exact_prefix; ++utf8_depth) {
+      metric->Put(codepoints[utf8_depth], utf8_depth);
+    }
+
+    Match first_match;
+    // check for a match given the exact prefix
+    for (const auto& fsa_state : fsa_start_state_pairs) {
+      if (fsa_state.first->IsFinalState(fsa_state.second)) {
+        first_match =
+            Match(0, query_length, query, 0, fsa_state.first, fsa_state.first->GetStateValue(fsa_state.second));
+        break;
+      }
+    }
+
+    std::unique_ptr<innerTraverserType> traverser = std::make_unique<innerTraverserType>(fsa_start_state_pairs);
+
+    return FuzzyMultiwordCompletionMatching(std::move(traverser), std::move(first_match), std::move(metric),
+                                            minimum_exact_prefix, number_of_tokens, multiword_separator);
+  }
+
+  Match FirstMatch() const { return first_match_; }
+
+  Match NextMatch() {
+    for (; traverser_ptr_ && *traverser_ptr_; (*traverser_ptr_)++) {
+      uint64_t label = traverser_ptr_->GetStateLabel();
+      TRACE("label [%c] prefix length %ld traverser depth: %ld", label, prefix_length_, traverser_ptr_->GetDepth());
+
+      if (label == multiword_separator_) {
+        TRACE("found MW boundary at %d", traverser_ptr_->GetDepth());
+        if (token_start_positions_.size() != number_of_tokens_ - 1) {
+          TRACE("found MW boundary before seeing enough tokens (%d/%d)", token_start_positions_.size(),
+                number_of_tokens_);
+          traverser_ptr_->Prune();
+          TRACE("pruned, now at %d", traverser_ptr_->GetDepth());
+          continue;
+        }
+
+        multiword_boundary_ = traverser_ptr_->GetDepth();
+      } else if (traverser_ptr_->GetDepth() <= multiword_boundary_) {
+        // reset the multiword boundary if we went up
+        multiword_boundary_ = 0;
+        TRACE("reset MW boundary at %d %d", traverser_ptr_->GetDepth(), multiword_boundary_);
+      }
+
+      if (token_start_positions_.size() > 0 && traverser_ptr_->GetDepth() <= token_start_positions_.back()) {
+        TRACE("pop token stack");
+        token_start_positions_.pop_back();
+      }
+
+      // only match up to the number of tokens in input
+      if (label == 0x20 && multiword_boundary_ == 0) {
+        TRACE("push space(%d)", token_start_positions_.size());
+        token_start_positions_.push_back(traverser_ptr_->GetDepth());
+      }
+
+      int32_t intermediate_score = distance_metric_->Put(label, prefix_length_ + traverser_ptr_->GetDepth() - 1);
+
+      TRACE("Candidate: [%s] %ld intermediate score: %d(%d)", distance_metric_->GetCandidate().c_str(),
+            prefix_length_ + traverser_ptr_->GetDepth() - 1, intermediate_score, max_edit_distance_);
+
+      if (intermediate_score > max_edit_distance_) {
+        traverser_ptr_->Prune();
+        continue;
+      }
+
+      if (traverser_ptr_->IsFinalState()) {
+        std::string match_str = multiword_boundary_ > 0
+                                    ? distance_metric_->GetCandidate().substr(prefix_length_ + multiword_boundary_)
+                                    : distance_metric_->GetCandidate();
+
+        TRACE("found final state at depth %d %s", prefix_length_ + traverser_ptr_->GetDepth(), match_str.c_str());
+        Match m(0, prefix_length_ + traverser_ptr_->GetDepth(), match_str, distance_metric_->GetScore(),
+                traverser_ptr_->GetFsa(), traverser_ptr_->GetStateValue());
+
+        (*traverser_ptr_)++;
+        return m;
+      }
+    }
+
+    return Match();
+  }
+
+  void SetMinWeight(uint32_t min_weight) { traverser_ptr_->SetMinWeight(min_weight); }
+
+ private:
+  FuzzyMultiwordCompletionMatching(std::unique_ptr<innerTraverserType>&& traverser, Match&& first_match,
+                                   std::unique_ptr<stringdistance::LevenshteinCompletion>&& distance_metric,
+                                   const int32_t max_edit_distance, const size_t prefix_length, size_t number_of_tokens,
+                                   const unsigned char multiword_separator)
+      : traverser_ptr_(std::move(traverser)),
+        first_match_(std::move(first_match)),
+        distance_metric_(std::move(distance_metric)),
+        max_edit_distance_(max_edit_distance),
+        prefix_length_(prefix_length),
+        number_of_tokens_(number_of_tokens),
+        multiword_separator_(static_cast<uint64_t>(multiword_separator)) {}
+
+  FuzzyMultiwordCompletionMatching() {}
+
+ private:
+  std::unique_ptr<innerTraverserType> traverser_ptr_;
+  const Match first_match_;
+  std::unique_ptr<stringdistance::LevenshteinCompletion> distance_metric_;
+  const int32_t max_edit_distance_ = 0;
+  const size_t prefix_length_ = 0;
+  const size_t number_of_tokens_ = 0;
+  const uint64_t multiword_separator_ = 0;
+  std::vector<size_t> token_start_positions_;
+  size_t multiword_boundary_ = 0;
+
+  // reset method for the index in the special case the match is deleted
+  template <class MatcherT, class DeletedT>
+  friend Match index::internal::NextFilteredMatchSingle(const MatcherT&, const DeletedT&);
+  template <class MatcherT, class DeletedT>
+  friend Match index::internal::NextFilteredMatch(const MatcherT&, const DeletedT&);
+
+  void ResetLastMatch() {}
+};
+
+} /* namespace matching */
+} /* namespace dictionary */
+} /* namespace keyvi */
+#endif  // KEYVI_DICTIONARY_MATCHING_FUZZY_MULTIWORD_COMPLETION_MATCHING_H_

--- a/keyvi/include/keyvi/stringdistance/needleman_wunsch.h
+++ b/keyvi/include/keyvi/stringdistance/needleman_wunsch.h
@@ -36,7 +36,7 @@
 #include "keyvi/stringdistance/distance_matrix.h"
 #include "utf8.h"
 
-// #define ENABLE_TRACING
+#define ENABLE_TRACING
 #include "keyvi/dictionary/util/trace.h"
 
 namespace keyvi {
@@ -115,7 +115,8 @@ class NeedlemanWunsch final {
     if (left_cutoff >= columns) {
       // last character == exact match?
       if (row > completion_row_ || input_sequence_.empty() ||
-          compare_sequence_[columns - 2] == input_sequence_.back()) {
+           compare_sequence_[columns - 2] == input_sequence_.back()) {
+      //if (row > completion_row_ || input_sequence_.empty()) {
         intermediate_scores_[row] = intermediate_scores_[row - 1] + cost_function_.GetCompletionCost();
       } else {
         intermediate_scores_[row] = intermediate_scores_[row - 1] + cost_function_.GetInsertionCost(codepoint);
@@ -145,10 +146,11 @@ class NeedlemanWunsch final {
         int32_t completion_result = std::numeric_limits<int32_t>::max();
 
         if (row > completion_row_) {
-          completion_result = distance_matrix_.Get(completion_row_, column) + cost_function_.GetCompletionCost();
+          completion_result = distance_matrix_.Get(row - 1, column) + cost_function_.GetCompletionCost();
         } else if (column + 1 == columns && columns > 1 &&
                    compare_sequence_[last_put_position_ - 1] == input_sequence_.back()) {
           completion_row_ = row;
+          TRACE("set completion row %d columns: %d", row, columns);
           completion_result = distance_matrix_.Get(row - 1, column) + cost_function_.GetCompletionCost();
         }
 

--- a/keyvi/include/keyvi/stringdistance/needleman_wunsch.h
+++ b/keyvi/include/keyvi/stringdistance/needleman_wunsch.h
@@ -114,7 +114,8 @@ class NeedlemanWunsch final {
     // shortcut
     if (left_cutoff >= columns) {
       // last character == exact match?
-      if (row > completion_row_ || compare_sequence_[columns - 2] == input_sequence_.back()) {
+      if (row > completion_row_ || input_sequence_.empty() ||
+          compare_sequence_[columns - 2] == input_sequence_.back()) {
         intermediate_scores_[row] = intermediate_scores_[row - 1] + cost_function_.GetCompletionCost();
       } else {
         intermediate_scores_[row] = intermediate_scores_[row - 1] + cost_function_.GetInsertionCost(codepoint);
@@ -144,7 +145,7 @@ class NeedlemanWunsch final {
         int32_t completion_result = std::numeric_limits<int32_t>::max();
 
         if (row > completion_row_) {
-          completion_result = distance_matrix_.Get(row - 1, column) + cost_function_.GetCompletionCost();
+          completion_result = distance_matrix_.Get(completion_row_, column) + cost_function_.GetCompletionCost();
         } else if (column + 1 == columns && columns > 1 &&
                    compare_sequence_[last_put_position_ - 1] == input_sequence_.back()) {
           completion_row_ = row;
@@ -163,14 +164,8 @@ class NeedlemanWunsch final {
         }
 
         // 4. take the minimum cost
-        // field_result = std::min( { deletion_result, insertion_result,
-        //    transposition_result, substitution_result });
-
-        field_result = std::min(deletion_result, transposition_result);
-
-        field_result = std::min(field_result, substitution_result);
-        field_result = std::min(field_result, insertion_result);
-        field_result = std::min(field_result, completion_result);
+        field_result =
+            std::min({deletion_result, insertion_result, transposition_result, substitution_result, completion_result});
       }
 
       // put cost into matrix

--- a/keyvi/include/keyvi/stringdistance/needleman_wunsch.h
+++ b/keyvi/include/keyvi/stringdistance/needleman_wunsch.h
@@ -36,7 +36,7 @@
 #include "keyvi/stringdistance/distance_matrix.h"
 #include "utf8.h"
 
-#define ENABLE_TRACING
+// #define ENABLE_TRACING
 #include "keyvi/dictionary/util/trace.h"
 
 namespace keyvi {
@@ -115,8 +115,7 @@ class NeedlemanWunsch final {
     if (left_cutoff >= columns) {
       // last character == exact match?
       if (row > completion_row_ || input_sequence_.empty() ||
-           compare_sequence_[columns - 2] == input_sequence_.back()) {
-      //if (row > completion_row_ || input_sequence_.empty()) {
+          compare_sequence_[columns - 2] == input_sequence_.back()) {
         intermediate_scores_[row] = intermediate_scores_[row - 1] + cost_function_.GetCompletionCost();
       } else {
         intermediate_scores_[row] = intermediate_scores_[row - 1] + cost_function_.GetInsertionCost(codepoint);

--- a/keyvi/include/keyvi/stringdistance/needleman_wunsch.h
+++ b/keyvi/include/keyvi/stringdistance/needleman_wunsch.h
@@ -198,9 +198,9 @@ class NeedlemanWunsch final {
 
   int32_t GetScore() const { return distance_matrix_.Get(latest_calculated_row_, distance_matrix_.Columns() - 1); }
 
-  std::string GetCandidate() {
+  std::string GetCandidate(size_t pos = 0) {
     std::vector<unsigned char> utf8result;
-    utf8::utf32to8(compare_sequence_.begin(), compare_sequence_.begin() + last_put_position_ + 1,
+    utf8::utf32to8(compare_sequence_.begin() + pos, compare_sequence_.begin() + last_put_position_ + 1,
                    back_inserter(utf8result));
 
     return std::string(utf8result.begin(), utf8result.end());

--- a/keyvi/tests/keyvi/dictionary/completion/prefix_completion_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/completion/prefix_completion_test.cpp
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(approx1) {
 
   std::vector<std::string> expected_output;
   expected_output.push_back("aabc");
-  // not matching aabcül because of last character mismatch
+  expected_output.push_back("aabcül");
   expected_output.push_back("aabcdefghijklmnop");  // this matches because aab_c_d, "c" is an insert
 
   auto expected_it = expected_output.begin();

--- a/python/src/pxds/dictionary.pxd
+++ b/python/src/pxds/dictionary.pxd
@@ -81,6 +81,16 @@ cdef extern from "keyvi/dictionary/dictionary.h" namespace "keyvi::dictionary":
         #  In case the used dictionary supports inner weights, the
         #  completer traverses the dictionary according to weights. If weights
         #  are not available the dictionary gets traversed in byte-order.
+        _MatchIteratorPair GetFuzzyMultiwordCompletion (libcpp_utf8_string key, int32_t max_edit_distance, size_t minimum_exact_prefix) except + # wrap-as:complete_fuzzy_multiword
+        # wrap-doc:
+        #  complete the given key to full matches by matching the given key as
+        #  multiword allowing up to max_edit_distance distance(Levenshtein).
+        #  The key can consist of multiple tokens separated by space.
+        #  For matching it gets tokenized put back together bag-of-words style.
+        #  The dictionary must be created the same way.
+        #  In case the used dictionary supports inner weights, the
+        #  completer traverses the dictionary according to weights. If weights
+        #  are not available the dictionary gets traversed in byte-order.
         _MatchIteratorPair GetAllItems () # wrap-ignore
         _MatchIteratorPair Lookup(libcpp_utf8_string  key) # wrap-as:search
         _MatchIteratorPair LookupText(libcpp_utf8_string text) # wrap-as:search_tokenized

--- a/python/src/pxds/dictionary.pxd
+++ b/python/src/pxds/dictionary.pxd
@@ -71,6 +71,16 @@ cdef extern from "keyvi/dictionary/dictionary.h" namespace "keyvi::dictionary":
         #  In case the used dictionary supports inner weights, the
         #  completer traverses the dictionary according to weights. If weights
         #  are not available the dictionary gets traversed in byte-order.
+        _MatchIteratorPair GetFuzzyMultiwordCompletion (libcpp_utf8_string key, int32_t max_edit_distance) except + # wrap-as:complete_fuzzy_multiword
+        # wrap-doc:
+        #  complete the given key to full matches by matching the given key as
+        #  multiword allowing up to max_edit_distance distance(Levenshtein).
+        #  The key can consist of multiple tokens separated by space.
+        #  For matching it gets tokenized put back together bag-of-words style.
+        #  The dictionary must be created the same way.
+        #  In case the used dictionary supports inner weights, the
+        #  completer traverses the dictionary according to weights. If weights
+        #  are not available the dictionary gets traversed in byte-order.
         _MatchIteratorPair GetAllItems () # wrap-ignore
         _MatchIteratorPair Lookup(libcpp_utf8_string  key) # wrap-as:search
         _MatchIteratorPair LookupText(libcpp_utf8_string text) # wrap-as:search_tokenized

--- a/python/tests/completion/fuzzy_completion_test.py
+++ b/python/tests/completion/fuzzy_completion_test.py
@@ -44,13 +44,13 @@ def test_fuzzy_completion():
         assert len(matches) == 9
 
         matches = [m.matched_string for m in completer.GetFuzzyCompletions('tue', 1)]
-        assert len(matches) == 1
+        assert len(matches) == 21
 
         matches = [m.matched_string for m in completer.GetFuzzyCompletions('tuv h', 1)]
-        assert len(matches) == 2
+        assert len(matches) == 8
 
         matches = [m.matched_string for m in completer.GetFuzzyCompletions('tuv h', 2)]
-        assert len(matches) == 7
+        assert len(matches) == 12
 
         matches = [m.matched_string for m in completer.GetFuzzyCompletions('tuk töffnungszeiten', 2)]
         assert len(matches) == 1

--- a/python/tests/dictionary/dictionary_fuzzy_multiword_completion_test.py
+++ b/python/tests/dictionary/dictionary_fuzzy_multiword_completion_test.py
@@ -142,9 +142,19 @@ def test_multiword_simple():
         assert [
             m.matched_string for m in d.complete_fuzzy_multiword("zonbies 8", 1)
         ] == ["80s movie with zombies"]
+        assert [
+            m.matched_string for m in d.complete_fuzzy_multiword("80th mo", 2, 2)
+        ] == [
+            "80s movie with zombies",
+            "80s monsters tribute art",
+        ]
+
+        # matches 80s movie with zombies twice: 80th -> 80s, 80th -> with
+        # note: order comes from depth first traversal
         assert [m.matched_string for m in d.complete_fuzzy_multiword("80th mo", 2)] == [
             "80s movie with zombies",
             "80s monsters tribute art",
+            "80s movie with zombies",
         ]
         assert [
             m.matched_string for m in d.complete_fuzzy_multiword("witsah 80s", 3)
@@ -166,13 +176,25 @@ def test_multiword_simple():
             "80s techno fashion",
         ]
 
-        assert [m.matched_string for m in d.complete_fuzzy_multiword("90s", 10)] == []
+        assert [
+            m.matched_string for m in d.complete_fuzzy_multiword("90s", 10, 2)
+        ] == []
+
+        # no exact prefix: match all
+        assert len(
+            [m.matched_string for m in d.complete_fuzzy_multiword("90s", 10)]
+        ) == 44
 
         assert [
             m.matched_string for m in d.complete_fuzzy_multiword("80s xxxf", 3)
         ] == ["80s techno fashion"]
 
-        assert [m.matched_string for m in d.complete_fuzzy_multiword("", 10)] == []
+        assert [m.matched_string for m in d.complete_fuzzy_multiword("", 10, 2)] == []
+
+        # no exact prefix: match all
+        assert len(
+            [m.matched_string for m in d.complete_fuzzy_multiword("", 10)]
+        ) == 44
 
 
 def test_multiword_nonascii():

--- a/python/tests/dictionary/dictionary_fuzzy_multiword_completion_test.py
+++ b/python/tests/dictionary/dictionary_fuzzy_multiword_completion_test.py
@@ -37,7 +37,12 @@ multiword_data = {
 multiword_data_non_ascii = {
     "bäder öfen übelkeit": {"w": 43, "id": "a1"},
     "übelkeit kräuterschnapps alles gut": {"w": 72, "id": "a2"},
-    "öfen übelkeit rauchvergiftung ": {"w": 372, "id": "a3"},
+    "öfen übelkeit rauchvergiftung": {"w": 372, "id": "a3"},
+}
+
+multiword_data_stack_corner_case = {
+    "a b c d e f": {"w": 43, "id": "a1"},
+    "a": {"w": 12, "id": "a2"},
 }
 
 PERMUTATION_LOOKUP_TABLE = {
@@ -181,9 +186,9 @@ def test_multiword_simple():
         ] == []
 
         # no exact prefix: match all
-        assert len(
-            [m.matched_string for m in d.complete_fuzzy_multiword("90s", 10)]
-        ) == 44
+        assert (
+            len([m.matched_string for m in d.complete_fuzzy_multiword("90s", 10)]) == 44
+        )
 
         assert [
             m.matched_string for m in d.complete_fuzzy_multiword("80s xxxf", 3)
@@ -192,19 +197,17 @@ def test_multiword_simple():
         assert [m.matched_string for m in d.complete_fuzzy_multiword("", 10, 2)] == []
 
         # no exact prefix: match all
-        assert len(
-            [m.matched_string for m in d.complete_fuzzy_multiword("", 10)]
-        ) == 44
+        assert len([m.matched_string for m in d.complete_fuzzy_multiword("", 10)]) == 44
 
 
 def test_multiword_nonascii():
     with tmp_dictionary(create_dict(multiword_data_non_ascii), "completion.kv") as d:
         assert [m.matched_string for m in d.complete_fuzzy_multiword("öfen", 0)] == [
-            "öfen übelkeit rauchvergiftung ",
+            "öfen übelkeit rauchvergiftung",
             "bäder öfen übelkeit",
         ]
         assert [m.matched_string for m in d.complete_fuzzy_multiword("ofen", 1, 0)] == [
-            "öfen übelkeit rauchvergiftung ",
+            "öfen übelkeit rauchvergiftung",
             "bäder öfen übelkeit",
         ]
 
@@ -218,4 +221,13 @@ def test_multiword_nonascii():
             m.matched_string for m in d.complete_fuzzy_multiword("krauterl", 2)
         ] == [
             "übelkeit kräuterschnapps alles gut",
+        ]
+
+
+def test_multiword_stack_corner_case():
+    with tmp_dictionary(
+        create_dict(multiword_data_stack_corner_case), "completion.kv"
+    ) as d:
+        assert [m.matched_string for m in d.complete_fuzzy_multiword("a", 0)] == [
+            "a",
         ]

--- a/python/tests/dictionary/dictionary_fuzzy_multiword_completion_test.py
+++ b/python/tests/dictionary/dictionary_fuzzy_multiword_completion_test.py
@@ -132,13 +132,18 @@ def test_multiword_simple():
         assert [
             m.matched_string for m in d.complete_fuzzy_multiword("zonbies 8", 1)
         ] == ["80s movie with zombies"]
-        assert [m.matched_string for m in d.complete_fuzzy_multiword("80th mo", 2)] == [
+        #assert [m.matched_string for m in d.complete_fuzzy_multiword("80th mo", 2)] == [
+        #    "80s movie with zombies",
+        #    "80s monsters tribute art",
+        #]
+        #assert [
+        #    m.matched_string for m in d.complete_fuzzy_multiword("witsah 80s", 3)
+        #] == ["80s movie with zombies", "80s cartoon with cars"]
+
+        assert [m.matched_string for m in d.complete_fuzzy_multiword("80ts mo", 1)] == [
             "80s movie with zombies",
             "80s monsters tribute art",
         ]
-        assert [
-            m.matched_string for m in d.complete_fuzzy_multiword("witsah 80s", 3)
-        ] == ["80s movie with zombies", "80s cartoon with cars"]
 
         # todo: this should work with edit distance 1
         assert [

--- a/python/tests/dictionary/dictionary_fuzzy_multiword_completion_test.py
+++ b/python/tests/dictionary/dictionary_fuzzy_multiword_completion_test.py
@@ -129,48 +129,33 @@ def test_multiword_simple():
             c.Add(e, weight)
 
     with tmp_dictionary(c, "completion.kv") as d:
-        assert [m.matched_string for m in d.complete_multiword("zombies 8")] == [
-            "80s movie with zombies"
-        ]
-        assert [m.matched_string for m in d.complete_multiword("80s mo")] == [
+        assert [
+            m.matched_string for m in d.complete_fuzzy_multiword("zonbies 8", 1)
+        ] == ["80s movie with zombies"]
+        assert [m.matched_string for m in d.complete_fuzzy_multiword("80th mo", 2)] == [
             "80s movie with zombies",
             "80s monsters tribute art",
         ]
-        assert [m.matched_string for m in d.complete_multiword("with 80")] == [
-            "80s movie with zombies",
-            "80s cartoon with cars",
-        ]
-        assert [m.matched_string for m in d.complete_multiword("techno fa")] == [
+        assert [
+            m.matched_string for m in d.complete_fuzzy_multiword("witsah 80s", 3)
+        ] == ["80s movie with zombies", "80s cartoon with cars"]
+
+        # todo: this should work with edit distance 1
+        assert [
+            m.matched_string for m in d.complete_fuzzy_multiword("tehno fa", 2)
+        ] == [
             "80s techno fashion",
         ]
-        assert [m.matched_string for m in d.complete_multiword("90s")] == []
-
         assert [
-            m.matched_string
-            for m in sorted(
-                [m for m in d.complete_multiword("80")],
-                key=lambda m: m.weight,
-                reverse=True,
-            )
+            m.matched_string for m in d.complete_fuzzy_multiword("teschno fa", 1)
         ] == [
-            k
-            for k, v in sorted(
-                multiword_data.items(), key=lambda item: item[1]["w"], reverse=True
-            )
-            if len(k.split(" ")) < 5
+            "80s techno fashion",
         ]
 
-        assert set(
-            m.matched_string
-            for m in sorted(
-                [m for m in d.complete_multiword("")],
-                key=lambda m: m.weight,
-                reverse=True,
-            )
-        ) == set(
-            k
-            for k, v in sorted(
-                multiword_data.items(), key=lambda item: item[1]["w"], reverse=True
-            )
-            if len(k.split(" ")) < 5
-        )
+        assert [m.matched_string for m in d.complete_fuzzy_multiword("90s", 10)] == []
+
+        assert [
+            m.matched_string for m in d.complete_fuzzy_multiword("80s xxxf", 3)
+        ] == ["80s techno fashion"]
+
+        assert [m.matched_string for m in d.complete_fuzzy_multiword("", 10)] == []


### PR DESCRIPTION
implement a fuzzy version of multiword completion matching. This change also fixes a couple of fuzzy completion matching issues and simplifies the distance matrix calculations.

Note:
  - the distance calculation for cases where fuzzy completions are combined with a character deletion, e.g. completing "finnite state"(note the double "n") to "finite state traverser", was totally broken
  - there was also a case where completions required the last character to be an exact match, not sure where this came from, but this can be handled by the caller
