### PR TITLE
refactor matches to be returned as shared pointers

### DIFF
--- a/keyvi/bin/keyvi_c/c_api.cpp
+++ b/keyvi/bin/keyvi_c/c_api.cpp
@@ -147,15 +147,26 @@ bool keyvi_match_is_empty(const keyvi_match* match) {
 }
 
 double keyvi_match_get_score(const keyvi_match* match) {
+  if (match->obj_ == nullptr) {
+    return 0;
+  }
   return match->obj_->GetScore();
 }
 
 char* keyvi_match_get_value_as_string(const keyvi_match* match) {
+  if (match->obj_ == nullptr) {
+    return std_2_c_string("");
+  }
   return std_2_c_string(match->obj_->GetValueAsString());
 }
 
 keyvi_bytes keyvi_match_get_msgpacked_value(const struct keyvi_match* match) {
   const keyvi_bytes empty_keyvi_bytes{0, nullptr};
+
+  if (match->obj_ == nullptr) {
+    return empty_keyvi_bytes;
+  }
+
   const std::string msgpacked_value = match->obj_->GetMsgPackedValueAsString();
 
   const size_t data_size = msgpacked_value.size();
@@ -172,6 +183,9 @@ keyvi_bytes keyvi_match_get_msgpacked_value(const struct keyvi_match* match) {
 }
 
 char* keyvi_match_get_matched_string(const keyvi_match* match) {
+  if (match->obj_ == nullptr) {
+    return std_2_c_string("");
+  }
   return std_2_c_string(match->obj_->GetMatchedString());
 }
 

--- a/keyvi/bin/keyvi_c/c_api.cpp
+++ b/keyvi/bin/keyvi_c/c_api.cpp
@@ -60,7 +60,7 @@ struct keyvi_match {
 };
 
 struct keyvi_match_iterator {
-  explicit keyvi_match_iterator(const MatchIterator::MatchIteratorPair&& obj)
+  explicit keyvi_match_iterator(const MatchIterator::MatchIteratorPair& obj)
       : current_(obj.begin()), end_(obj.end()) {}
   MatchIterator current_;
   const MatchIterator end_;

--- a/keyvi/bin/keyvi_c/c_api.cpp
+++ b/keyvi/bin/keyvi_c/c_api.cpp
@@ -143,7 +143,7 @@ void keyvi_match_destroy(const keyvi_match* match) {
 }
 
 bool keyvi_match_is_empty(const keyvi_match* match) {
-  return static_cast<bool>(match->obj_);
+  return !match->obj_;
 }
 
 double keyvi_match_get_score(const keyvi_match* match) {

--- a/keyvi/bin/keyvi_c/c_api.cpp
+++ b/keyvi/bin/keyvi_c/c_api.cpp
@@ -33,7 +33,7 @@
 
 using keyvi::dictionary::Dictionary;
 using keyvi::dictionary::dictionary_t;
-using keyvi::dictionary::Match;
+using keyvi::dictionary::match_t;
 using keyvi::dictionary::MatchIterator;
 using keyvi::dictionary::completion::MultiWordCompletion;
 using keyvi::dictionary::completion::PrefixCompletion;
@@ -54,9 +54,9 @@ struct keyvi_dictionary {
 };
 
 struct keyvi_match {
-  explicit keyvi_match(const Match& obj) : obj_(obj) {}
+  explicit keyvi_match(const match_t& obj) : obj_(obj) {}
 
-  Match obj_;
+  match_t obj_;
 };
 
 struct keyvi_match_iterator {
@@ -143,20 +143,20 @@ void keyvi_match_destroy(const keyvi_match* match) {
 }
 
 bool keyvi_match_is_empty(const keyvi_match* match) {
-  return match->obj_.IsEmpty();
+  return match->obj_->IsEmpty();
 }
 
 double keyvi_match_get_score(const keyvi_match* match) {
-  return match->obj_.GetScore();
+  return match->obj_->GetScore();
 }
 
 char* keyvi_match_get_value_as_string(const keyvi_match* match) {
-  return std_2_c_string(match->obj_.GetValueAsString());
+  return std_2_c_string(match->obj_->GetValueAsString());
 }
 
 keyvi_bytes keyvi_match_get_msgpacked_value(const struct keyvi_match* match) {
   const keyvi_bytes empty_keyvi_bytes{0, nullptr};
-  const std::string msgpacked_value = match->obj_.GetMsgPackedValueAsString();
+  const std::string msgpacked_value = match->obj_->GetMsgPackedValueAsString();
 
   const size_t data_size = msgpacked_value.size();
   if (0 == data_size) {
@@ -172,7 +172,7 @@ keyvi_bytes keyvi_match_get_msgpacked_value(const struct keyvi_match* match) {
 }
 
 char* keyvi_match_get_matched_string(const keyvi_match* match) {
-  return std_2_c_string(match->obj_.GetMatchedString());
+  return std_2_c_string(match->obj_->GetMatchedString());
 }
 
 //////////////////////

--- a/keyvi/bin/keyvi_c/c_api.cpp
+++ b/keyvi/bin/keyvi_c/c_api.cpp
@@ -60,10 +60,10 @@ struct keyvi_match {
 };
 
 struct keyvi_match_iterator {
-  explicit keyvi_match_iterator(const MatchIterator::MatchIteratorPair& obj) : current_(obj.begin()), end_(obj.end()) {}
-
+  explicit keyvi_match_iterator(const MatchIterator::MatchIteratorPair&& obj)
+      : current_(std::move(obj.begin())), end_(std::move(obj.end())) {}
   MatchIterator current_;
-  const MatchIterator end_;
+  MatchIterator end_;
 };
 
 //////////////////////
@@ -201,7 +201,7 @@ bool keyvi_match_iterator_empty(const keyvi_match_iterator* iterator) {
   return iterator->current_ == iterator->end_;
 }
 
-keyvi_match* keyvi_match_iterator_dereference(const keyvi_match_iterator* iterator) {
+keyvi_match* keyvi_match_iterator_dereference(keyvi_match_iterator* iterator) {
   return new keyvi_match(*iterator->current_);
 }
 

--- a/keyvi/bin/keyvi_c/c_api.cpp
+++ b/keyvi/bin/keyvi_c/c_api.cpp
@@ -147,11 +147,11 @@ bool keyvi_match_is_empty(const keyvi_match* match) {
 }
 
 double keyvi_match_get_score(const keyvi_match* match) {
-  return match->obj_ ? 0 : match->obj_->GetScore();
+  return match->obj_ ? match->obj_->GetScore() : 0;
 }
 
 char* keyvi_match_get_value_as_string(const keyvi_match* match) {
-  return match->obj_ ? std_2_c_string("") : std_2_c_string(match->obj_->GetValueAsString());
+  return std_2_c_string(match->obj_ ? match->obj_->GetValueAsString() : "");
 }
 
 keyvi_bytes keyvi_match_get_msgpacked_value(const struct keyvi_match* match) {
@@ -177,7 +177,7 @@ keyvi_bytes keyvi_match_get_msgpacked_value(const struct keyvi_match* match) {
 }
 
 char* keyvi_match_get_matched_string(const keyvi_match* match) {
-  return match->obj_ ? std_2_c_string("") : std_2_c_string(match->obj_->GetMatchedString());
+  return std_2_c_string(match->obj_ ? match->obj_->GetMatchedString() : "");
 }
 
 //////////////////////

--- a/keyvi/bin/keyvi_c/c_api.cpp
+++ b/keyvi/bin/keyvi_c/c_api.cpp
@@ -157,7 +157,7 @@ char* keyvi_match_get_value_as_string(const keyvi_match* match) {
 keyvi_bytes keyvi_match_get_msgpacked_value(const struct keyvi_match* match) {
   const keyvi_bytes empty_keyvi_bytes{0, nullptr};
 
-  if (match->obj_) {
+  if (!match->obj_) {
     return empty_keyvi_bytes;
   }
 

--- a/keyvi/bin/keyvi_c/c_api.cpp
+++ b/keyvi/bin/keyvi_c/c_api.cpp
@@ -61,7 +61,7 @@ struct keyvi_match {
 
 struct keyvi_match_iterator {
   explicit keyvi_match_iterator(const MatchIterator::MatchIteratorPair&& obj)
-      : current_(std::move(obj.begin())), end_(std::move(obj.end())) {}
+      : current_(obj.begin()), end_(obj.end()) {}
   MatchIterator current_;
   MatchIterator end_;
 };

--- a/keyvi/bin/keyvi_c/c_api.cpp
+++ b/keyvi/bin/keyvi_c/c_api.cpp
@@ -60,8 +60,7 @@ struct keyvi_match {
 };
 
 struct keyvi_match_iterator {
-  explicit keyvi_match_iterator(const MatchIterator::MatchIteratorPair& obj)
-      : current_(obj.begin()), end_(obj.end()) {}
+  explicit keyvi_match_iterator(const MatchIterator::MatchIteratorPair& obj) : current_(obj.begin()), end_(obj.end()) {}
   MatchIterator current_;
   const MatchIterator end_;
 };

--- a/keyvi/bin/keyvi_c/c_api.cpp
+++ b/keyvi/bin/keyvi_c/c_api.cpp
@@ -143,7 +143,7 @@ void keyvi_match_destroy(const keyvi_match* match) {
 }
 
 bool keyvi_match_is_empty(const keyvi_match* match) {
-  return match->obj_->IsEmpty();
+  return match->obj_ == nullptr;
 }
 
 double keyvi_match_get_score(const keyvi_match* match) {

--- a/keyvi/bin/keyvi_c/c_api.cpp
+++ b/keyvi/bin/keyvi_c/c_api.cpp
@@ -143,21 +143,21 @@ void keyvi_match_destroy(const keyvi_match* match) {
 }
 
 bool keyvi_match_is_empty(const keyvi_match* match) {
-  return match->obj_ == nullptr;
+  return static_cast<bool>(match->obj_);
 }
 
 double keyvi_match_get_score(const keyvi_match* match) {
-  return match->obj_ == nullptr ? 0 : match->obj_->GetScore();
+  return match->obj_ ? 0 : match->obj_->GetScore();
 }
 
 char* keyvi_match_get_value_as_string(const keyvi_match* match) {
-  return match->obj_ == nullptr ? std_2_c_string("") : std_2_c_string(match->obj_->GetValueAsString());
+  return match->obj_ ? std_2_c_string("") : std_2_c_string(match->obj_->GetValueAsString());
 }
 
 keyvi_bytes keyvi_match_get_msgpacked_value(const struct keyvi_match* match) {
   const keyvi_bytes empty_keyvi_bytes{0, nullptr};
 
-  if (match->obj_ == nullptr) {
+  if (match->obj_) {
     return empty_keyvi_bytes;
   }
 
@@ -177,7 +177,7 @@ keyvi_bytes keyvi_match_get_msgpacked_value(const struct keyvi_match* match) {
 }
 
 char* keyvi_match_get_matched_string(const keyvi_match* match) {
-  return match->obj_ == nullptr ? std_2_c_string("") : std_2_c_string(match->obj_->GetMatchedString());
+  return match->obj_ ? std_2_c_string("") : std_2_c_string(match->obj_->GetMatchedString());
 }
 
 //////////////////////

--- a/keyvi/bin/keyvi_c/c_api.cpp
+++ b/keyvi/bin/keyvi_c/c_api.cpp
@@ -147,17 +147,11 @@ bool keyvi_match_is_empty(const keyvi_match* match) {
 }
 
 double keyvi_match_get_score(const keyvi_match* match) {
-  if (match->obj_ == nullptr) {
-    return 0;
-  }
-  return match->obj_->GetScore();
+  return match->obj_ == nullptr ? 0 : match->obj_->GetScore();
 }
 
 char* keyvi_match_get_value_as_string(const keyvi_match* match) {
-  if (match->obj_ == nullptr) {
-    return std_2_c_string("");
-  }
-  return std_2_c_string(match->obj_->GetValueAsString());
+  return match->obj_ == nullptr ? std_2_c_string("") : std_2_c_string(match->obj_->GetValueAsString());
 }
 
 keyvi_bytes keyvi_match_get_msgpacked_value(const struct keyvi_match* match) {
@@ -183,10 +177,7 @@ keyvi_bytes keyvi_match_get_msgpacked_value(const struct keyvi_match* match) {
 }
 
 char* keyvi_match_get_matched_string(const keyvi_match* match) {
-  if (match->obj_ == nullptr) {
-    return std_2_c_string("");
-  }
-  return std_2_c_string(match->obj_->GetMatchedString());
+  return match->obj_ == nullptr ? std_2_c_string("") : std_2_c_string(match->obj_->GetMatchedString());
 }
 
 //////////////////////

--- a/keyvi/bin/keyvi_c/c_api.cpp
+++ b/keyvi/bin/keyvi_c/c_api.cpp
@@ -63,7 +63,7 @@ struct keyvi_match_iterator {
   explicit keyvi_match_iterator(const MatchIterator::MatchIteratorPair&& obj)
       : current_(obj.begin()), end_(obj.end()) {}
   MatchIterator current_;
-  MatchIterator end_;
+  const MatchIterator end_;
 };
 
 //////////////////////
@@ -201,7 +201,7 @@ bool keyvi_match_iterator_empty(const keyvi_match_iterator* iterator) {
   return iterator->current_ == iterator->end_;
 }
 
-keyvi_match* keyvi_match_iterator_dereference(keyvi_match_iterator* iterator) {
+keyvi_match* keyvi_match_iterator_dereference(const keyvi_match_iterator* iterator) {
   return new keyvi_match(*iterator->current_);
 }
 

--- a/keyvi/include/keyvi/dictionary/completion/multiword_completion.h
+++ b/keyvi/include/keyvi/dictionary/completion/multiword_completion.h
@@ -155,7 +155,7 @@ class MultiWordCompletion final {
         }
       };
 
-      return MatchIterator::MakeIteratorPair(tfunc, first_match);
+      return MatchIterator::MakeIteratorPair(tfunc, std::move(first_match));
     }
 
     return MatchIterator::EmptyIteratorPair();

--- a/keyvi/include/keyvi/dictionary/completion/multiword_completion.h
+++ b/keyvi/include/keyvi/dictionary/completion/multiword_completion.h
@@ -75,7 +75,7 @@ class MultiWordCompletion final {
     traversal_stack.reserve(100);
 
     if (depth == query_length) {
-      Match first_match;
+      match_t first_match;
       TRACE("matched prefix");
 
       // data which is required for the callback as well
@@ -95,7 +95,7 @@ class MultiWordCompletion final {
         TRACE("prefix matched depth %d %s", query_length + data->traverser.GetDepth(),
               std::string(reinterpret_cast<char*>(&data->traversal_stack[0]), query_length + data->traverser.GetDepth())
                   .c_str());
-        first_match = Match(0, query_length, query, 0, fsa_, fsa_->GetStateValue(state));
+        first_match = std::make_shared<Match>(0, query_length, query, 0, fsa_, fsa_->GetStateValue(state));
       }
 
       auto tfunc = [data, query_length]() {
@@ -140,7 +140,7 @@ class MultiWordCompletion final {
                                             query_length + data->traverser.GetDepth());
               }
 
-              Match m(0, data->traverser.GetDepth() + query_length, matched_entry, 0, data->traverser.GetFsa(),
+              match_t m = std::make_shared<Match>(0, data->traverser.GetDepth() + query_length, matched_entry, 0, data->traverser.GetFsa(),
                       data->traverser.GetStateValue());
 
               data->traverser++;
@@ -150,7 +150,7 @@ class MultiWordCompletion final {
             data->traverser++;
           } else {
             TRACE("StateTraverser exhausted.");
-            return Match();
+            return match_t();
           }
         }
       };

--- a/keyvi/include/keyvi/dictionary/completion/multiword_completion.h
+++ b/keyvi/include/keyvi/dictionary/completion/multiword_completion.h
@@ -140,8 +140,8 @@ class MultiWordCompletion final {
                                             query_length + data->traverser.GetDepth());
               }
 
-              match_t m = std::make_shared<Match>(0, data->traverser.GetDepth() + query_length, matched_entry, 0, data->traverser.GetFsa(),
-                      data->traverser.GetStateValue());
+              match_t m = std::make_shared<Match>(0, data->traverser.GetDepth() + query_length, matched_entry, 0,
+                                                  data->traverser.GetFsa(), data->traverser.GetStateValue());
 
               data->traverser++;
               data->traverser.TryReduceResultQueue();

--- a/keyvi/include/keyvi/dictionary/completion/prefix_completion.h
+++ b/keyvi/include/keyvi/dictionary/completion/prefix_completion.h
@@ -121,7 +121,7 @@ class PrefixCompletion final {
         }
       };
 
-      return MatchIterator::MakeIteratorPair(tfunc, first_match);
+      return MatchIterator::MakeIteratorPair(tfunc, std::move(first_match));
     }
 
     return MatchIterator::EmptyIteratorPair();
@@ -219,7 +219,7 @@ class PrefixCompletion final {
       }
     };
 
-    return MatchIterator::MakeIteratorPair(tfunc, first_match);
+    return MatchIterator::MakeIteratorPair(tfunc, std::move(first_match));
   }
 
  private:

--- a/keyvi/include/keyvi/dictionary/completion/prefix_completion.h
+++ b/keyvi/include/keyvi/dictionary/completion/prefix_completion.h
@@ -106,8 +106,8 @@ class PrefixCompletion final {
               std::string match_str = std::string(reinterpret_cast<char*>(&data->traversal_stack[0]),
                                                   query_length + data->traverser.GetDepth());
               TRACE("found final state at depth %d %s", query_length + data->traverser.GetDepth(), match_str.c_str());
-              match_t m = std::make_shared<Match>(0, data->traverser.GetDepth() + query_length, match_str, 0, data->traverser.GetFsa(),
-                      data->traverser.GetStateValue());
+              match_t m = std::make_shared<Match>(0, data->traverser.GetDepth() + query_length, match_str, 0,
+                                                  data->traverser.GetFsa(), data->traverser.GetStateValue());
 
               data->traverser++;
               // data->traverser.TryReduceResultQueue();
@@ -204,8 +204,8 @@ class PrefixCompletion final {
           if (data->traverser.IsFinalState()) {
             if (query_length < depth || data->metric.GetScore() <= max_edit_distance) {
               TRACE("found final state at depth %d %s", depth, data->metric.GetCandidate().c_str());
-              match_t m=std::make_shared<Match>(0, depth, data->metric.GetCandidate(), data->metric.GetScore(), data->traverser.GetFsa(),
-                      data->traverser.GetStateValue());
+              match_t m = std::make_shared<Match>(0, depth, data->metric.GetCandidate(), data->metric.GetScore(),
+                                                  data->traverser.GetFsa(), data->traverser.GetStateValue());
 
               data->traverser++;
               return m;

--- a/keyvi/include/keyvi/dictionary/dictionary.h
+++ b/keyvi/include/keyvi/dictionary/dictionary.h
@@ -266,14 +266,16 @@ class Dictionary final {
       iterators.push(Lookup(text, position).begin());
     }
 
+    MatchIterator current_it = iterators.front();
     iterators.pop();
 
-    auto func = [iterators = std::move(iterators)]() mutable {
-      while (iterators.size() && !(*iterators.front())) {
+    auto func = [iterators = std::move(iterators), current_it]() mutable {
+      while (iterators.size() && *current_it == nullptr) {
+        current_it = iterators.front();
         iterators.pop();
       }
 
-      return *iterators.front()++;
+      return *current_it++;
     };
 
     return MatchIterator::MakeIteratorPair(func);

--- a/keyvi/include/keyvi/dictionary/dictionary.h
+++ b/keyvi/include/keyvi/dictionary/dictionary.h
@@ -146,7 +146,7 @@ class Dictionary final {
     // right now this is returning just 1 match, but it could be more if it is a multi-value dictionary
     m = std::make_shared<Match>(0, text_length, key, 0, fsa_, fsa_->GetStateValue(state));
 
-    return MatchIterator::MakeIteratorPair([](){return match_t();}, m);
+    return MatchIterator::MakeIteratorPair([]() { return match_t(); }, m);
   }
 
   /**
@@ -186,7 +186,7 @@ class Dictionary final {
                 std::string(reinterpret_cast<char*>(&data->traversal_stack[0]), data->traverser.GetDepth());
             TRACE("found final state at depth %d %s", data->traverser.GetDepth(), match_str.c_str());
             match_t m = std::make_shared<Match>(0, data->traverser.GetDepth(), match_str, 0, data->traverser.GetFsa(),
-                    data->traverser.GetStateValue());
+                                                data->traverser.GetStateValue());
 
             data->traverser++;
             return m;
@@ -233,8 +233,9 @@ class Dictionary final {
 
     if (last_final_state) {
       // right now this is returning just 1 match, but it could do more
-      m = std::make_shared<Match>(offset, last_final_state_position, text.substr(offset, last_final_state_position - offset), 0, fsa_,
-                fsa_->GetStateValue(last_final_state));
+      m = std::make_shared<Match>(offset, last_final_state_position,
+                                  text.substr(offset, last_final_state_position - offset), 0, fsa_,
+                                  fsa_->GetStateValue(last_final_state));
     }
 
     auto func = [m, has_run]() mutable {

--- a/keyvi/include/keyvi/dictionary/dictionary.h
+++ b/keyvi/include/keyvi/dictionary/dictionary.h
@@ -270,7 +270,7 @@ class Dictionary final {
     iterators.pop();
 
     auto func = [iterators = std::move(iterators), current_it]() mutable {
-      while (iterators.size() && *current_it) {
+      while (iterators.size() && !*current_it) {
         current_it = iterators.front();
         iterators.pop();
       }

--- a/keyvi/include/keyvi/dictionary/dictionary.h
+++ b/keyvi/include/keyvi/dictionary/dictionary.h
@@ -270,7 +270,7 @@ class Dictionary final {
     iterators.pop();
 
     auto func = [iterators = std::move(iterators), current_it]() mutable {
-      while (iterators.size() && *current_it == nullptr) {
+      while (iterators.size() && *current_it) {
         current_it = iterators.front();
         iterators.pop();
       }

--- a/keyvi/include/keyvi/dictionary/match.h
+++ b/keyvi/include/keyvi/dictionary/match.h
@@ -44,9 +44,9 @@ struct Match;
 namespace index {
 namespace internal {
 template <class MatcherT, class DeletedT>
-keyvi::dictionary::Match NextFilteredMatch(const MatcherT&, const DeletedT&);
+std::shared_ptr<keyvi::dictionary::Match> NextFilteredMatch(const MatcherT&, const DeletedT&);
 template <class MatcherT, class DeletedT>
-keyvi::dictionary::Match FirstFilteredMatch(const MatcherT&, const DeletedT&);
+std::shared_ptr<keyvi::dictionary::Match> FirstFilteredMatch(const MatcherT&, const DeletedT&);
 }  // namespace internal
 }  // namespace index
 namespace dictionary {
@@ -200,14 +200,16 @@ struct Match {
 
   // friend for accessing the fsa
   template <class MatcherT, class DeletedT>
-  friend Match index::internal::NextFilteredMatch(const MatcherT&, const DeletedT&);
+  friend std::shared_ptr<Match> index::internal::NextFilteredMatch(const MatcherT&, const DeletedT&);
   template <class MatcherT, class DeletedT>
-  friend Match index::internal::FirstFilteredMatch(const MatcherT&, const DeletedT&);
+  friend std::shared_ptr<Match> index::internal::FirstFilteredMatch(const MatcherT&, const DeletedT&);
 
   fsa::automata_t& GetFsa() {
     return fsa_;
   }
 };
+
+using match_t = std::shared_ptr<Match>;
 
 } /* namespace dictionary */
 } /* namespace keyvi */

--- a/keyvi/include/keyvi/dictionary/match.h
+++ b/keyvi/include/keyvi/dictionary/match.h
@@ -130,6 +130,8 @@ struct Match {
 
   void SetStart(size_t start = 0) { start_ = start; }
 
+  bool IsEmpty() const { return start_ == 0 && end_ == 0; }
+
 #ifdef Py_PYTHON_H
   PyObject* GetAttributePy(const std::string& key) {
     auto result = GetAttribute(key);

--- a/keyvi/include/keyvi/dictionary/match.h
+++ b/keyvi/include/keyvi/dictionary/match.h
@@ -61,13 +61,7 @@ class attributes_visitor : public boost::static_visitor<PyObject*> {
 
   PyObject* operator()(bool i) const { return i ? Py_True : Py_False; }
 
-  PyObject* operator()(const std::string& str) const {
-#if PY_MAJOR_VERSION >= 3
-    return PyUnicode_FromString(str.c_str());
-#else
-    return PyString_FromString(str.c_str());
-#endif
-  }
+  PyObject* operator()(const std::string& str) const { return PyUnicode_FromString(str.c_str()); }
 };
 #endif
 
@@ -135,8 +129,6 @@ struct Match {
   size_t GetStart() const { return start_; }
 
   void SetStart(size_t start = 0) { start_ = start; }
-
-  bool IsEmpty() const { return start_ == 0 && end_ == 0; }
 
 #ifdef Py_PYTHON_H
   PyObject* GetAttributePy(const std::string& key) {

--- a/keyvi/include/keyvi/dictionary/match.h
+++ b/keyvi/include/keyvi/dictionary/match.h
@@ -27,6 +27,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 #include <boost/container/flat_map.hpp>
 #include <boost/variant.hpp>
@@ -87,9 +88,37 @@ struct Match {
 
   Match() : matched_item_(), raw_value_() {}
 
-  // todo: consider disallowing copy and assignment
-  // Match& operator=(Match const&) = delete;
-  // Match(const Match& that) = delete;
+  Match(Match&& other)
+      : start_(other.start_),
+        end_(other.end_),
+        matched_item_(std::move(other.matched_item_)),
+        raw_value_(std::move(other.raw_value_)),
+        score_(other.score_),
+        fsa_(other.fsa_),
+        state_(other.state_),
+        attributes_(std::move(other.attributes_)) {
+    other.start_ = 0;
+    other.end_ = 0;
+    other.score_ = 0;
+    other.state_ = 0;
+  }
+
+  Match& operator=(Match&& other) {
+    start_ = other.start_;
+    end_ = other.end_;
+    matched_item_ = std::move(other.matched_item_);
+    raw_value_ = std::move(other.raw_value_);
+    score_ = other.score_;
+    fsa_ = std::move(other.fsa_);
+    state_ = other.state_;
+    attributes_ = std::move(other.attributes_);
+
+    other.start_ = 0;
+    other.end_ = 0;
+    other.score_ = 0;
+    other.state_ = 0;
+    return *this;
+  }
 
   size_t GetEnd() const { return end_; }
 

--- a/keyvi/include/keyvi/dictionary/match.h
+++ b/keyvi/include/keyvi/dictionary/match.h
@@ -41,13 +41,16 @@
 namespace keyvi {
 namespace dictionary {
 struct Match;
-}
+
+using match_t = std::shared_ptr<Match>;
+}  // namespace dictionary
+
 namespace index {
 namespace internal {
 template <class MatcherT, class DeletedT>
-std::shared_ptr<keyvi::dictionary::Match> NextFilteredMatch(const MatcherT&, const DeletedT&);
+keyvi::dictionary::match_t NextFilteredMatch(const MatcherT&, const DeletedT&);
 template <class MatcherT, class DeletedT>
-std::shared_ptr<keyvi::dictionary::Match> FirstFilteredMatch(const MatcherT&, const DeletedT&);
+keyvi::dictionary::match_t FirstFilteredMatch(const MatcherT&, const DeletedT&);
 }  // namespace internal
 }  // namespace index
 namespace dictionary {
@@ -223,16 +226,14 @@ struct Match {
 
   // friend for accessing the fsa
   template <class MatcherT, class DeletedT>
-  friend std::shared_ptr<Match> index::internal::NextFilteredMatch(const MatcherT&, const DeletedT&);
+  friend match_t index::internal::NextFilteredMatch(const MatcherT&, const DeletedT&);
   template <class MatcherT, class DeletedT>
-  friend std::shared_ptr<Match> index::internal::FirstFilteredMatch(const MatcherT&, const DeletedT&);
+  friend match_t index::internal::FirstFilteredMatch(const MatcherT&, const DeletedT&);
 
   fsa::automata_t& GetFsa() {
     return fsa_;
   }
 };
-
-using match_t = std::shared_ptr<Match>;
 
 } /* namespace dictionary */
 } /* namespace keyvi */

--- a/keyvi/include/keyvi/dictionary/match_iterator.h
+++ b/keyvi/include/keyvi/dictionary/match_iterator.h
@@ -91,7 +91,7 @@ class MatchIterator : public boost::iterator_facade<MatchIterator, match_t const
     if (match_functor_) {
       TRACE("Match Iterator: call increment()");
 
-      current_match_ = std::move(match_functor_());
+      current_match_ = match_functor_();
 
       // if we get an empty match, release the functor
       if (!current_match_) {

--- a/keyvi/include/keyvi/dictionary/match_iterator.h
+++ b/keyvi/include/keyvi/dictionary/match_iterator.h
@@ -59,7 +59,9 @@ class MatchIterator : public boost::iterator_facade<MatchIterator, match_t const
 
   explicit MatchIterator(std::function<match_t()> match_functor, match_t&& first_match = match_t(),
                          std::function<void(uint32_t)> set_min_weight = {})
-      : match_functor_(match_functor), current_match_(std::move(first_match)), set_min_weight_(set_min_weight) {
+      : match_functor_(std::move(match_functor)),
+        current_match_(std::move(first_match)),
+        set_min_weight_(std::move(set_min_weight)) {
     if (!current_match_) {
       TRACE("first match empty");
       increment();
@@ -70,7 +72,8 @@ class MatchIterator : public boost::iterator_facade<MatchIterator, match_t const
 
   static MatchIteratorPair MakeIteratorPair(std::function<match_t()> f, match_t&& first_match = match_t(),
                                             std::function<void(uint32_t)> set_min_weight = {}) {
-    return MatchIteratorPair(MatchIterator(f, std::move(first_match), set_min_weight), MatchIterator());
+    return MatchIteratorPair(MatchIterator(std::move(f), std::move(first_match), std::move(set_min_weight)),
+                             MatchIterator());
   }
 
   static MatchIteratorPair EmptyIteratorPair() { return MatchIteratorPair(MatchIterator(), MatchIterator()); }

--- a/keyvi/include/keyvi/dictionary/matching/fuzzy_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/fuzzy_matching.h
@@ -130,8 +130,8 @@ class FuzzyMatching final {
 
     if (fsa->IsFinalState(start_state) && metric->GetScore() <= max_edit_distance) {
       TRACE("exact prefix matched");
-      first_match =
-          std::make_shared<Match>(0, exact_prefix, metric->GetCandidate(), metric->GetScore(), fsa, fsa->GetStateValue(start_state));
+      first_match = std::make_shared<Match>(0, exact_prefix, metric->GetCandidate(), metric->GetScore(), fsa,
+                                            fsa->GetStateValue(start_state));
     }
 
     TRACE("create iterator");
@@ -191,8 +191,8 @@ class FuzzyMatching final {
     // check for a match given the exact prefix
     for (const auto& fsa_state : fsa_start_state_pairs) {
       if (fsa_state.first->IsFinalState(fsa_state.second) && metric->GetScore() <= max_edit_distance) {
-        first_match = std::make_shared<Match>(0, exact_prefix, metric->GetCandidate(), metric->GetScore(), fsa_state.first,
-                            fsa_state.first->GetStateValue(fsa_state.second));
+        first_match = std::make_shared<Match>(0, exact_prefix, metric->GetCandidate(), metric->GetScore(),
+                                              fsa_state.first, fsa_state.first->GetStateValue(fsa_state.second));
         break;
       }
     }
@@ -253,7 +253,7 @@ class FuzzyMatching final {
       if (traverser_ptr_->IsFinalState() && metric_ptr_->GetScore() <= max_edit_distance_) {
         TRACE("found match %s %lu", metric_ptr_->GetCandidate().c_str(), traverser_ptr_->GetStateValue());
         match_t m = std::make_shared<Match>(0, candidate_length(), metric_ptr_->GetCandidate(), metric_ptr_->GetScore(),
-                        traverser_ptr_->GetFsa(), traverser_ptr_->GetStateValue());
+                                            traverser_ptr_->GetFsa(), traverser_ptr_->GetStateValue());
         (*traverser_ptr_)++;
         return m;
       }

--- a/keyvi/include/keyvi/dictionary/matching/fuzzy_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/fuzzy_matching.h
@@ -233,7 +233,7 @@ class FuzzyMatching final {
     return fsa_start_state_pairs;
   }
 
-  match_t FirstMatch() const { return first_match_; }
+  match_t& FirstMatch() { return first_match_; }
 
   match_t NextMatch() {
     for (; traverser_ptr_ && *traverser_ptr_; (*traverser_ptr_)++) {
@@ -283,7 +283,7 @@ class FuzzyMatching final {
   std::unique_ptr<fsa::CodePointStateTraverser<codepointInnerTraverserType>> traverser_ptr_;
   const int32_t max_edit_distance_;
   const size_t exact_prefix_;
-  const match_t first_match_;
+  match_t first_match_;
 
   // reset method for the index in the special case the match is deleted
   template <class MatcherT, class DeletedT>

--- a/keyvi/include/keyvi/dictionary/matching/fuzzy_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/fuzzy_matching.h
@@ -48,9 +48,9 @@ namespace keyvi {
 namespace index {
 namespace internal {
 template <class MatcherT, class DeletedT>
-keyvi::dictionary::Match NextFilteredMatchSingle(const MatcherT&, const DeletedT&);
+keyvi::dictionary::match_t NextFilteredMatchSingle(const MatcherT&, const DeletedT&);
 template <class MatcherT, class DeletedT>
-keyvi::dictionary::Match NextFilteredMatch(const MatcherT&, const DeletedT&);
+keyvi::dictionary::match_t NextFilteredMatch(const MatcherT&, const DeletedT&);
 }  // namespace internal
 }  // namespace index
 namespace dictionary {
@@ -110,7 +110,7 @@ class FuzzyMatching final {
 
     std::unique_ptr<stringdistance::Levenshtein> metric;
     std::unique_ptr<fsa::CodePointStateTraverser<innerTraverserType>> traverser;
-    Match first_match;
+    match_t first_match;
 
     std::vector<uint32_t> codepoints;
     utf8::unchecked::utf8to32(query.begin(), query.end(), back_inserter(codepoints));
@@ -131,7 +131,7 @@ class FuzzyMatching final {
     if (fsa->IsFinalState(start_state) && metric->GetScore() <= max_edit_distance) {
       TRACE("exact prefix matched");
       first_match =
-          Match(0, exact_prefix, metric->GetCandidate(), metric->GetScore(), fsa, fsa->GetStateValue(start_state));
+          std::make_shared<Match>(0, exact_prefix, metric->GetCandidate(), metric->GetScore(), fsa, fsa->GetStateValue(start_state));
     }
 
     TRACE("create iterator");
@@ -176,7 +176,7 @@ class FuzzyMatching final {
 
     std::unique_ptr<stringdistance::Levenshtein> metric;
     std::unique_ptr<fsa::CodePointStateTraverser<fsa::ZipStateTraverser<innerTraverserType>>> traverser;
-    Match first_match;
+    match_t first_match;
 
     // decode the utf8 query into single codepoints
     std::vector<uint32_t> codepoints;
@@ -191,7 +191,7 @@ class FuzzyMatching final {
     // check for a match given the exact prefix
     for (const auto& fsa_state : fsa_start_state_pairs) {
       if (fsa_state.first->IsFinalState(fsa_state.second) && metric->GetScore() <= max_edit_distance) {
-        first_match = Match(0, exact_prefix, metric->GetCandidate(), metric->GetScore(), fsa_state.first,
+        first_match = std::make_shared<Match>(0, exact_prefix, metric->GetCandidate(), metric->GetScore(), fsa_state.first,
                             fsa_state.first->GetStateValue(fsa_state.second));
         break;
       }
@@ -233,9 +233,9 @@ class FuzzyMatching final {
     return fsa_start_state_pairs;
   }
 
-  Match FirstMatch() const { return first_match_; }
+  match_t FirstMatch() const { return first_match_; }
 
-  Match NextMatch() {
+  match_t NextMatch() {
     for (; traverser_ptr_ && *traverser_ptr_; (*traverser_ptr_)++) {
       TRACE("metric->put %lu  depth: %lu", traverser_ptr_->GetStateLabel(), candidate_length() - 1);
       const int32_t intermediate_score = metric_ptr_->Put(traverser_ptr_->GetStateLabel(), candidate_length() - 1);
@@ -252,18 +252,18 @@ class FuzzyMatching final {
 
       if (traverser_ptr_->IsFinalState() && metric_ptr_->GetScore() <= max_edit_distance_) {
         TRACE("found match %s %lu", metric_ptr_->GetCandidate().c_str(), traverser_ptr_->GetStateValue());
-        Match m = Match(0, candidate_length(), metric_ptr_->GetCandidate(), metric_ptr_->GetScore(),
+        match_t m = std::make_shared<Match>(0, candidate_length(), metric_ptr_->GetCandidate(), metric_ptr_->GetScore(),
                         traverser_ptr_->GetFsa(), traverser_ptr_->GetStateValue());
         (*traverser_ptr_)++;
         return m;
       }
     }
-    return Match();
+    return match_t();
   }
 
  private:
   FuzzyMatching(std::unique_ptr<fsa::CodePointStateTraverser<codepointInnerTraverserType>>&& traverser,
-                std::unique_ptr<stringdistance::Levenshtein>&& metric, Match&& first_match,
+                std::unique_ptr<stringdistance::Levenshtein>&& metric, match_t&& first_match,
                 const int32_t max_edit_distance, const size_t minimum_exact_prefix)
       : metric_ptr_(std::move(metric)),
         traverser_ptr_(std::move(traverser)),
@@ -283,13 +283,13 @@ class FuzzyMatching final {
   std::unique_ptr<fsa::CodePointStateTraverser<codepointInnerTraverserType>> traverser_ptr_;
   const int32_t max_edit_distance_;
   const size_t exact_prefix_;
-  const Match first_match_;
+  const match_t first_match_;
 
   // reset method for the index in the special case the match is deleted
   template <class MatcherT, class DeletedT>
-  friend Match index::internal::NextFilteredMatchSingle(const MatcherT&, const DeletedT&);
+  friend match_t index::internal::NextFilteredMatchSingle(const MatcherT&, const DeletedT&);
   template <class MatcherT, class DeletedT>
-  friend Match index::internal::NextFilteredMatch(const MatcherT&, const DeletedT&);
+  friend match_t index::internal::NextFilteredMatch(const MatcherT&, const DeletedT&);
 
   void ResetLastMatch() {}
 };

--- a/keyvi/include/keyvi/dictionary/matching/fuzzy_multiword_completion_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/fuzzy_multiword_completion_matching.h
@@ -202,7 +202,7 @@ class FuzzyMultiwordCompletionMatching final {
                                             minimum_exact_prefix, number_of_tokens, multiword_separator);
   }
 
-  match_t FirstMatch() const { return first_match_; }
+  match_t& FirstMatch() { return first_match_; }
 
   match_t NextMatch() {
     for (; traverser_ptr_ && *traverser_ptr_; (*traverser_ptr_)++) {
@@ -285,7 +285,7 @@ class FuzzyMultiwordCompletionMatching final {
 
  private:
   std::unique_ptr<innerTraverserType> traverser_ptr_;
-  const match_t first_match_;
+  match_t first_match_;
   std::unique_ptr<stringdistance::LevenshteinCompletion> distance_metric_;
   const int32_t max_edit_distance_ = 0;
   const size_t prefix_length_ = 0;

--- a/keyvi/include/keyvi/dictionary/matching/fuzzy_multiword_completion_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/fuzzy_multiword_completion_matching.h
@@ -190,8 +190,8 @@ class FuzzyMultiwordCompletionMatching final {
     // check for a match given the exact prefix
     for (const auto& fsa_state : fsa_start_state_pairs) {
       if (fsa_state.first->IsFinalState(fsa_state.second)) {
-        first_match =
-            std::make_shared<Match>(0, query_length, query, 0, fsa_state.first, fsa_state.first->GetStateValue(fsa_state.second));
+        first_match = std::make_shared<Match>(0, query_length, query, 0, fsa_state.first,
+                                              fsa_state.first->GetStateValue(fsa_state.second));
         break;
       }
     }
@@ -254,8 +254,9 @@ class FuzzyMultiwordCompletionMatching final {
                                     : distance_metric_->GetCandidate();
 
         TRACE("found final state at depth %d %s", prefix_length_ + traverser_ptr_->GetDepth(), match_str.c_str());
-        match_t m=std::make_shared<Match>(0, prefix_length_ + traverser_ptr_->GetDepth(), match_str, distance_metric_->GetScore(),
-                traverser_ptr_->GetFsa(), traverser_ptr_->GetStateValue());
+        match_t m = std::make_shared<Match>(0, prefix_length_ + traverser_ptr_->GetDepth(), match_str,
+                                            distance_metric_->GetScore(), traverser_ptr_->GetFsa(),
+                                            traverser_ptr_->GetStateValue());
 
         (*traverser_ptr_)++;
         return m;

--- a/keyvi/include/keyvi/dictionary/matching/multiword_completion_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/multiword_completion_matching.h
@@ -159,8 +159,8 @@ class MultiwordCompletionMatching final {
     // check for a match given the exact prefix
     for (const auto& fsa_state : fsa_start_state_pairs) {
       if (fsa_state.first->IsFinalState(fsa_state.second)) {
-        first_match =
-            std::make_shared<Match>(0, query_length, query, 0, fsa_state.first, fsa_state.first->GetStateValue(fsa_state.second));
+        first_match = std::make_shared<Match>(0, query_length, query, 0, fsa_state.first,
+                                              fsa_state.first->GetStateValue(fsa_state.second));
         break;
       }
     }
@@ -203,8 +203,8 @@ class MultiwordCompletionMatching final {
                 : std::string(traversal_stack_->begin(), traversal_stack_->end());
 
         TRACE("found final state at depth %d %s", prefix_length_ + traverser_ptr_->GetDepth(), match_str.c_str());
-        match_t m = std::make_shared<Match>(0, prefix_length_ + traverser_ptr_->GetDepth(), match_str, 0, traverser_ptr_->GetFsa(),
-                traverser_ptr_->GetStateValue());
+        match_t m = std::make_shared<Match>(0, prefix_length_ + traverser_ptr_->GetDepth(), match_str, 0,
+                                            traverser_ptr_->GetFsa(), traverser_ptr_->GetStateValue());
 
         (*traverser_ptr_)++;
         return m;

--- a/keyvi/include/keyvi/dictionary/matching/multiword_completion_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/multiword_completion_matching.h
@@ -171,7 +171,7 @@ class MultiwordCompletionMatching final {
                                        query_length, multiword_separator);
   }
 
-  const match_t& FirstMatch() const { return first_match_; }
+  match_t& FirstMatch() { return first_match_; }
 
   match_t NextMatch() {
     for (; traverser_ptr_ && *traverser_ptr_; (*traverser_ptr_)++) {
@@ -230,7 +230,7 @@ class MultiwordCompletionMatching final {
 
  private:
   std::unique_ptr<innerTraverserType> traverser_ptr_;
-  const match_t first_match_;
+  match_t first_match_;
   std::unique_ptr<std::vector<unsigned char>> traversal_stack_;
   const size_t prefix_length_ = 0;
   const unsigned char multiword_separator_ = 0;

--- a/keyvi/include/keyvi/dictionary/matching/near_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/near_matching.h
@@ -149,7 +149,7 @@ class NearMatching final {
     for (const auto& fsa_state : boost::adaptors::reverse(fsa_start_state_payloads)) {
       if (std::get<0>(fsa_state)->IsFinalState(std::get<1>(fsa_state))) {
         first_match = std::make_shared<Match>(0, query.size(), query, exact_prefix, std::get<0>(fsa_state),
-                            std::get<0>(fsa_state)->GetStateValue(std::get<1>(fsa_state)));
+                                              std::get<0>(fsa_state)->GetStateValue(std::get<1>(fsa_state)));
         break;
       }
     }
@@ -195,8 +195,8 @@ class NearMatching final {
 
         // length should be query.size???
         match_t m = std::make_shared<Match>(0, traverser_ptr_->GetDepth() + exact_prefix_.size(), match_str,
-                exact_prefix_.size() + traverser_ptr_->GetTraversalPayload().exact_depth, traverser_ptr_->GetFsa(),
-                traverser_ptr_->GetStateValue());
+                                            exact_prefix_.size() + traverser_ptr_->GetTraversalPayload().exact_depth,
+                                            traverser_ptr_->GetFsa(), traverser_ptr_->GetStateValue());
 
         if (!greedy_) {
           // remember the depth
@@ -221,8 +221,8 @@ class NearMatching final {
   const bool greedy_ = false;
   size_t matched_depth_ = 0;
 
-  NearMatching(std::unique_ptr<innerTraverserType>&& traverser, match_t&& first_match, std::string&& minimum_exact_prefix,
-               const bool greedy)
+  NearMatching(std::unique_ptr<innerTraverserType>&& traverser, match_t&& first_match,
+               std::string&& minimum_exact_prefix, const bool greedy)
       : traverser_ptr_(std::move(traverser)),
         exact_prefix_(std::move(minimum_exact_prefix)),
         first_match_(std::move(first_match)),

--- a/keyvi/include/keyvi/dictionary/matching/near_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/near_matching.h
@@ -182,7 +182,7 @@ class NearMatching final {
     return fsa_start_state_payloads;
   }
 
-  match_t FirstMatch() const { return first_match_; }
+  match_t& FirstMatch() { return first_match_; }
 
   match_t NextMatch() {
     TRACE("call next match %lu", matched_depth_);
@@ -217,7 +217,7 @@ class NearMatching final {
  private:
   std::unique_ptr<innerTraverserType> traverser_ptr_;
   const std::string exact_prefix_;
-  const match_t first_match_;
+  match_t first_match_;
   const bool greedy_ = false;
   size_t matched_depth_ = 0;
 

--- a/keyvi/include/keyvi/dictionary/matching/prefix_completion_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/prefix_completion_matching.h
@@ -164,7 +164,7 @@ class PrefixCompletionMatching final {
                                     query_length);
   }
 
-  match_t FirstMatch() const { return first_match_; }
+  match_t& FirstMatch() { return first_match_; }
 
   match_t NextMatch() {
     for (; traverser_ptr_ && *traverser_ptr_; (*traverser_ptr_)++) {
@@ -201,7 +201,7 @@ class PrefixCompletionMatching final {
 
  private:
   std::unique_ptr<innerTraverserType> traverser_ptr_;
-  const match_t first_match_;
+  match_t first_match_;
   std::unique_ptr<std::vector<unsigned char>> traversal_stack_;
   const size_t prefix_length_ = 0;
 

--- a/keyvi/include/keyvi/dictionary/matching/prefix_completion_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/prefix_completion_matching.h
@@ -44,9 +44,9 @@ namespace keyvi {
 namespace index {
 namespace internal {
 template <class MatcherT, class DeletedT>
-keyvi::dictionary::Match NextFilteredMatchSingle(const MatcherT&, const DeletedT&);
+keyvi::dictionary::match_t NextFilteredMatchSingle(const MatcherT&, const DeletedT&);
 template <class MatcherT, class DeletedT>
-keyvi::dictionary::Match NextFilteredMatch(const MatcherT&, const DeletedT&);
+keyvi::dictionary::match_t NextFilteredMatch(const MatcherT&, const DeletedT&);
 }  // namespace internal
 }  // namespace index
 namespace dictionary {
@@ -85,7 +85,7 @@ class PrefixCompletionMatching final {
     size_t depth = 0;
     uint64_t state = start_state;
 
-    Match first_match;
+    match_t first_match;
 
     TRACE("start state %d", state);
 
@@ -105,7 +105,7 @@ class PrefixCompletionMatching final {
     std::unique_ptr<innerTraverserType> traverser = std::make_unique<innerTraverserType>(fsa, state);
 
     if (fsa->IsFinalState(state)) {
-      first_match = Match(0, query_length, query, 0, fsa, fsa->GetStateValue(state));
+      first_match = std::make_shared<Match>(0, query_length, query, 0, fsa, fsa->GetStateValue(state));
     }
 
     TRACE("create matcher");
@@ -148,12 +148,12 @@ class PrefixCompletionMatching final {
       traversal_stack->push_back(c);
     }
 
-    Match first_match;
+    match_t first_match;
     // check for a match given the exact prefix
     for (const auto& fsa_state : fsa_start_state_pairs) {
       if (fsa_state.first->IsFinalState(fsa_state.second)) {
         first_match =
-            Match(0, query_length, query, 0, fsa_state.first, fsa_state.first->GetStateValue(fsa_state.second));
+            std::make_shared<Match>(0, query_length, query, 0, fsa_state.first, fsa_state.first->GetStateValue(fsa_state.second));
         break;
       }
     }
@@ -164,9 +164,9 @@ class PrefixCompletionMatching final {
                                     query_length);
   }
 
-  Match FirstMatch() const { return first_match_; }
+  match_t FirstMatch() const { return first_match_; }
 
-  Match NextMatch() {
+  match_t NextMatch() {
     for (; traverser_ptr_ && *traverser_ptr_; (*traverser_ptr_)++) {
       traversal_stack_->resize(prefix_length_ + traverser_ptr_->GetDepth() - 1);
       traversal_stack_->push_back(traverser_ptr_->GetStateLabel());
@@ -176,7 +176,7 @@ class PrefixCompletionMatching final {
         std::string match_str = std::string(traversal_stack_->begin(), traversal_stack_->end());
 
         TRACE("found final state at depth %d %s", prefix_length_ + traverser_ptr_->GetDepth(), match_str.c_str());
-        Match m(0, prefix_length_ + traverser_ptr_->GetDepth(), match_str, 0, traverser_ptr_->GetFsa(),
+        match_t m = std::make_shared<Match>(0, prefix_length_ + traverser_ptr_->GetDepth(), match_str, 0, traverser_ptr_->GetFsa(),
                 traverser_ptr_->GetStateValue());
 
         (*traverser_ptr_)++;
@@ -184,13 +184,13 @@ class PrefixCompletionMatching final {
       }
     }
 
-    return Match();
+    return match_t();
   }
 
   void SetMinWeight(uint32_t min_weight) { traverser_ptr_->SetMinWeight(min_weight); }
 
  private:
-  PrefixCompletionMatching(std::unique_ptr<innerTraverserType>&& traverser, Match&& first_match,
+  PrefixCompletionMatching(std::unique_ptr<innerTraverserType>&& traverser, match_t&& first_match,
                            std::unique_ptr<std::vector<unsigned char>>&& traversal_stack, const size_t prefix_length)
       : traverser_ptr_(std::move(traverser)),
         first_match_(std::move(first_match)),
@@ -201,15 +201,15 @@ class PrefixCompletionMatching final {
 
  private:
   std::unique_ptr<innerTraverserType> traverser_ptr_;
-  const Match first_match_;
+  const match_t first_match_;
   std::unique_ptr<std::vector<unsigned char>> traversal_stack_;
   const size_t prefix_length_ = 0;
 
   // reset method for the index in the special case the match is deleted
   template <class MatcherT, class DeletedT>
-  friend Match index::internal::NextFilteredMatchSingle(const MatcherT&, const DeletedT&);
+  friend match_t index::internal::NextFilteredMatchSingle(const MatcherT&, const DeletedT&);
   template <class MatcherT, class DeletedT>
-  friend Match index::internal::NextFilteredMatch(const MatcherT&, const DeletedT&);
+  friend match_t index::internal::NextFilteredMatch(const MatcherT&, const DeletedT&);
 
   void ResetLastMatch() {}
 };

--- a/keyvi/include/keyvi/dictionary/matching/prefix_completion_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/prefix_completion_matching.h
@@ -152,8 +152,8 @@ class PrefixCompletionMatching final {
     // check for a match given the exact prefix
     for (const auto& fsa_state : fsa_start_state_pairs) {
       if (fsa_state.first->IsFinalState(fsa_state.second)) {
-        first_match =
-            std::make_shared<Match>(0, query_length, query, 0, fsa_state.first, fsa_state.first->GetStateValue(fsa_state.second));
+        first_match = std::make_shared<Match>(0, query_length, query, 0, fsa_state.first,
+                                              fsa_state.first->GetStateValue(fsa_state.second));
         break;
       }
     }
@@ -176,8 +176,8 @@ class PrefixCompletionMatching final {
         std::string match_str = std::string(traversal_stack_->begin(), traversal_stack_->end());
 
         TRACE("found final state at depth %d %s", prefix_length_ + traverser_ptr_->GetDepth(), match_str.c_str());
-        match_t m = std::make_shared<Match>(0, prefix_length_ + traverser_ptr_->GetDepth(), match_str, 0, traverser_ptr_->GetFsa(),
-                traverser_ptr_->GetStateValue());
+        match_t m = std::make_shared<Match>(0, prefix_length_ + traverser_ptr_->GetDepth(), match_str, 0,
+                                            traverser_ptr_->GetFsa(), traverser_ptr_->GetStateValue());
 
         (*traverser_ptr_)++;
         return m;

--- a/keyvi/include/keyvi/dictionary/util/iterator_utils.h
+++ b/keyvi/include/keyvi/dictionary/util/iterator_utils.h
@@ -22,8 +22,10 @@
  *      Author: hendrik
  */
 
-#ifndef ITERATOR_UTILS_H_
-#define ITERATOR_UTILS_H_
+#ifndef KEYVI_DICTIONARY_UTIL_ITERATOR_UTILS_H_
+#define KEYVI_DICTIONARY_UTIL_ITERATOR_UTILS_H_
+
+#include <utility>
 
 namespace keyvi {
 namespace dictionary {
@@ -46,4 +48,4 @@ iterator_pair<Iterator> make_iterator_pair(Iterator f, Iterator l) {
 } /* namespace dictionary */
 } /* namespace keyvi */
 
-#endif /* ITERATOR_UTILS_H_ */
+#endif /* KEYVI_DICTIONARY_UTIL_ITERATOR_UTILS_H_ */

--- a/keyvi/include/keyvi/dictionary/util/iterator_utils.h
+++ b/keyvi/include/keyvi/dictionary/util/iterator_utils.h
@@ -29,28 +29,15 @@ namespace keyvi {
 namespace dictionary {
 namespace util {
 
-template<typename Iterator>
-class iterator_pair {
- public:
-  iterator_pair(){}
+template <typename Iterator>
+struct iterator_pair : std::pair<Iterator, Iterator> {
+  using std::pair<Iterator, Iterator>::pair;
 
-  iterator_pair(Iterator first, Iterator last)
-      : f_(first),
-        l_(last) {
-  }
-  Iterator begin() const {
-    return f_;
-  }
-  Iterator end() const {
-    return l_;
-  }
-
- private:
-  Iterator f_;
-  Iterator l_;
+  Iterator begin() const { return this->first; }
+  Iterator end() const { return this->second; }
 };
 
-template<typename Iterator>
+template <typename Iterator>
 iterator_pair<Iterator> make_iterator_pair(Iterator f, Iterator l) {
   return iterator_pair<Iterator>(f, l);
 }

--- a/keyvi/include/keyvi/index/internal/base_index_reader.h
+++ b/keyvi/include/keyvi/index/internal/base_index_reader.h
@@ -64,15 +64,15 @@ class BaseIndexReader {
    *
    * @param key the key
    */
-  dictionary::Match operator[](const std::string& key) {
-    dictionary::Match match;
+  dictionary::match_t operator[](const std::string& key) {
+    dictionary::match_t match;
     const_segments_t segments = payload_.Segments();
 
     for (auto it = segments->crbegin(); it != segments->crend(); ++it) {
       match = (*it)->GetDictionary()->operator[](key);
-      if (!match.IsEmpty()) {
+      if (match) {
         if ((*it)->IsDeleted(key)) {
-          return dictionary::Match();
+          return dictionary::match_t();
         }
         return match;
       }

--- a/keyvi/include/keyvi/index/internal/base_index_reader.h
+++ b/keyvi/include/keyvi/index/internal/base_index_reader.h
@@ -150,7 +150,7 @@ class BaseIndexReader {
       }
 
       auto func = [near_matcher]() { return near_matcher->NextMatch(); };
-      return dictionary::MatchIterator::MakeIteratorPair(func, near_matcher->FirstMatch());
+      return dictionary::MatchIterator::MakeIteratorPair(func, std::move(near_matcher->FirstMatch()));
     }
 
     auto deleted_keys_map = CreatedDeletedKeysMap(segments, fsa_start_state_payloads);
@@ -161,7 +161,7 @@ class BaseIndexReader {
 
     if (deleted_keys_map.size() == 0) {
       auto func = [near_matcher]() { return near_matcher->NextMatch(); };
-      return dictionary::MatchIterator::MakeIteratorPair(func, near_matcher->FirstMatch());
+      return dictionary::MatchIterator::MakeIteratorPair(func, std::move(near_matcher->FirstMatch()));
     }
 
     auto func = [near_matcher, deleted_keys_map]() { return NextFilteredMatch(near_matcher, deleted_keys_map); };
@@ -221,7 +221,7 @@ class BaseIndexReader {
       }
 
       auto func = [fuzzy_matcher]() { return fuzzy_matcher->NextMatch(); };
-      return dictionary::MatchIterator::MakeIteratorPair(func, fuzzy_matcher->FirstMatch());
+      return dictionary::MatchIterator::MakeIteratorPair(func, std::move(fuzzy_matcher->FirstMatch()));
     }
 
     TRACE("collect deleted keys");
@@ -238,7 +238,7 @@ class BaseIndexReader {
 
     if (deleted_keys_map.size() == 0) {
       auto func = [fuzzy_matcher]() { return fuzzy_matcher->NextMatch(); };
-      return dictionary::MatchIterator::MakeIteratorPair(func, fuzzy_matcher->FirstMatch());
+      return dictionary::MatchIterator::MakeIteratorPair(func, std::move(fuzzy_matcher->FirstMatch()));
     }
 
     auto func = [fuzzy_matcher, deleted_keys_map]() { return NextFilteredMatch(fuzzy_matcher, deleted_keys_map); };

--- a/keyvi/include/keyvi/index/internal/index_lookup_util.h
+++ b/keyvi/include/keyvi/index/internal/index_lookup_util.h
@@ -41,12 +41,12 @@ namespace internal {
  * Filters matches and drops results for deleted keys for a single FSA.
  */
 template <class MatcherT, class DeletedT>
-inline keyvi::dictionary::Match NextFilteredMatchSingle(const MatcherT& matcher, const DeletedT& deleted_keys) {
-  keyvi::dictionary::Match m = matcher->NextMatch();
+inline keyvi::dictionary::match_t NextFilteredMatchSingle(const MatcherT& matcher, const DeletedT& deleted_keys) {
+  keyvi::dictionary::match_t m = matcher->NextMatch();
 
   TRACE("check if key is deleted");
-  while (m.IsEmpty() == false) {
-    if (deleted_keys->count(m.GetMatchedString()) > 0) {
+  while (m) {
+    if (deleted_keys->count(m->GetMatchedString()) > 0) {
       matcher->ResetLastMatch();
       m = matcher->NextMatch();
       continue;
@@ -61,11 +61,11 @@ inline keyvi::dictionary::Match NextFilteredMatchSingle(const MatcherT& matcher,
  * Checks if a first match is marked as deleted. Single FSA case.
  */
 template <class MatcherT, class DeletedT>
-inline keyvi::dictionary::Match FirstFilteredMatchSingle(const MatcherT& matcher, const DeletedT& deleted_keys) {
-  dictionary::Match first_match = matcher->FirstMatch();
-  if (first_match.IsEmpty() == false) {
-    if (deleted_keys->count(first_match.GetMatchedString()) > 0) {
-      return dictionary::Match();
+inline keyvi::dictionary::match_t FirstFilteredMatchSingle(const MatcherT& matcher, const DeletedT& deleted_keys) {
+  dictionary::match_t first_match = matcher->FirstMatch();
+  if (first_match) {
+    if (deleted_keys->count(first_match->GetMatchedString()) > 0) {
+      return dictionary::match_t();
     }
   }
   return first_match;
@@ -75,14 +75,14 @@ inline keyvi::dictionary::Match FirstFilteredMatchSingle(const MatcherT& matcher
  * Filters matches and drops results for deleted keys for a multiple FSA's.
  */
 template <class MatcherT, class DeletedT>
-inline keyvi::dictionary::Match NextFilteredMatch(const MatcherT& matcher, const DeletedT& deleted_keys_map) {
-  keyvi::dictionary::Match m = matcher->NextMatch();
+inline keyvi::dictionary::match_t NextFilteredMatch(const MatcherT& matcher, const DeletedT& deleted_keys_map) {
+  keyvi::dictionary::match_t m = matcher->NextMatch();
 
   TRACE("check if key is deleted");
-  while (m.IsEmpty() == false) {
-    auto dk = deleted_keys_map.find(m.GetFsa());
+  while (m) {
+    auto dk = deleted_keys_map.find(m->GetFsa());
     if (dk != deleted_keys_map.end()) {
-      if (dk->second->count(m.GetMatchedString()) > 0) {
+      if (dk->second->count(m->GetMatchedString()) > 0) {
         matcher->ResetLastMatch();
         m = matcher->NextMatch();
         continue;
@@ -97,13 +97,13 @@ inline keyvi::dictionary::Match NextFilteredMatch(const MatcherT& matcher, const
  * Checks if a first match is marked as deleted. Multi FSA case.
  */
 template <class MatcherT, class DeletedT>
-inline keyvi::dictionary::Match FirstFilteredMatch(const MatcherT& matcher, const DeletedT& deleted_keys_map) {
-  dictionary::Match first_match = matcher->FirstMatch();
-  if (first_match.IsEmpty() == false) {
-    auto dk = deleted_keys_map.find(first_match.GetFsa());
+inline keyvi::dictionary::match_t FirstFilteredMatch(const MatcherT& matcher, const DeletedT& deleted_keys_map) {
+  dictionary::match_t first_match = matcher->FirstMatch();
+  if (first_match) {
+    auto dk = deleted_keys_map.find(first_match->GetFsa());
     if (dk != deleted_keys_map.end()) {
-      if (dk->second->count(first_match.GetMatchedString()) > 0) {
-        return dictionary::Match();
+      if (dk->second->count(first_match->GetMatchedString()) > 0) {
+        return dictionary::match_t();
       }
     }
   }

--- a/keyvi/include/keyvi/testing/matching_test_utils.h
+++ b/keyvi/include/keyvi/testing/matching_test_utils.h
@@ -45,7 +45,7 @@ void test_matching(std::vector<std::pair<std::string, uint32_t>>* test_data, con
       matchingType<dictionary::fsa::WeightedStateTraverser>::FromSingleFsa(dictionary.GetFsa(), query));
 
   dictionary::MatchIterator::MatchIteratorPair it = dictionary::MatchIterator::MakeIteratorPair(
-      [matcher_weights]() { return matcher_weights->NextMatch(); }, matcher_weights->FirstMatch());
+      [matcher_weights]() { return matcher_weights->NextMatch(); }, std::move(matcher_weights->FirstMatch()));
 
   auto expected_it = expected.begin();
   for (auto m : it) {
@@ -60,7 +60,7 @@ void test_matching(std::vector<std::pair<std::string, uint32_t>>* test_data, con
   auto matcher_no_weights = std::make_shared<matchingType<dictionary::fsa::StateTraverser<>>>(
       matchingType<dictionary::fsa::StateTraverser<>>::FromSingleFsa(dictionary.GetFsa(), query));
   dictionary::MatchIterator::MatchIteratorPair matcher_no_weights_it = dictionary::MatchIterator::MakeIteratorPair(
-      [matcher_no_weights]() { return matcher_no_weights->NextMatch(); }, matcher_no_weights->FirstMatch());
+      [matcher_no_weights]() { return matcher_no_weights->NextMatch(); }, std::move(matcher_no_weights->FirstMatch()));
 
   expected_it = expected_sorted.begin();
   for (auto m : matcher_no_weights_it) {
@@ -96,7 +96,7 @@ void test_matching(std::vector<std::pair<std::string, uint32_t>>* test_data, con
           matchingType<dictionary::fsa::ZipStateTraverser<dictionary::fsa::WeightedStateTraverser>>::FromMulipleFsas(
               fsas, query));
   dictionary::MatchIterator::MatchIteratorPair matcher_zipped_it = dictionary::MatchIterator::MakeIteratorPair(
-      [matcher_zipped]() { return matcher_zipped->NextMatch(); }, matcher_zipped->FirstMatch());
+      [matcher_zipped]() { return matcher_zipped->NextMatch(); }, std::move(matcher_zipped->FirstMatch()));
   expected_it = expected.begin();
   for (auto m : matcher_zipped_it) {
     BOOST_CHECK(expected_it != expected.end());
@@ -112,7 +112,7 @@ void test_matching(std::vector<std::pair<std::string, uint32_t>>* test_data, con
   dictionary::MatchIterator::MatchIteratorPair matcher_zipped_no_weights_it =
       dictionary::MatchIterator::MakeIteratorPair(
           [matcher_zipped_no_weights]() { return matcher_zipped_no_weights->NextMatch(); },
-          matcher_zipped_no_weights->FirstMatch());
+          std::move(matcher_zipped_no_weights->FirstMatch()));
   expected_it = expected_sorted.begin();
   for (auto m : matcher_zipped_no_weights_it) {
     BOOST_CHECK(expected_it != expected_sorted.end());

--- a/keyvi/include/keyvi/testing/matching_test_utils.h
+++ b/keyvi/include/keyvi/testing/matching_test_utils.h
@@ -50,7 +50,7 @@ void test_matching(std::vector<std::pair<std::string, uint32_t>>* test_data, con
   auto expected_it = expected.begin();
   for (auto m : it) {
     BOOST_CHECK(expected_it != expected.end());
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    BOOST_CHECK_EQUAL(*expected_it++, m->GetMatchedString());
   }
 
   // test without weights
@@ -65,7 +65,7 @@ void test_matching(std::vector<std::pair<std::string, uint32_t>>* test_data, con
   expected_it = expected_sorted.begin();
   for (auto m : matcher_no_weights_it) {
     BOOST_CHECK(expected_it != expected_sorted.end());
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    BOOST_CHECK_EQUAL(*expected_it++, m->GetMatchedString());
   }
   BOOST_CHECK(expected_it == expected_sorted.end());
 
@@ -100,7 +100,7 @@ void test_matching(std::vector<std::pair<std::string, uint32_t>>* test_data, con
   expected_it = expected.begin();
   for (auto m : matcher_zipped_it) {
     BOOST_CHECK(expected_it != expected.end());
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    BOOST_CHECK_EQUAL(*expected_it++, m->GetMatchedString());
   }
   BOOST_CHECK(expected_it == expected.end());
 
@@ -116,7 +116,7 @@ void test_matching(std::vector<std::pair<std::string, uint32_t>>* test_data, con
   expected_it = expected_sorted.begin();
   for (auto m : matcher_zipped_no_weights_it) {
     BOOST_CHECK(expected_it != expected_sorted.end());
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    BOOST_CHECK_EQUAL(*expected_it++, m->GetMatchedString());
   }
   BOOST_CHECK(expected_it == expected_sorted.end());
 }

--- a/keyvi/tests/keyvi/dictionary/completion/prefix_completion_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/completion/prefix_completion_test.cpp
@@ -73,14 +73,14 @@ BOOST_AUTO_TEST_CASE(simple) {
 
   auto expected_it = expected_output.begin();
   for (auto m : prefix_completion.GetCompletions("aa")) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    BOOST_CHECK_EQUAL(*expected_it++, m->GetMatchedString());
   }
 
   BOOST_CHECK(expected_it == expected_output.end());
 
   auto prefix_match_pair = prefix_completion.GetCompletions("aaaa");
   MatchIterator prefix = prefix_match_pair.begin();
-  BOOST_CHECK_EQUAL((*prefix).GetMatchedString(), "aaaa");
+  BOOST_CHECK_EQUAL((*prefix)->GetMatchedString(), "aaaa");
   prefix++;
   BOOST_CHECK(prefix == prefix_match_pair.end());
 }
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(limit) {
 
   auto expected_it = expected_output.begin();
   for (auto m : prefix_completion.GetCompletions("angel")) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    BOOST_CHECK_EQUAL(*expected_it++, m->GetMatchedString());
   }
 
   BOOST_CHECK(expected_it == expected_output.end());
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(approx1) {
 
   auto expected_it = expected_output.begin();
   for (auto m : prefix_completion.GetFuzzyCompletions("aabd", 2)) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    BOOST_CHECK_EQUAL(*expected_it++, m->GetMatchedString());
   }
   BOOST_CHECK(expected_it == expected_output.end());
 
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(approx1) {
 
   expected_it = expected_output.begin();
   for (auto m : prefix_completion.GetFuzzyCompletions("aabc", 2)) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    BOOST_CHECK_EQUAL(*expected_it++, m->GetMatchedString());
   }
   BOOST_CHECK(expected_it == expected_output.end());
 }
@@ -157,13 +157,13 @@ BOOST_AUTO_TEST_CASE(approxWithExactPrefix) {
 
   auto expected_it = expected_output.begin();
   for (auto m : prefix_completion.GetFuzzyCompletions("mß", 1)) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    BOOST_CHECK_EQUAL(*expected_it++, m->GetMatchedString());
   }
   BOOST_CHECK(expected_it == expected_output.end());
 
   expected_it = expected_output.begin();
   for (auto m : prefix_completion.GetFuzzyCompletions("mß", 2)) {
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    BOOST_CHECK_EQUAL(*expected_it++, m->GetMatchedString());
   }
   BOOST_CHECK(expected_it == expected_output.end());
 }

--- a/keyvi/tests/keyvi/dictionary/dictionary_compiler_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/dictionary_compiler_test.cpp
@@ -255,9 +255,9 @@ void bigger_compile_test(const keyvi::util::parameters_t& params = keyvi::util::
   Dictionary d(file_name.c_str());
 
   for (size_t i = 0; i < keys; ++i) {
-    keyvi::dictionary::Match m = d["loooooooooooooooonnnnnnnngggggggg_key-" + std::to_string(i)];
-    BOOST_CHECK_EQUAL("loooooooooooooooonnnnnnnngggggggg_key-" + std::to_string(i), m.GetMatchedString());
-    BOOST_CHECK_EQUAL("{\"id\":" + std::to_string(i) + "}", m.GetValueAsString());
+    keyvi::dictionary::match_t m = d["loooooooooooooooonnnnnnnngggggggg_key-" + std::to_string(i)];
+    BOOST_CHECK_EQUAL("loooooooooooooooonnnnnnnngggggggg_key-" + std::to_string(i), m->GetMatchedString());
+    BOOST_CHECK_EQUAL("{\"id\":" + std::to_string(i) + "}", m->GetValueAsString());
   }
 }
 
@@ -291,8 +291,8 @@ BOOST_AUTO_TEST_CASE(float_dictionary) {
 
   bool matched = false;
   for (auto m : d.Get("abbe")) {
-    BOOST_CHECK_EQUAL("3.1, 0.2, 1.3, 0.4, 0.5", m.GetValueAsString());
-    std::vector<float> float_vector = keyvi::util::DecodeFloatVector(m.GetRawValueAsString());
+    BOOST_CHECK_EQUAL("3.1, 0.2, 1.3, 0.4, 0.5", m->GetValueAsString());
+    std::vector<float> float_vector = keyvi::util::DecodeFloatVector(m->GetRawValueAsString());
     BOOST_CHECK_EQUAL(5, float_vector.size());
     BOOST_CHECK_EQUAL(3.1f, float_vector[0]);
     BOOST_CHECK_EQUAL(1.3f, float_vector[2]);

--- a/keyvi/tests/keyvi/dictionary/dictionary_index_compiler_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/dictionary_index_compiler_test.cpp
@@ -151,9 +151,9 @@ void bigger_compile_test(const keyvi::util::parameters_t& params = keyvi::util::
   Dictionary d(file_name.c_str());
 
   for (size_t i = 0; i < 50; ++i) {
-    keyvi::dictionary::Match m = d["loooooooooooooooonnnnnnnngggggggg_key-" + std::to_string(i)];
-    BOOST_CHECK_EQUAL("loooooooooooooooonnnnnnnngggggggg_key-" + std::to_string(i), m.GetMatchedString());
-    BOOST_CHECK_EQUAL("{\"id\":" + std::to_string(keys - 50 + i) + "}", m.GetValueAsString());
+    keyvi::dictionary::match_t m = d["loooooooooooooooonnnnnnnngggggggg_key-" + std::to_string(i)];
+    BOOST_CHECK_EQUAL("loooooooooooooooonnnnnnnngggggggg_key-" + std::to_string(i), m->GetMatchedString());
+    BOOST_CHECK_EQUAL("{\"id\":" + std::to_string(keys - 50 + i) + "}", m->GetValueAsString());
   }
 }
 

--- a/keyvi/tests/keyvi/dictionary/dictionary_merger_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/dictionary_merger_test.cpp
@@ -114,20 +114,20 @@ BOOST_AUTO_TEST_CASE(MergeIntegerDicts) {
   BOOST_CHECK(d->Contains("abdd"));
   BOOST_CHECK(d->Contains("bba"));
 
-  BOOST_CHECK_EQUAL("22", d->operator[]("abc").GetValueAsString());
-  BOOST_CHECK_EQUAL("24", d->operator[]("abbc").GetValueAsString());
-  BOOST_CHECK_EQUAL("444", d->operator[]("abbcd").GetValueAsString());
-  BOOST_CHECK_EQUAL("200", d->operator[]("abcde").GetValueAsString());
-  BOOST_CHECK_EQUAL("180", d->operator[]("abdd").GetValueAsString());
-  BOOST_CHECK_EQUAL("10", d->operator[]("bba").GetValueAsString());
+  BOOST_CHECK_EQUAL("22", d->operator[]("abc")->GetValueAsString());
+  BOOST_CHECK_EQUAL("24", d->operator[]("abbc")->GetValueAsString());
+  BOOST_CHECK_EQUAL("444", d->operator[]("abbcd")->GetValueAsString());
+  BOOST_CHECK_EQUAL("200", d->operator[]("abcde")->GetValueAsString());
+  BOOST_CHECK_EQUAL("180", d->operator[]("abdd")->GetValueAsString());
+  BOOST_CHECK_EQUAL("10", d->operator[]("bba")->GetValueAsString());
 
   BOOST_CHECK(d->Contains("abcd"));
   BOOST_CHECK(d->Contains("abbe"));
   BOOST_CHECK(d->Contains("bbacd"));
 
-  BOOST_CHECK_EQUAL("21", d->operator[]("abcd").GetValueAsString());
-  BOOST_CHECK_EQUAL("25", d->operator[]("abbe").GetValueAsString());
-  BOOST_CHECK_EQUAL("30", d->operator[]("bbacd").GetValueAsString());
+  BOOST_CHECK_EQUAL("21", d->operator[]("abcd")->GetValueAsString());
+  BOOST_CHECK_EQUAL("25", d->operator[]("abbe")->GetValueAsString());
+  BOOST_CHECK_EQUAL("30", d->operator[]("bbacd")->GetValueAsString());
 
   std::remove(filename.c_str());
 }
@@ -158,9 +158,9 @@ BOOST_AUTO_TEST_CASE(MergeIntegerDictsValueMerge) {
   BOOST_CHECK(d->Contains("abbc"));
   BOOST_CHECK(d->Contains("abcd"));
 
-  BOOST_CHECK_EQUAL("25", d->operator[]("abc").GetValueAsString());
-  BOOST_CHECK_EQUAL("21", d->operator[]("abcd").GetValueAsString());
-  BOOST_CHECK_EQUAL("30", d->operator[]("abbc").GetValueAsString());
+  BOOST_CHECK_EQUAL("25", d->operator[]("abc")->GetValueAsString());
+  BOOST_CHECK_EQUAL("21", d->operator[]("abcd")->GetValueAsString());
+  BOOST_CHECK_EQUAL("30", d->operator[]("abbc")->GetValueAsString());
 
   std::remove(filename.c_str());
 
@@ -180,11 +180,11 @@ BOOST_AUTO_TEST_CASE(MergeIntegerDictsValueMerge) {
   BOOST_CHECK(d2->Contains("abbc"));
   BOOST_CHECK(d2->Contains("abcd"));
 
-  BOOST_CHECK_EQUAL("22", d2->operator[]("abc").GetValueAsString());
-  BOOST_CHECK_EQUAL("21", d2->operator[]("abcd").GetValueAsString());
+  BOOST_CHECK_EQUAL("22", d2->operator[]("abc")->GetValueAsString());
+  BOOST_CHECK_EQUAL("21", d2->operator[]("abcd")->GetValueAsString());
 
   // overwritten by 2nd
-  BOOST_CHECK_EQUAL("24", d2->operator[]("abbc").GetValueAsString());
+  BOOST_CHECK_EQUAL("24", d2->operator[]("abbc")->GetValueAsString());
 
   std::remove(filename.c_str());
 
@@ -203,9 +203,9 @@ BOOST_AUTO_TEST_CASE(MergeIntegerDictsValueMerge) {
   BOOST_CHECK(d3->Contains("abbc"));
   BOOST_CHECK(d3->Contains("abcd"));
 
-  BOOST_CHECK_EQUAL("22", d3->operator[]("abc").GetValueAsString());
-  BOOST_CHECK_EQUAL("21", d3->operator[]("abcd").GetValueAsString());
-  BOOST_CHECK_EQUAL("24", d3->operator[]("abbc").GetValueAsString());
+  BOOST_CHECK_EQUAL("22", d3->operator[]("abc")->GetValueAsString());
+  BOOST_CHECK_EQUAL("21", d3->operator[]("abcd")->GetValueAsString());
+  BOOST_CHECK_EQUAL("24", d3->operator[]("abbc")->GetValueAsString());
 
   std::remove(filename.c_str());
 }
@@ -236,9 +236,9 @@ BOOST_AUTO_TEST_CASE(MergeIntegerDictsAppendMerge) {
   BOOST_CHECK(d->Contains("abbc"));
   BOOST_CHECK(d->Contains("abcd"));
 
-  BOOST_CHECK_EQUAL("25", d->operator[]("abc").GetValueAsString());
-  BOOST_CHECK_EQUAL("21", d->operator[]("abcd").GetValueAsString());
-  BOOST_CHECK_EQUAL("30", d->operator[]("abbc").GetValueAsString());
+  BOOST_CHECK_EQUAL("25", d->operator[]("abc")->GetValueAsString());
+  BOOST_CHECK_EQUAL("21", d->operator[]("abcd")->GetValueAsString());
+  BOOST_CHECK_EQUAL("30", d->operator[]("abbc")->GetValueAsString());
 
   std::remove(filename.c_str());
 
@@ -258,11 +258,11 @@ BOOST_AUTO_TEST_CASE(MergeIntegerDictsAppendMerge) {
   BOOST_CHECK(d2->Contains("abbc"));
   BOOST_CHECK(d2->Contains("abcd"));
 
-  BOOST_CHECK_EQUAL("22", d2->operator[]("abc").GetValueAsString());
-  BOOST_CHECK_EQUAL("21", d2->operator[]("abcd").GetValueAsString());
+  BOOST_CHECK_EQUAL("22", d2->operator[]("abc")->GetValueAsString());
+  BOOST_CHECK_EQUAL("21", d2->operator[]("abcd")->GetValueAsString());
 
   // overwritten by 2nd
-  BOOST_CHECK_EQUAL("24", d2->operator[]("abbc").GetValueAsString());
+  BOOST_CHECK_EQUAL("24", d2->operator[]("abbc")->GetValueAsString());
 
   std::remove(filename.c_str());
 
@@ -281,9 +281,9 @@ BOOST_AUTO_TEST_CASE(MergeIntegerDictsAppendMerge) {
   BOOST_CHECK(d3->Contains("abbc"));
   BOOST_CHECK(d3->Contains("abcd"));
 
-  BOOST_CHECK_EQUAL("22", d3->operator[]("abc").GetValueAsString());
-  BOOST_CHECK_EQUAL("21", d3->operator[]("abcd").GetValueAsString());
-  BOOST_CHECK_EQUAL("24", d3->operator[]("abbc").GetValueAsString());
+  BOOST_CHECK_EQUAL("22", d3->operator[]("abc")->GetValueAsString());
+  BOOST_CHECK_EQUAL("21", d3->operator[]("abcd")->GetValueAsString());
+  BOOST_CHECK_EQUAL("24", d3->operator[]("abbc")->GetValueAsString());
 
   std::remove(filename.c_str());
 }
@@ -323,22 +323,22 @@ BOOST_AUTO_TEST_CASE(MergeStringDicts) {
     BOOST_CHECK(d->Contains("abdd"));
     BOOST_CHECK(d->Contains("bba"));
 
-    BOOST_CHECK_EQUAL("a", d->operator[]("abc").GetValueAsString());
+    BOOST_CHECK_EQUAL("a", d->operator[]("abc")->GetValueAsString());
 
     // overwritten by 2nd
-    BOOST_CHECK_EQUAL("z", d->operator[]("abbc").GetValueAsString());
-    BOOST_CHECK_EQUAL("c", d->operator[]("abbcd").GetValueAsString());
-    BOOST_CHECK_EQUAL("a", d->operator[]("abcde").GetValueAsString());
-    BOOST_CHECK_EQUAL("b", d->operator[]("abdd").GetValueAsString());
-    BOOST_CHECK_EQUAL("c", d->operator[]("bba").GetValueAsString());
+    BOOST_CHECK_EQUAL("z", d->operator[]("abbc")->GetValueAsString());
+    BOOST_CHECK_EQUAL("c", d->operator[]("abbcd")->GetValueAsString());
+    BOOST_CHECK_EQUAL("a", d->operator[]("abcde")->GetValueAsString());
+    BOOST_CHECK_EQUAL("b", d->operator[]("abdd")->GetValueAsString());
+    BOOST_CHECK_EQUAL("c", d->operator[]("bba")->GetValueAsString());
 
     BOOST_CHECK(d->Contains("abcd"));
     BOOST_CHECK(d->Contains("abbe"));
     BOOST_CHECK(d->Contains("bbacd"));
 
-    BOOST_CHECK_EQUAL("a", d->operator[]("abcd").GetValueAsString());
-    BOOST_CHECK_EQUAL("d", d->operator[]("abbe").GetValueAsString());
-    BOOST_CHECK_EQUAL("f", d->operator[]("bbacd").GetValueAsString());
+    BOOST_CHECK_EQUAL("a", d->operator[]("abcd")->GetValueAsString());
+    BOOST_CHECK_EQUAL("d", d->operator[]("abbe")->GetValueAsString());
+    BOOST_CHECK_EQUAL("f", d->operator[]("bbacd")->GetValueAsString());
 
     std::remove(filename.c_str());
   }
@@ -383,22 +383,22 @@ BOOST_AUTO_TEST_CASE(MergeJsonDicts) {
     BOOST_CHECK(d->Contains("bba"));
     BOOST_CHECK(d->Contains("bbacd"));
 
-    BOOST_CHECK_EQUAL("\"{a:1}\"", d->operator[]("abc").GetValueAsString());
+    BOOST_CHECK_EQUAL("\"{a:1}\"", d->operator[]("abc")->GetValueAsString());
 
     // overwritten by 2nd
-    BOOST_CHECK_EQUAL("\"{b:3}\"", d->operator[]("abbc").GetValueAsString());
-    BOOST_CHECK_EQUAL("\"{c:3}\"", d->operator[]("abbcd").GetValueAsString());
-    BOOST_CHECK_EQUAL("\"{a:1}\"", d->operator[]("abcde").GetValueAsString());
-    BOOST_CHECK_EQUAL("\"{b:2}\"", d->operator[]("abdd").GetValueAsString());
-    BOOST_CHECK_EQUAL("\"{c:3}\"", d->operator[]("bba").GetValueAsString());
+    BOOST_CHECK_EQUAL("\"{b:3}\"", d->operator[]("abbc")->GetValueAsString());
+    BOOST_CHECK_EQUAL("\"{c:3}\"", d->operator[]("abbcd")->GetValueAsString());
+    BOOST_CHECK_EQUAL("\"{a:1}\"", d->operator[]("abcde")->GetValueAsString());
+    BOOST_CHECK_EQUAL("\"{b:2}\"", d->operator[]("abdd")->GetValueAsString());
+    BOOST_CHECK_EQUAL("\"{c:3}\"", d->operator[]("bba")->GetValueAsString());
 
     BOOST_CHECK(d->Contains("abcd"));
     BOOST_CHECK(d->Contains("abbe"));
     BOOST_CHECK(d->Contains("bbacd"));
 
-    BOOST_CHECK_EQUAL("\"{a:1}\"", d->operator[]("abcd").GetValueAsString());
-    BOOST_CHECK_EQUAL("\"{d:4}\"", d->operator[]("abbe").GetValueAsString());
-    BOOST_CHECK_EQUAL("\"{f:5}\"", d->operator[]("bbacd").GetValueAsString());
+    BOOST_CHECK_EQUAL("\"{a:1}\"", d->operator[]("abcd")->GetValueAsString());
+    BOOST_CHECK_EQUAL("\"{d:4}\"", d->operator[]("abbe")->GetValueAsString());
+    BOOST_CHECK_EQUAL("\"{f:5}\"", d->operator[]("bbacd")->GetValueAsString());
 
     BOOST_CHECK_EQUAL(0, merger.GetStats().deleted_keys_);
     BOOST_CHECK_EQUAL(1, merger.GetStats().updated_keys_);
@@ -447,12 +447,12 @@ BOOST_AUTO_TEST_CASE(MergeFloatVectorDicts, *boost::unit_test::tolerance(0.00001
     BOOST_CHECK(d->Contains("bba"));
     BOOST_CHECK(d->Contains("bbacd"));
 
-    auto v = keyvi::util::DecodeFloatVector(d->operator[]("abc").GetRawValueAsString());
+    auto v = keyvi::util::DecodeFloatVector(d->operator[]("abc")->GetRawValueAsString());
     BOOST_CHECK_EQUAL(5, v.size());
     BOOST_TEST(0.4 == v[3]);
     BOOST_TEST(0.2 == v[1]);
 
-    v = keyvi::util::DecodeFloatVector(d->operator[]("abbc").GetRawValueAsString());
+    v = keyvi::util::DecodeFloatVector(d->operator[]("abbc")->GetRawValueAsString());
     BOOST_CHECK_EQUAL(5, v.size());
     BOOST_TEST(3.1 == v[0]);
     BOOST_TEST(2.3 == v[2]);
@@ -519,9 +519,9 @@ BOOST_AUTO_TEST_CASE(MergeIntegerWeightDictsValueMerge) {
   BOOST_CHECK(d->Contains("abbc"));
   BOOST_CHECK(d->Contains("abcd"));
 
-  BOOST_CHECK_EQUAL("25", d->operator[]("abc").GetValueAsString());
-  BOOST_CHECK_EQUAL("21", d->operator[]("abcd").GetValueAsString());
-  BOOST_CHECK_EQUAL("30", d->operator[]("abbc").GetValueAsString());
+  BOOST_CHECK_EQUAL("25", d->operator[]("abc")->GetValueAsString());
+  BOOST_CHECK_EQUAL("21", d->operator[]("abcd")->GetValueAsString());
+  BOOST_CHECK_EQUAL("30", d->operator[]("abbc")->GetValueAsString());
 
   fsa::WeightedStateTraverser s(fsa);
   BOOST_CHECK_EQUAL('a', s.GetStateLabel());
@@ -575,11 +575,11 @@ BOOST_AUTO_TEST_CASE(MergeIntegerWeightDictsValueMerge) {
   BOOST_CHECK(d2->Contains("abbc"));
   BOOST_CHECK(d2->Contains("abcd"));
 
-  BOOST_CHECK_EQUAL("22", d2->operator[]("abc").GetValueAsString());
-  BOOST_CHECK_EQUAL("21", d2->operator[]("abcd").GetValueAsString());
+  BOOST_CHECK_EQUAL("22", d2->operator[]("abc")->GetValueAsString());
+  BOOST_CHECK_EQUAL("21", d2->operator[]("abcd")->GetValueAsString());
 
   // overwritten by 2nd
-  BOOST_CHECK_EQUAL("24", d2->operator[]("abbc").GetValueAsString());
+  BOOST_CHECK_EQUAL("24", d2->operator[]("abbc")->GetValueAsString());
 
   std::remove(filename.c_str());
 
@@ -598,9 +598,9 @@ BOOST_AUTO_TEST_CASE(MergeIntegerWeightDictsValueMerge) {
   BOOST_CHECK(d3->Contains("abbc"));
   BOOST_CHECK(d3->Contains("abcd"));
 
-  BOOST_CHECK_EQUAL("22", d3->operator[]("abc").GetValueAsString());
-  BOOST_CHECK_EQUAL("21", d3->operator[]("abcd").GetValueAsString());
-  BOOST_CHECK_EQUAL("24", d3->operator[]("abbc").GetValueAsString());
+  BOOST_CHECK_EQUAL("22", d3->operator[]("abc")->GetValueAsString());
+  BOOST_CHECK_EQUAL("21", d3->operator[]("abcd")->GetValueAsString());
+  BOOST_CHECK_EQUAL("24", d3->operator[]("abbc")->GetValueAsString());
 
   fsa::WeightedStateTraverser s3(fsa3);
   BOOST_CHECK_EQUAL('a', s3.GetStateLabel());
@@ -667,11 +667,11 @@ BOOST_AUTO_TEST_CASE(MergeIntegerWeightDictsAppendMerge) {
   BOOST_CHECK(d2->Contains("abbc"));
   BOOST_CHECK(d2->Contains("abcd"));
 
-  BOOST_CHECK_EQUAL("22", d2->operator[]("abc").GetValueAsString());
-  BOOST_CHECK_EQUAL("21", d2->operator[]("abcd").GetValueAsString());
+  BOOST_CHECK_EQUAL("22", d2->operator[]("abc")->GetValueAsString());
+  BOOST_CHECK_EQUAL("21", d2->operator[]("abcd")->GetValueAsString());
 
   // overwritten by 2nd
-  BOOST_CHECK_EQUAL("24", d2->operator[]("abbc").GetValueAsString());
+  BOOST_CHECK_EQUAL("24", d2->operator[]("abbc")->GetValueAsString());
 
   std::remove(filename.c_str());
 }
@@ -696,8 +696,8 @@ BOOST_AUTO_TEST_CASE(MergeToEmptyDict) {
 
   BOOST_CHECK(d->Contains("abbc"));
   BOOST_CHECK(d->Contains("abbe"));
-  BOOST_CHECK_EQUAL("\"{b:3}\"", d->operator[]("abbc").GetValueAsString());
-  BOOST_CHECK_EQUAL("\"{d:4}\"", d->operator[]("abbe").GetValueAsString());
+  BOOST_CHECK_EQUAL("\"{b:3}\"", d->operator[]("abbc")->GetValueAsString());
+  BOOST_CHECK_EQUAL("\"{d:4}\"", d->operator[]("abbe")->GetValueAsString());
 
   BOOST_CHECK_EQUAL(0, merger.GetStats().deleted_keys_);
   BOOST_CHECK_EQUAL(0, merger.GetStats().updated_keys_);

--- a/keyvi/tests/keyvi/dictionary/dictionary_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/dictionary_test.cpp
@@ -70,8 +70,8 @@ BOOST_AUTO_TEST_CASE(DictGet) {
 
   bool matched = false;
   for (auto m : d->Get("test")) {
-    BOOST_CHECK_EQUAL("test", m.GetMatchedString());
-    BOOST_CHECK_EQUAL(std::string("22"), boost::get<std::string>(m.GetAttribute("weight")));
+    BOOST_CHECK_EQUAL("test", m->GetMatchedString());
+    BOOST_CHECK_EQUAL(std::string("22"), boost::get<std::string>(m->GetAttribute("weight")));
     matched = true;
   }
   BOOST_CHECK(matched);
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(DictGet) {
   BOOST_CHECK(!matched);
 
   auto m = (*d)["test"];
-  BOOST_CHECK_EQUAL("22", boost::get<std::string>(m.GetAttribute("weight")));
+  BOOST_CHECK_EQUAL("22", boost::get<std::string>(m->GetAttribute("weight")));
 }
 
 BOOST_AUTO_TEST_CASE(DictLookup) {
@@ -98,24 +98,24 @@ BOOST_AUTO_TEST_CASE(DictLookup) {
 
   bool matched = false;
   for (auto m : d->Lookup("nude")) {
-    BOOST_CHECK_EQUAL("nude", m.GetMatchedString());
-    BOOST_CHECK_EQUAL("22", boost::get<std::string>(m.GetAttribute("weight")));
+    BOOST_CHECK_EQUAL("nude", m->GetMatchedString());
+    BOOST_CHECK_EQUAL("22", boost::get<std::string>(m->GetAttribute("weight")));
     matched = true;
   }
   BOOST_CHECK(matched);
 
   matched = false;
   for (auto m : d->Lookup("nude ")) {
-    BOOST_CHECK_EQUAL("nude", m.GetMatchedString());
-    BOOST_CHECK_EQUAL("22", boost::get<std::string>(m.GetAttribute("weight")));
+    BOOST_CHECK_EQUAL("nude", m->GetMatchedString());
+    BOOST_CHECK_EQUAL("22", boost::get<std::string>(m->GetAttribute("weight")));
     matched = true;
   }
   BOOST_CHECK(matched);
 
   matched = false;
   for (auto m : d->Lookup("nude at work")) {
-    BOOST_CHECK_EQUAL("nude", m.GetMatchedString());
-    BOOST_CHECK_EQUAL("22", boost::get<std::string>(m.GetAttribute("weight")));
+    BOOST_CHECK_EQUAL("nude", m->GetMatchedString());
+    BOOST_CHECK_EQUAL("22", boost::get<std::string>(m->GetAttribute("weight")));
     matched = true;
   }
   BOOST_CHECK(matched);
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(DictGetNear) {
     if (i >= expected_matches.size()) {
       BOOST_FAIL("got more results than expected.");
     }
-    BOOST_CHECK_EQUAL(expected_matches[i++], m.GetMatchedString());
+    BOOST_CHECK_EQUAL(expected_matches[i++], m->GetMatchedString());
   }
 
   BOOST_CHECK_EQUAL(expected_matches.size(), i);
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(DictGetNear) {
     if (i >= expected_matches.size()) {
       BOOST_FAIL("got more results than expected.");
     }
-    BOOST_CHECK_EQUAL(expected_matches[i++], m.GetMatchedString());
+    BOOST_CHECK_EQUAL(expected_matches[i++], m->GetMatchedString());
   }
 
   BOOST_CHECK_EQUAL(expected_matches.size(), i);
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE(DictGetNear) {
     if (i >= expected_matches.size()) {
       BOOST_FAIL("got more results than expected.");
     }
-    BOOST_CHECK_EQUAL(expected_matches[i++], m.GetMatchedString());
+    BOOST_CHECK_EQUAL(expected_matches[i++], m->GetMatchedString());
   }
 
   BOOST_CHECK_EQUAL(expected_matches.size(), i);
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(DictGetNear) {
     if (i >= expected_matches.size()) {
       BOOST_FAIL("got more results than expected.");
     }
-    BOOST_CHECK_EQUAL(expected_matches[i++], m.GetMatchedString());
+    BOOST_CHECK_EQUAL(expected_matches[i++], m->GetMatchedString());
   }
 
   BOOST_CHECK_EQUAL(expected_matches.size(), i);
@@ -206,8 +206,8 @@ BOOST_AUTO_TEST_CASE(DictGetZerobyte) {
 
   bool matched = false;
   for (auto m : d->Get(std::string("\0test", 5))) {
-    BOOST_CHECK_EQUAL(std::string("\0test", 5), m.GetMatchedString());
-    BOOST_CHECK_EQUAL(std::string("22"), boost::get<std::string>(m.GetAttribute("weight")));
+    BOOST_CHECK_EQUAL(std::string("\0test", 5), m->GetMatchedString());
+    BOOST_CHECK_EQUAL(std::string("22"), boost::get<std::string>(m->GetAttribute("weight")));
     matched = true;
   }
   BOOST_CHECK(matched);
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(DictGetZerobyte) {
   BOOST_CHECK(!matched);
 
   auto m = (*d)[std::string("\0test", 5)];
-  BOOST_CHECK_EQUAL("22", boost::get<std::string>(m.GetAttribute("weight")));
+  BOOST_CHECK_EQUAL("22", boost::get<std::string>(m->GetAttribute("weight")));
 }
 
 BOOST_AUTO_TEST_CASE(DictGetPrefixCompletion) {
@@ -240,7 +240,7 @@ BOOST_AUTO_TEST_CASE(DictGetPrefixCompletion) {
     if (i >= expected_matches.size()) {
       BOOST_FAIL("got more results than expected.");
     }
-    BOOST_CHECK_EQUAL(expected_matches[i++], m.GetMatchedString());
+    BOOST_CHECK_EQUAL(expected_matches[i++], m->GetMatchedString());
   }
 
   BOOST_CHECK_EQUAL(expected_matches.size(), i);
@@ -253,7 +253,7 @@ BOOST_AUTO_TEST_CASE(DictGetPrefixCompletion) {
     if (i >= expected_matches.size()) {
       BOOST_FAIL("got more results than expected.");
     }
-    BOOST_CHECK_EQUAL(expected_matches[i++], m.GetMatchedString());
+    BOOST_CHECK_EQUAL(expected_matches[i++], m->GetMatchedString());
   }
 
   BOOST_CHECK_EQUAL(expected_matches.size(), i);
@@ -281,11 +281,11 @@ BOOST_AUTO_TEST_CASE(DictGetPrefixCompletionCustomFilter) {
   auto completer_it = completer.begin();
 
   while (completer_it != completer.end()) {
-    if (completer_it->GetMatchedString().back() == 'b') {
+    if ((*completer_it)->GetMatchedString().back() == 'b') {
       if (i >= expected_matches.size()) {
         BOOST_FAIL("got more results than expected.");
       }
-      BOOST_CHECK_EQUAL(expected_matches[i++], completer_it->GetMatchedString());
+      BOOST_CHECK_EQUAL(expected_matches[i++], (*completer_it)->GetMatchedString());
     }
     completer_it.SetMinWeight(500);
     completer_it++;

--- a/keyvi/tests/keyvi/dictionary/matching/fuzzy_matching_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/matching/fuzzy_matching_test.cpp
@@ -50,7 +50,7 @@ void test_fuzzy_matching(std::vector<std::pair<std::string, uint32_t>>* test_dat
   auto expected_it = expected.begin();
   for (auto m : it) {
     BOOST_CHECK(expected_it != expected.end());
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    BOOST_CHECK_EQUAL(*expected_it++, m->GetMatchedString());
   }
 
   // test without weights
@@ -66,7 +66,7 @@ void test_fuzzy_matching(std::vector<std::pair<std::string, uint32_t>>* test_dat
   expected_it = expected_sorted.begin();
   for (auto m : matcher_no_weights_it) {
     BOOST_CHECK(expected_it != expected_sorted.end());
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    BOOST_CHECK_EQUAL(*expected_it++, m->GetMatchedString());
   }
   BOOST_CHECK(expected_it == expected_sorted.end());
 
@@ -100,7 +100,7 @@ void test_fuzzy_matching(std::vector<std::pair<std::string, uint32_t>>* test_dat
   expected_it = expected.begin();
   for (auto m : matcher_zipped_it) {
     BOOST_CHECK(expected_it != expected.end());
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    BOOST_CHECK_EQUAL(*expected_it++, m->GetMatchedString());
   }
   BOOST_CHECK(expected_it == expected.end());
 
@@ -114,7 +114,7 @@ void test_fuzzy_matching(std::vector<std::pair<std::string, uint32_t>>* test_dat
   expected_it = expected_sorted.begin();
   for (auto m : matcher_zipped_no_weights_it) {
     BOOST_CHECK(expected_it != expected_sorted.end());
-    BOOST_CHECK_EQUAL(*expected_it++, m.GetMatchedString());
+    BOOST_CHECK_EQUAL(*expected_it++, m->GetMatchedString());
   }
   BOOST_CHECK(expected_it == expected_sorted.end());
 }

--- a/keyvi/tests/keyvi/dictionary/matching/fuzzy_matching_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/matching/fuzzy_matching_test.cpp
@@ -45,7 +45,7 @@ void test_fuzzy_matching(std::vector<std::pair<std::string, uint32_t>>* test_dat
       matching::FuzzyMatching<>::FromSingleFsa<>(dictionary.GetFsa(), query, max_edit_distance));
 
   MatchIterator::MatchIteratorPair it = MatchIterator::MakeIteratorPair(
-      [matcher_weights]() { return matcher_weights->NextMatch(); }, matcher_weights->FirstMatch());
+      [matcher_weights]() { return matcher_weights->NextMatch(); }, std::move(matcher_weights->FirstMatch()));
 
   auto expected_it = expected.begin();
   for (auto m : it) {
@@ -61,7 +61,7 @@ void test_fuzzy_matching(std::vector<std::pair<std::string, uint32_t>>* test_dat
       matching::FuzzyMatching<fsa::StateTraverser<>>::FromSingleFsa<fsa::StateTraverser<>>(dictionary.GetFsa(), query,
                                                                                            max_edit_distance));
   MatchIterator::MatchIteratorPair matcher_no_weights_it = MatchIterator::MakeIteratorPair(
-      [matcher_no_weights]() { return matcher_no_weights->NextMatch(); }, matcher_no_weights->FirstMatch());
+      [matcher_no_weights]() { return matcher_no_weights->NextMatch(); }, std::move(matcher_no_weights->FirstMatch()));
 
   expected_it = expected_sorted.begin();
   for (auto m : matcher_no_weights_it) {
@@ -96,7 +96,7 @@ void test_fuzzy_matching(std::vector<std::pair<std::string, uint32_t>>* test_dat
       matching::FuzzyMatching<fsa::ZipStateTraverser<fsa::WeightedStateTraverser>>::FromMulipleFsas<
           fsa::WeightedStateTraverser>(fsas, query, max_edit_distance));
   MatchIterator::MatchIteratorPair matcher_zipped_it = MatchIterator::MakeIteratorPair(
-      [matcher_zipped]() { return matcher_zipped->NextMatch(); }, matcher_zipped->FirstMatch());
+      [matcher_zipped]() { return matcher_zipped->NextMatch(); }, std::move(matcher_zipped->FirstMatch()));
   expected_it = expected.begin();
   for (auto m : matcher_zipped_it) {
     BOOST_CHECK(expected_it != expected.end());
@@ -110,7 +110,7 @@ void test_fuzzy_matching(std::vector<std::pair<std::string, uint32_t>>* test_dat
               fsa::StateTraverser<>>(fsas, query, max_edit_distance));
   MatchIterator::MatchIteratorPair matcher_zipped_no_weights_it =
       MatchIterator::MakeIteratorPair([matcher_zipped_no_weights]() { return matcher_zipped_no_weights->NextMatch(); },
-                                      matcher_zipped_no_weights->FirstMatch());
+                                      std::move(matcher_zipped_no_weights->FirstMatch()));
   expected_it = expected_sorted.begin();
   for (auto m : matcher_zipped_no_weights_it) {
     BOOST_CHECK(expected_it != expected_sorted.end());

--- a/keyvi/tests/keyvi/index/index_limits_test.cpp
+++ b/keyvi/tests/keyvi/index/index_limits_test.cpp
@@ -78,9 +78,9 @@ BOOST_AUTO_TEST_CASE(filedescriptor_limit) {
     }
     writer.Flush();
     BOOST_CHECK(writer.Contains("a"));
-    dictionary::Match m = writer["a"];
+    dictionary::match_t m = writer["a"];
 
-    BOOST_CHECK_EQUAL("{\"id\":4999}", m.GetValueAsString());
+    BOOST_CHECK_EQUAL("{\"id\":4999}", m->GetValueAsString());
   }
   boost::filesystem::remove_all(tmp_path);
 

--- a/keyvi/tests/keyvi/index/index_test.cpp
+++ b/keyvi/tests/keyvi/index/index_test.cpp
@@ -150,10 +150,10 @@ void basic_writer_bulk_test(const keyvi::util::parameters_t& params = keyvi::uti
     BOOST_CHECK(writer.Contains("c5"));
 
     // check that last one wins
-    dictionary::Match m = writer["b"];
-    BOOST_CHECK_EQUAL("{\"id\":9}", m.GetValueAsString());
+    dictionary::match_t m = writer["b"];
+    BOOST_CHECK_EQUAL("{\"id\":9}", m->GetValueAsString());
     m = writer["c5"];
-    BOOST_CHECK_EQUAL("{\"id\":5}", m.GetValueAsString());
+    BOOST_CHECK_EQUAL("{\"id\":5}", m->GetValueAsString());
   }
   boost::filesystem::remove_all(tmp_path);
 }
@@ -188,9 +188,9 @@ void bigger_feed_test(const keyvi::util::parameters_t& params = keyvi::util::par
     }
     writer.Flush();
     BOOST_CHECK(writer.Contains("a"));
-    dictionary::Match m = writer["a"];
+    dictionary::match_t m = writer["a"];
 
-    BOOST_CHECK_EQUAL("{\"id\":9999}", m.GetValueAsString());
+    BOOST_CHECK_EQUAL("{\"id\":9999}", m->GetValueAsString());
   }
   boost::filesystem::remove_all(tmp_path);
 }

--- a/keyvi/tests/keyvi/index/read_only_index_test.cpp
+++ b/keyvi/tests/keyvi/index/read_only_index_test.cpp
@@ -57,13 +57,13 @@ BOOST_AUTO_TEST_CASE(basicindex) {
   BOOST_CHECK(!reader.Contains("ab"));
   BOOST_CHECK(!reader.Contains("bbc"));
   BOOST_CHECK(!reader.Contains(""));
-  BOOST_CHECK_EQUAL(reader["abc"].GetValueAsString(), "\"{a:1}\"");
+  BOOST_CHECK_EQUAL(reader["abc"]->GetValueAsString(), "\"{a:1}\"");
 
-  BOOST_CHECK(reader[""].IsEmpty());
-  BOOST_CHECK(reader["ab"].IsEmpty());
+  BOOST_CHECK(!reader[""]);
+  BOOST_CHECK(!reader["ab"]);
 
   // test priority, last one should be returned
-  BOOST_CHECK_EQUAL(reader["abbcd"].GetValueAsString(), "\"{c:6}\"");
+  BOOST_CHECK_EQUAL(reader["abbcd"]->GetValueAsString(), "\"{c:6}\"");
 
   std::vector<std::pair<std::string, std::string>> test_data_3 = {
       {"abbcd", "{c:8}"}, {"cabc", "{a:1}"}, {"cabbc", "{b:2}"}, {"cabcde", "{a:1}"}, {"cabdd", "{b:2}"},
@@ -75,26 +75,26 @@ BOOST_AUTO_TEST_CASE(basicindex) {
   index.AddSegment(&test_data_3);
   BOOST_CHECK(reader.Contains("abc"));
 
-  BOOST_CHECK_EQUAL(reader["abbcd"].GetValueAsString(), "\"{c:6}\"");
+  BOOST_CHECK_EQUAL(reader["abbcd"]->GetValueAsString(), "\"{c:6}\"");
 
   // force reload
   reader.Reload();
   BOOST_CHECK(reader.Contains("abc"));
 
-  BOOST_CHECK_EQUAL(reader["abbcd"].GetValueAsString(), "\"{c:8}\"");
+  BOOST_CHECK_EQUAL(reader["abbcd"]->GetValueAsString(), "\"{c:8}\"");
   std::this_thread::sleep_for(std::chrono::seconds(1));
   std::vector<std::pair<std::string, std::string>> test_data_4 = {{"abbcd", "{c:10}"}};
   index.AddSegment(&test_data_4);
   std::this_thread::sleep_for(std::chrono::seconds(1));
 
-  BOOST_CHECK_EQUAL(reader["abbcd"].GetValueAsString(), "\"{c:10}\"");
+  BOOST_CHECK_EQUAL(reader["abbcd"]->GetValueAsString(), "\"{c:10}\"");
 
   std::vector<std::pair<std::string, std::string>> test_data_5 = {{"abbcd", "{c:12}"}};
   index.AddSegment(&test_data_5);
   std::this_thread::sleep_for(std::chrono::seconds(1));
   BOOST_CHECK(reader.Contains("abc"));
 
-  BOOST_CHECK_EQUAL(reader["abbcd"].GetValueAsString(), "\"{c:12}\"");
+  BOOST_CHECK_EQUAL(reader["abbcd"]->GetValueAsString(), "\"{c:12}\"");
 }
 
 BOOST_AUTO_TEST_CASE(indexwithdeletedkeys) {
@@ -122,13 +122,13 @@ BOOST_AUTO_TEST_CASE(indexwithdeletedkeys) {
   BOOST_CHECK(!reader.Contains(""));
   BOOST_CHECK(!reader.Contains("תֵ"));
 
-  BOOST_CHECK_EQUAL(reader["מַפְתֵחַ"].GetValueAsString(), "\"{b:2}\"");
+  BOOST_CHECK_EQUAL(reader["מַפְתֵחַ"]->GetValueAsString(), "\"{b:2}\"");
 
-  BOOST_CHECK(reader[""].IsEmpty());
-  BOOST_CHECK(reader["ab"].IsEmpty());
+  BOOST_CHECK(!reader[""]);
+  BOOST_CHECK(!reader["ab"]);
 
   // test priority, last one should be returned
-  BOOST_CHECK_EQUAL(reader["商店"].GetValueAsString(), "\"{b:2}\"");
+  BOOST_CHECK_EQUAL(reader["商店"]->GetValueAsString(), "\"{b:2}\"");
   index.AddDeletedKeys({"מַפְתֵחַ", "商店"}, 1);
   reader.Reload();
 
@@ -158,8 +158,8 @@ void testFuzzyMatching(ReadOnlyIndex* reader, const std::string& query, const si
   auto matcher = reader->GetFuzzy(query, max_edit_distance, minimum_exact_prefix);
   for (auto m : matcher) {
     BOOST_REQUIRE(expected_matches_it != expected_matches.end());
-    BOOST_CHECK_EQUAL(*expected_matches_it++, m.GetMatchedString());
-    BOOST_CHECK_EQUAL(*expected_values_it++, m.GetValueAsString());
+    BOOST_CHECK_EQUAL(*expected_matches_it++, m->GetMatchedString());
+    BOOST_CHECK_EQUAL(*expected_values_it++, m->GetValueAsString());
   }
   BOOST_CHECK(expected_matches_it == expected_matches.end());
 }
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(fuzzyMatching) {
   testFuzzyMatching(&reader_1, "babdd", 0, 5, {"babdd"}, {"\"{g:2}\""});
   testFuzzyMatching(&reader_1, "babdd", 0, 4, {"babdd"}, {"\"{g:2}\""});
 
-  BOOST_CHECK_EQUAL(reader_1["abbc"].GetValueAsString(), "\"{b:2}\"");
+  BOOST_CHECK_EQUAL(reader_1["abbc"]->GetValueAsString(), "\"{b:2}\"");
   testFuzzyMatching(&reader_1, "abbc", 0, 2, {"abbc"}, {"\"{b:2}\""});
   testFuzzyMatching(&reader_1, "abc", 0, 2, {"abc"}, {"\"{a:1}\""});
 
@@ -239,8 +239,8 @@ void testNearMatching(ReadOnlyIndex* reader, const std::string& query, const siz
   auto matcher = reader->GetNear(query, minimum_exact_prefix, greedy);
   for (auto m : matcher) {
     BOOST_REQUIRE(expected_matches_it != expected_matches.end());
-    BOOST_CHECK_EQUAL(*expected_matches_it++, m.GetMatchedString());
-    BOOST_CHECK_EQUAL(*expected_values_it++, m.GetValueAsString());
+    BOOST_CHECK_EQUAL(*expected_matches_it++, m->GetMatchedString());
+    BOOST_CHECK_EQUAL(*expected_values_it++, m->GetValueAsString());
   }
   BOOST_CHECK(expected_matches_it == expected_matches.end());
 }

--- a/python/src/addons/Dictionary.pyx
+++ b/python/src/addons/Dictionary.pyx
@@ -7,7 +7,7 @@
     
         cdef shared_ptr[_Match] _r = deref(self.inst.get())[(<libcpp_string>key)]
 
-        if _r.get().IsEmpty():
+        if _r.get() == nullptr:
             return default
         cdef Match py_result = Match.__new__(Match)
         py_result.inst = _r
@@ -32,7 +32,7 @@
     
         cdef shared_ptr[_Match] _r = deref(self.inst.get())[(<libcpp_string>key)]
 
-        if _r.get().IsEmpty():
+        if _r.get() == nullptr:
             raise KeyError(key)
         cdef Match py_result = Match.__new__(Match)
         py_result.inst = _r

--- a/python/src/addons/Dictionary.pyx
+++ b/python/src/addons/Dictionary.pyx
@@ -5,7 +5,7 @@
             key = key.encode('utf-8')
         assert isinstance(key, bytes), 'arg in_0 wrong type'
     
-        cdef shared_ptr[_Match] _r = shared_ptr[_Match](new _Match(deref(self.inst.get())[(<libcpp_string>key)]))
+        cdef shared_ptr[_Match] _r = deref(self.inst.get())[(<libcpp_string>key)]
 
         if _r.get().IsEmpty():
             return default
@@ -30,7 +30,7 @@
 
         assert isinstance(key, bytes), 'arg in_0 wrong type'
     
-        cdef shared_ptr[_Match] _r = shared_ptr[_Match](new _Match(deref(self.inst.get())[(<libcpp_string>key)]))
+        cdef shared_ptr[_Match] _r = deref(self.inst.get())[(<libcpp_string>key)]
 
         if _r.get().IsEmpty():
             raise KeyError(key)

--- a/python/src/addons/Index.pyx
+++ b/python/src/addons/Index.pyx
@@ -44,7 +44,7 @@
 
         cdef shared_ptr[_Match] _r = deref(self.inst.get())[(<libcpp_string>key)]
 
-        if _r.get().IsEmpty():
+        if _r.get() == nullptr:
             return default
         cdef Match py_result = Match.__new__(Match)
         py_result.inst = _r
@@ -66,7 +66,7 @@
 
         cdef shared_ptr[_Match] _r = deref(self.inst.get())[(<libcpp_string>key)]
 
-        if _r.get().IsEmpty():
+        if _r.get() == nullptr:
             raise KeyError(key)
         cdef Match py_result = Match.__new__(Match)
         py_result.inst = _r
@@ -74,7 +74,7 @@
 
     def MSet(self, list key_values ):
         assert isinstance(key_values, list), 'arg in_0 wrong type'
-        cdef s_shared_ptr[libcpp_vector[libcpp_pair[libcpp_utf8_string,libcpp_utf8_string]]] cpp_key_values = s_shared_ptr[libcpp_vector[libcpp_pair[libcpp_utf8_string,libcpp_utf8_string]]](new libcpp_vector[libcpp_pair[libcpp_utf8_string,libcpp_utf8_string]]())
+        cdef shared_ptr[libcpp_vector[libcpp_pair[libcpp_utf8_string,libcpp_utf8_string]]] cpp_key_values = shared_ptr[libcpp_vector[libcpp_pair[libcpp_utf8_string,libcpp_utf8_string]]](new libcpp_vector[libcpp_pair[libcpp_utf8_string,libcpp_utf8_string]]())
         cdef libcpp_pair[libcpp_utf8_string, libcpp_utf8_string] cpp_kv
 
         for kv in key_values:

--- a/python/src/addons/Index.pyx
+++ b/python/src/addons/Index.pyx
@@ -42,7 +42,7 @@
             key = key.encode('utf-8')
         assert isinstance(key, bytes), 'arg in_0 wrong type'
 
-        cdef shared_ptr[_Match] _r = shared_ptr[_Match](new _Match(deref(self.inst.get())[(<libcpp_string>key)]))
+        cdef shared_ptr[_Match] _r = deref(self.inst.get())[(<libcpp_string>key)]
 
         if _r.get().IsEmpty():
             return default
@@ -64,7 +64,7 @@
 
         assert isinstance(key, bytes), 'arg in_0 wrong type'
 
-        cdef shared_ptr[_Match] _r = shared_ptr[_Match](new _Match(deref(self.inst.get())[(<libcpp_string>key)]))
+        cdef shared_ptr[_Match] _r = deref(self.inst.get())[(<libcpp_string>key)]
 
         if _r.get().IsEmpty():
             raise KeyError(key)

--- a/python/src/addons/ReadOnlyIndex.pyx
+++ b/python/src/addons/ReadOnlyIndex.pyx
@@ -6,7 +6,7 @@
             key = key.encode('utf-8')
         assert isinstance(key, bytes), 'arg in_0 wrong type'
 
-        cdef shared_ptr[_Match] _r = shared_ptr[_Match](new _Match(deref(self.inst.get())[(<libcpp_string>key)]))
+        cdef shared_ptr[_Match] _r = deref(self.inst.get())[(<libcpp_string>key)]
 
         if _r.get().IsEmpty():
             return default
@@ -28,7 +28,7 @@
 
         assert isinstance(key, bytes), 'arg in_0 wrong type'
 
-        cdef shared_ptr[_Match] _r = shared_ptr[_Match](new _Match(deref(self.inst.get())[(<libcpp_string>key)]))
+        cdef shared_ptr[_Match] _r = deref(self.inst.get())[(<libcpp_string>key)]
 
         if _r.get().IsEmpty():
             raise KeyError(key)

--- a/python/src/addons/ReadOnlyIndex.pyx
+++ b/python/src/addons/ReadOnlyIndex.pyx
@@ -8,7 +8,7 @@
 
         cdef shared_ptr[_Match] _r = deref(self.inst.get())[(<libcpp_string>key)]
 
-        if _r.get().IsEmpty():
+        if _r.get() == nullptr:
             return default
         cdef Match py_result = Match.__new__(Match)
         py_result.inst = _r
@@ -30,7 +30,7 @@
 
         cdef shared_ptr[_Match] _r = deref(self.inst.get())[(<libcpp_string>key)]
 
-        if _r.get().IsEmpty():
+        if _r.get() == nullptr:
             raise KeyError(key)
         cdef Match py_result = Match.__new__(Match)
         py_result.inst = _r

--- a/python/src/addons/autwrap_workarounds.pyx
+++ b/python/src/addons/autwrap_workarounds.pyx
@@ -8,7 +8,7 @@ from cpython.version cimport PY_MAJOR_VERSION
 from libcpp.string  cimport string as libcpp_utf8_string
 from libcpp.vector cimport vector as libcpp_vector
 from libcpp.pair  cimport pair  as libcpp_pair
-from std_smart_ptr cimport shared_ptr as s_shared_ptr
+from libcpp cimport nullptr
 
 import json
 import msgpack

--- a/python/src/addons/match_iterator.pyx
+++ b/python/src/addons/match_iterator.pyx
@@ -13,16 +13,15 @@ cdef class MatchIterator:
         return self
 
     def __next__(self):
-        #if  co.dereference( self.it ) == co.dereference( self.end ) :
         if  self.it == self.end:
-
             raise StopIteration()
-        cdef _Match * _r = new _Match(co.dereference( self.it ))
+
+        cdef shared_ptr[_Match] _r = co.dereference( self.it )
         with nogil:
             co.preincrement( self.it )
         
         cdef Match py_result = Match.__new__(Match)
-        py_result.inst = shared_ptr[_Match](_r)
+        py_result.inst = _r
 
         return py_result
 

--- a/python/src/pxds/dictionary.pxd
+++ b/python/src/pxds/dictionary.pxd
@@ -8,6 +8,7 @@ from libcpp cimport bool
 from libcpp.pair cimport pair as libcpp_pair
 from match cimport Match as _Match
 from match_iterator cimport MatchIteratorPair as _MatchIteratorPair
+from std_smart_ptr cimport shared_ptr
 
 cdef extern from "keyvi/dictionary/dictionary.h" namespace "keyvi::dictionary":
     ctypedef enum loading_strategy_types:
@@ -31,7 +32,7 @@ cdef extern from "keyvi/dictionary/dictionary.h" namespace "keyvi::dictionary":
         Dictionary (libcpp_utf8_string filename) except +
         Dictionary (libcpp_utf8_string filename, loading_strategy_types) except +
         bool Contains (libcpp_utf8_string key) # wrap-ignore
-        _Match operator[](libcpp_utf8_string key) # wrap-ignore
+        shared_ptr[_Match] operator[](libcpp_utf8_string key) # wrap-ignore
         _MatchIteratorPair Get (libcpp_utf8_string key) # wrap-as:match
         _MatchIteratorPair GetNear (libcpp_utf8_string key, size_t minimum_prefix_length) except + # wrap-as:match_near
         _MatchIteratorPair GetNear (libcpp_utf8_string key, size_t minimum_prefix_length, bool greedy) except + # wrap-as:match_near

--- a/python/src/pxds/dictionary.pxd
+++ b/python/src/pxds/dictionary.pxd
@@ -8,7 +8,7 @@ from libcpp cimport bool
 from libcpp.pair cimport pair as libcpp_pair
 from match cimport Match as _Match
 from match_iterator cimport MatchIteratorPair as _MatchIteratorPair
-from std_smart_ptr cimport shared_ptr
+from libcpp.memory cimport shared_ptr
 
 cdef extern from "keyvi/dictionary/dictionary.h" namespace "keyvi::dictionary":
     ctypedef enum loading_strategy_types:

--- a/python/src/pxds/forward_backward_completion.pxd
+++ b/python/src/pxds/forward_backward_completion.pxd
@@ -1,6 +1,6 @@
 from libcpp.string cimport string as libcpp_utf8_string
 from dictionary cimport Dictionary
-from std_smart_ptr cimport shared_ptr
+from libcpp.memory cimport shared_ptr
 from match_iterator cimport MatchIteratorPair as _MatchIteratorPair
 
 cdef extern from "keyvi/dictionary/completion/forward_backward_completion.h" namespace "keyvi::dictionary::completion":

--- a/python/src/pxds/index.pxd
+++ b/python/src/pxds/index.pxd
@@ -21,4 +21,4 @@ cdef extern from "keyvi/index/index.h" namespace "keyvi::index":
         void Flush() except+
         void Flush(bool) except+
         bool Contains(libcpp_utf8_string) # wrap-ignore
-        Match operator[](libcpp_utf8_string) # wrap-ignore
+        s_shared_ptr[Match] operator[](libcpp_utf8_string) # wrap-ignore

--- a/python/src/pxds/index.pxd
+++ b/python/src/pxds/index.pxd
@@ -6,14 +6,14 @@ from libcpp cimport bool
 from match cimport Match
 from libc.stdint cimport int32_t
 from match_iterator cimport MatchIteratorPair as _MatchIteratorPair
-from std_smart_ptr cimport shared_ptr as s_shared_ptr
+from libcpp.memory cimport shared_ptr
 
 cdef extern from "keyvi/index/index.h" namespace "keyvi::index":
     cdef cppclass Index:
         Index(libcpp_utf8_string) except+ # wrap-ignore
         Index(libcpp_utf8_string, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] params) except+ # wrap-ignore
         void Set(libcpp_utf8_string, libcpp_utf8_string) except+
-        void MSet(s_shared_ptr[libcpp_vector[libcpp_pair[libcpp_utf8_string, libcpp_utf8_string]]]) # wrap-ignore
+        void MSet(shared_ptr[libcpp_vector[libcpp_pair[libcpp_utf8_string, libcpp_utf8_string]]]) # wrap-ignore
         _MatchIteratorPair GetNear (libcpp_utf8_string, size_t minimum_prefix_length) except +
         _MatchIteratorPair GetNear (libcpp_utf8_string, size_t minimum_prefix_length, bool greedy) except +
         _MatchIteratorPair GetFuzzy(libcpp_utf8_string, int32_t max_edit_distance, size_t minimum_exact_prefix) except +
@@ -21,4 +21,4 @@ cdef extern from "keyvi/index/index.h" namespace "keyvi::index":
         void Flush() except+
         void Flush(bool) except+
         bool Contains(libcpp_utf8_string) # wrap-ignore
-        s_shared_ptr[Match] operator[](libcpp_utf8_string) # wrap-ignore
+        shared_ptr[Match] operator[](libcpp_utf8_string) # wrap-ignore

--- a/python/src/pxds/match.pxd
+++ b/python/src/pxds/match.pxd
@@ -8,7 +8,6 @@ from cpython.ref cimport PyObject
 cdef extern from "keyvi/dictionary/match.h" namespace "keyvi::dictionary":
     cdef cppclass Match:
         Match()
-        Match(Match& m)
         size_t GetStart() # wrap-ignore
         void SetStart(size_t start) # wrap-ignore
         size_t GetEnd() # wrap-ignore

--- a/python/src/pxds/match_iterator.pxd
+++ b/python/src/pxds/match_iterator.pxd
@@ -1,11 +1,13 @@
 # same import style as autowrap
 from match cimport Match as _Match
 from libc.stdint cimport uint32_t
+from std_smart_ptr cimport shared_ptr
+
 
 cdef extern from "keyvi/dictionary/match_iterator.h" namespace "keyvi::dictionary":
     cdef cppclass MatchIterator:
         # wrap-ignore
-        _Match operator*()
+        shared_ptr[_Match] operator*()
         # wrap-ignore
         MatchIterator& operator++()
         bint operator==(MatchIterator)

--- a/python/src/pxds/match_iterator.pxd
+++ b/python/src/pxds/match_iterator.pxd
@@ -1,8 +1,7 @@
 # same import style as autowrap
 from match cimport Match as _Match
 from libc.stdint cimport uint32_t
-from std_smart_ptr cimport shared_ptr
-
+from libcpp.memory cimport shared_ptr
 
 cdef extern from "keyvi/dictionary/match_iterator.h" namespace "keyvi::dictionary":
     cdef cppclass MatchIterator:

--- a/python/src/pxds/multi_word_completion.pxd
+++ b/python/src/pxds/multi_word_completion.pxd
@@ -1,7 +1,7 @@
 from libcpp.string cimport string as libcpp_string
 from libcpp.string cimport string as libcpp_utf8_string
 from dictionary cimport Dictionary
-from std_smart_ptr cimport shared_ptr
+from libcpp.memory cimport shared_ptr
 from match_iterator cimport MatchIteratorPair as _MatchIteratorPair
 
 cdef extern from "keyvi/dictionary/completion/multiword_completion.h" namespace "keyvi::dictionary::completion":

--- a/python/src/pxds/normalization.pxd
+++ b/python/src/pxds/normalization.pxd
@@ -1,7 +1,7 @@
 from libcpp.string cimport string as libcpp_string
 from libcpp.string cimport string as libcpp_utf8_string
 from dictionary cimport Dictionary
-from std_smart_ptr cimport shared_ptr
+from libcpp.memory cimport shared_ptr
 
 cdef extern from "keyvi/transform/fsa_transform.h" namespace "keyvi::transform":
     cdef cppclass FsaTransform:

--- a/python/src/pxds/prefix_completion.pxd
+++ b/python/src/pxds/prefix_completion.pxd
@@ -2,7 +2,7 @@ from libcpp.string cimport string as libcpp_string
 from libcpp.string cimport string as libcpp_utf8_string
 from libc.stdint cimport int32_t
 from dictionary cimport Dictionary
-from std_smart_ptr cimport shared_ptr
+from libcpp.memory cimport shared_ptr
 from match_iterator cimport MatchIteratorPair as _MatchIteratorPair
 
 cdef extern from "keyvi/dictionary/completion/prefix_completion.h" namespace "keyvi::dictionary::completion":

--- a/python/src/pxds/read_only_index.pxd
+++ b/python/src/pxds/read_only_index.pxd
@@ -4,13 +4,14 @@ from libcpp cimport bool
 from libc.stdint cimport int32_t
 from match cimport Match
 from match_iterator cimport MatchIteratorPair as _MatchIteratorPair
+from std_smart_ptr cimport shared_ptr
 
 cdef extern from "keyvi/index/read_only_index.h" namespace "keyvi::index":
     cdef cppclass ReadOnlyIndex:
         ReadOnlyIndex(libcpp_utf8_string) except+
         ReadOnlyIndex(libcpp_utf8_string, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] params) except+
         bool Contains(libcpp_utf8_string) # wrap-ignore
-        Match operator[](libcpp_utf8_string) # wrap-ignore
+        shared_ptr[Match] operator[](libcpp_utf8_string) # wrap-ignore
         _MatchIteratorPair GetFuzzy(libcpp_utf8_string, int32_t max_edit_distance, size_t minimum_exact_prefix) except+
         _MatchIteratorPair GetNear (libcpp_utf8_string, size_t minimum_prefix_length) except +
         _MatchIteratorPair GetNear (libcpp_utf8_string, size_t minimum_prefix_length, bool greedy) except +

--- a/python/src/pxds/read_only_index.pxd
+++ b/python/src/pxds/read_only_index.pxd
@@ -4,7 +4,7 @@ from libcpp cimport bool
 from libc.stdint cimport int32_t
 from match cimport Match
 from match_iterator cimport MatchIteratorPair as _MatchIteratorPair
-from std_smart_ptr cimport shared_ptr
+from libcpp.memory cimport shared_ptr
 
 cdef extern from "keyvi/index/read_only_index.h" namespace "keyvi::index":
     cdef cppclass ReadOnlyIndex:

--- a/python/src/pxds/std_smart_ptr.pxd
+++ b/python/src/pxds/std_smart_ptr.pxd
@@ -1,8 +1,0 @@
-cdef extern from "<memory>" namespace "std":
-    cppclass shared_ptr[T]:
-        shared_ptr()
-        shared_ptr(T*)
-        void reset()
-        T* get() nogil
-        int unique()
-        int use_count()

--- a/python/tests/dictionary/unicode_test.py
+++ b/python/tests/dictionary/unicode_test.py
@@ -26,7 +26,7 @@ def test_unicode():
         assert d.get(key).value == {"a": 2}
 
 
-def test_unicode_lookup():
+def disable_test_unicode_lookup():
     c = JsonDictionaryCompiler({"memory_limit_mb": "10"})
     c.Add("Los Angeles", '{"country" : "USA"}')
     c.Add("Frankfurt am Main", '{"country" : "Germany"}')

--- a/python/tests/dictionary/unicode_test.py
+++ b/python/tests/dictionary/unicode_test.py
@@ -26,7 +26,7 @@ def test_unicode():
         assert d.get(key).value == {"a": 2}
 
 
-def disable_test_unicode_lookup():
+def test_unicode_lookup():
     c = JsonDictionaryCompiler({"memory_limit_mb": "10"})
     c.Add("Los Angeles", '{"country" : "USA"}')
     c.Add("Frankfurt am Main", '{"country" : "Germany"}')


### PR DESCRIPTION
refactor matches to be returned as shared pointers with the intention to further modernize the code, remove some quirks with copy/assignment and avoid copying match objects in various places.

This avoids 1 deep-copy for every match in the python extension as well as copies when creating the match iterator.