### PR TITLE
add secondary key dictionaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake_mo
 # configure C++17
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
 
 # keyvi specific compile options, definitions and flags
 set (_KEVYI_COMPILE_OPTIONS "-Wall")
@@ -29,7 +30,6 @@ set (_OS_LIBRARIES "")
 # OSX specifics
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set (_KEYVI_COMPILE_DEFINITIONS "${_KEYVI_COMPILE_DEFINITIONS} OS_MACOSX")
-    set (_KEYVI_CXX_FLAGS "${_KEYVI_CXX_FLAGS} -mmacosx-version-min=10.9")
 endif()
 
 # build type specific settings

--- a/keyvi/include/keyvi/dictionary/dictionary.h
+++ b/keyvi/include/keyvi/dictionary/dictionary.h
@@ -347,8 +347,8 @@ class Dictionary final {
     return MatchIterator::MakeIteratorPair(tfunc, std::move(first_match));
   }
 
-  MatchIterator::MatchIteratorPair GetNear(const uint64_t state, const std::string& key, const size_t minimum_prefix_length,
-                                           const bool greedy = false) const {
+  MatchIterator::MatchIteratorPair GetNear(const uint64_t state, const std::string& key,
+                                           const size_t minimum_prefix_length, const bool greedy = false) const {
     auto data = std::make_shared<matching::NearMatching<>>(
         matching::NearMatching<>::FromSingleFsa(fsa_, state, key, minimum_prefix_length, greedy));
 

--- a/keyvi/include/keyvi/dictionary/dictionary.h
+++ b/keyvi/include/keyvi/dictionary/dictionary.h
@@ -223,7 +223,7 @@ class Dictionary final {
                                        multiword_separator);
   }
 
-  std::string GetManifest() const { return fsa_->GetManifest(); }
+  const std::string& GetManifest() const { return fsa_->GetManifest(); }
 
  private:
   fsa::automata_t fsa_;

--- a/keyvi/include/keyvi/dictionary/dictionary.h
+++ b/keyvi/include/keyvi/dictionary/dictionary.h
@@ -189,7 +189,7 @@ class Dictionary final {
    */
   MatchIterator::MatchIteratorPair GetNear(const std::string& key, const size_t minimum_prefix_length,
                                            const bool greedy = false) const {
-    return GetNear(fsa_->GetStartState(),key, minimum_prefix_length, greedy);
+    return GetNear(fsa_->GetStartState(), key, minimum_prefix_length, greedy);
   }
 
   MatchIterator::MatchIteratorPair GetFuzzy(const std::string& query, const int32_t max_edit_distance,
@@ -422,7 +422,7 @@ class Dictionary final {
         std::bind(&matching::MultiwordCompletionMatching<>::SetMinWeight, &(*data), std::placeholders::_1));
   }
 
-  MatchIterator::MatchIteratorPair GetMultiwordCompletion(const uint64_t state, const std::string& query, 
+  MatchIterator::MatchIteratorPair GetMultiwordCompletion(const uint64_t state, const std::string& query,
                                                           const size_t top_n,
                                                           const unsigned char multiword_separator) const {
     auto data = std::make_shared<matching::MultiwordCompletionMatching<>>(

--- a/keyvi/include/keyvi/dictionary/dictionary_compiler.h
+++ b/keyvi/include/keyvi/dictionary/dictionary_compiler.h
@@ -65,9 +65,8 @@ template <keyvi::dictionary::fsa::internal::value_store_t ValueStoreType = fsa::
 class DictionaryCompiler final {
  public:
   using ValueStoreT = typename fsa::internal::ValueStoreComponents<ValueStoreType>::value_store_writer_t;
-
- private:
   using callback_t = std::function<void(size_t, size_t, void*)>;
+ private:
   using GeneratorAdapter = fsa::GeneratorAdapterInterface<typename ValueStoreT::value_t>;
 
  public:

--- a/keyvi/include/keyvi/dictionary/dictionary_compiler.h
+++ b/keyvi/include/keyvi/dictionary/dictionary_compiler.h
@@ -66,6 +66,7 @@ class DictionaryCompiler final {
  public:
   using ValueStoreT = typename fsa::internal::ValueStoreComponents<ValueStoreType>::value_store_writer_t;
   using callback_t = std::function<void(size_t, size_t, void*)>;
+
  private:
   using GeneratorAdapter = fsa::GeneratorAdapterInterface<typename ValueStoreT::value_t>;
 

--- a/keyvi/include/keyvi/dictionary/dictionary_compiler.h
+++ b/keyvi/include/keyvi/dictionary/dictionary_compiler.h
@@ -138,10 +138,11 @@ class DictionaryCompiler final {
     }
 
     generator_->SetManifest(manifest_);
+    generator_->SetSpecializedDictionaryProperties(specialized_dictionary_properties_);
   }
 
   /**
-   * Set a custom manifest to be embedded into the index file.
+   * Set a custom manifest to be embedded into the keyvi file.
    *
    * @param manifest as string
    */
@@ -152,6 +153,21 @@ class DictionaryCompiler final {
     // is created
     if (generator_) {
       generator_->SetManifest(manifest);
+    }
+  }
+
+  /**
+   * Set a specialized dictionary properties.
+   *
+   * @param specialized_dictionary_properties properties as string
+   */
+  void SetSpecializedDictionaryProperties(const std::string& specialized_dictionary_properties) {
+    specialized_dictionary_properties_ = specialized_dictionary_properties;
+
+    // if generator object is already there, set it otherwise cache it until it
+    // is created
+    if (generator_) {
+      generator_->SetSpecializedDictionaryProperties(specialized_dictionary_properties_);
     }
   }
 
@@ -180,6 +196,7 @@ class DictionaryCompiler final {
   ValueStoreT* value_store_;
   typename GeneratorAdapter::AdapterPtr generator_;
   std::string manifest_;
+  std::string specialized_dictionary_properties_;
   size_t memory_limit_;
   size_t memory_estimate_ = 0;
   size_t chunk_ = 0;

--- a/keyvi/include/keyvi/dictionary/dictionary_properties.h
+++ b/keyvi/include/keyvi/dictionary/dictionary_properties.h
@@ -306,7 +306,8 @@ class DictionaryProperties {
     size_t transitions_offset = persistence_offset + sparse_array_size;
 
     // check for file truncation
-    file_stream.seekg((size_t)file_stream.tellg() + sparse_array_size + bucket_size * sparse_array_size - 1);
+    file_stream.seekg(static_cast<size_t>(file_stream.tellg()) + sparse_array_size + bucket_size * sparse_array_size -
+                      1);
     if (file_stream.peek() == EOF) {
       throw std::invalid_argument("file is corrupt(truncated)");
     }

--- a/keyvi/include/keyvi/dictionary/dictionary_properties.h
+++ b/keyvi/include/keyvi/dictionary/dictionary_properties.h
@@ -136,7 +136,10 @@ class DictionaryProperties {
 
   size_t GetTransitionsSize() const { return sparse_array_size_ * 2; }
 
-  size_t GetEndOffset() const { return GetTransitionsOffset() + GetTransitionsSize(); }
+  size_t GetEndOffset() const {
+    return value_store_properties_.GetOffset() ? value_store_properties_.GetOffset() + value_store_properties_.GetSize()
+                                               : GetTransitionsOffset() + GetTransitionsSize();
+  }
 
   const fsa::internal::ValueStoreProperties& GetValueStoreProperties() const { return value_store_properties_; }
 

--- a/keyvi/include/keyvi/dictionary/dictionary_properties.h
+++ b/keyvi/include/keyvi/dictionary/dictionary_properties.h
@@ -102,9 +102,10 @@ class DictionaryProperties {
     specialized_dictionary_properties_ = specialized_dictionary_properties;
   }
 
-  static DictionaryProperties FromFile(const std::string& file_name) {
+  static DictionaryProperties FromFile(const std::string& file_name, const size_t offset = 0) {
     std::ifstream file_stream(file_name, std::ios::binary);
 
+    file_stream.seekg(offset);
     if (!file_stream.good()) {
       throw std::invalid_argument("dictionary file not found");
     }
@@ -134,6 +135,8 @@ class DictionaryProperties {
   size_t GetTransitionsOffset() const { return transitions_offset_; }
 
   size_t GetTransitionsSize() const { return sparse_array_size_ * 2; }
+
+  size_t GetEndOffset() const { return GetTransitionsOffset() + GetTransitionsSize(); }
 
   const fsa::internal::ValueStoreProperties& GetValueStoreProperties() const { return value_store_properties_; }
 
@@ -315,8 +318,9 @@ class DictionaryProperties {
     file_stream.get();
 
     fsa::internal::ValueStoreProperties value_store_properties;
-    // not all value stores have properties
-    if (file_stream.peek() != EOF) {
+
+    // not all value stores have persisted properties
+    if (fsa::internal::ValueStoreHasPersistedProperties(value_store_type)) {
       value_store_properties = fsa::internal::ValueStoreProperties::FromJson(file_stream);
     }
 

--- a/keyvi/include/keyvi/dictionary/dictionary_types.h
+++ b/keyvi/include/keyvi/dictionary/dictionary_types.h
@@ -26,6 +26,7 @@
 #define KEYVI_DICTIONARY_DICTIONARY_TYPES_H_
 
 #include "keyvi/dictionary/dictionary_compiler.h"
+#include "keyvi/dictionary/secondary_key_dictionary_compiler.h"
 #include "keyvi/dictionary/dictionary_index_compiler.h"
 #include "keyvi/dictionary/dictionary_merger.h"
 #include "keyvi/dictionary/fsa/generator.h"
@@ -68,6 +69,19 @@ using StringDictionaryMerger = keyvi::dictionary::DictionaryMerger<dictionary_ty
 using KeyOnlyDictionaryMerger = keyvi::dictionary::DictionaryMerger<dictionary_type_t::KEY_ONLY>;
 
 using JsonDictionaryIndexCompiler = keyvi::dictionary::DictionaryIndexCompiler<dictionary_type_t::JSON>;
+
+// secondary key types
+using SecondaryKeyCompletionDictionaryCompiler = keyvi::dictionary::SecondaryKeyDictionaryCompiler<dictionary_type_t::INT_WITH_WEIGHTS>;
+
+using SecondaryKeyFloatVectorDictionaryCompiler = keyvi::dictionary::SecondaryKeyDictionaryCompiler<dictionary_type_t::FLOAT_VECTOR>;
+
+using SecondaryKeyIntDictionaryCompiler = keyvi::dictionary::SecondaryKeyDictionaryCompiler<dictionary_type_t::INT>;
+
+using SecondaryKeyKeyOnlyDictionaryCompiler = keyvi::dictionary::SecondaryKeyDictionaryCompiler<dictionary_type_t::KEY_ONLY>;
+
+using SecondaryKeyJsonDictionaryCompiler = keyvi::dictionary::SecondaryKeyDictionaryCompiler<dictionary_type_t::JSON>;
+
+using SecondaryKeyStringDictionaryCompiler = keyvi::dictionary::SecondaryKeyDictionaryCompiler<dictionary_type_t::STRING>;
 
 #ifndef KEYVI_REMOVE_DEPRECATED
 using IntDictionaryCompilerSmallData = IntDictionaryCompiler;

--- a/keyvi/include/keyvi/dictionary/dictionary_types.h
+++ b/keyvi/include/keyvi/dictionary/dictionary_types.h
@@ -26,7 +26,6 @@
 #define KEYVI_DICTIONARY_DICTIONARY_TYPES_H_
 
 #include "keyvi/dictionary/dictionary_compiler.h"
-#include "keyvi/dictionary/secondary_key_dictionary_compiler.h"
 #include "keyvi/dictionary/dictionary_index_compiler.h"
 #include "keyvi/dictionary/dictionary_merger.h"
 #include "keyvi/dictionary/fsa/generator.h"
@@ -36,6 +35,7 @@
 #include "keyvi/dictionary/fsa/internal/json_value_store.h"
 #include "keyvi/dictionary/fsa/internal/sparse_array_persistence.h"
 #include "keyvi/dictionary/fsa/internal/string_value_store.h"
+#include "keyvi/dictionary/secondary_key_dictionary_compiler.h"
 
 namespace keyvi {
 namespace dictionary {
@@ -71,17 +71,21 @@ using KeyOnlyDictionaryMerger = keyvi::dictionary::DictionaryMerger<dictionary_t
 using JsonDictionaryIndexCompiler = keyvi::dictionary::DictionaryIndexCompiler<dictionary_type_t::JSON>;
 
 // secondary key types
-using SecondaryKeyCompletionDictionaryCompiler = keyvi::dictionary::SecondaryKeyDictionaryCompiler<dictionary_type_t::INT_WITH_WEIGHTS>;
+using SecondaryKeyCompletionDictionaryCompiler =
+    keyvi::dictionary::SecondaryKeyDictionaryCompiler<dictionary_type_t::INT_WITH_WEIGHTS>;
 
-using SecondaryKeyFloatVectorDictionaryCompiler = keyvi::dictionary::SecondaryKeyDictionaryCompiler<dictionary_type_t::FLOAT_VECTOR>;
+using SecondaryKeyFloatVectorDictionaryCompiler =
+    keyvi::dictionary::SecondaryKeyDictionaryCompiler<dictionary_type_t::FLOAT_VECTOR>;
 
 using SecondaryKeyIntDictionaryCompiler = keyvi::dictionary::SecondaryKeyDictionaryCompiler<dictionary_type_t::INT>;
 
-using SecondaryKeyKeyOnlyDictionaryCompiler = keyvi::dictionary::SecondaryKeyDictionaryCompiler<dictionary_type_t::KEY_ONLY>;
+using SecondaryKeyKeyOnlyDictionaryCompiler =
+    keyvi::dictionary::SecondaryKeyDictionaryCompiler<dictionary_type_t::KEY_ONLY>;
 
 using SecondaryKeyJsonDictionaryCompiler = keyvi::dictionary::SecondaryKeyDictionaryCompiler<dictionary_type_t::JSON>;
 
-using SecondaryKeyStringDictionaryCompiler = keyvi::dictionary::SecondaryKeyDictionaryCompiler<dictionary_type_t::STRING>;
+using SecondaryKeyStringDictionaryCompiler =
+    keyvi::dictionary::SecondaryKeyDictionaryCompiler<dictionary_type_t::STRING>;
 
 #ifndef KEYVI_REMOVE_DEPRECATED
 using IntDictionaryCompilerSmallData = IntDictionaryCompiler;

--- a/keyvi/include/keyvi/dictionary/fsa/automata.h
+++ b/keyvi/include/keyvi/dictionary/fsa/automata.h
@@ -46,6 +46,10 @@
 
 namespace keyvi {
 namespace dictionary {
+
+// for friending
+class SecondaryKeyDictionary;
+
 namespace fsa {
 
 /**
@@ -76,6 +80,11 @@ class Automata final {
                     loading_strategy_types loading_strategy = loading_strategy_types::lazy)
       : Automata(std::make_shared<DictionaryProperties>(DictionaryProperties::FromFile(file_name)), loading_strategy,
                  true) {}
+
+  explicit Automata(const std::string& file_name, const size_t offset,
+                    loading_strategy_types loading_strategy = loading_strategy_types::lazy)
+      : Automata(std::make_shared<DictionaryProperties>(DictionaryProperties::FromFile(file_name, offset)),
+                 loading_strategy, true) {}
 
  private:
   explicit Automata(const dictionary_properties_t& dictionary_properties, loading_strategy_types loading_strategy,
@@ -385,13 +394,9 @@ class Automata final {
     return value_store_reader_->GetRawValueAsString(state_value);
   }
 
-  std::string GetStatistics() const {
-    return dictionary_properties_->GetStatistics();
-  }
+  std::string GetStatistics() const { return dictionary_properties_->GetStatistics(); }
 
-  std::string GetManifest() const {
-    return dictionary_properties_->GetManifest();
-  }
+  const std::string& GetManifest() const { return dictionary_properties_->GetManifest(); }
 
  private:
   dictionary_properties_t dictionary_properties_;
@@ -450,6 +455,10 @@ class Automata final {
     TRACE("Compact Transition after resolve %d", resolved_ptr);
     return resolved_ptr;
   }
+
+  friend class keyvi::dictionary::SecondaryKeyDictionary;
+
+  const dictionary_properties_t& GetDictionaryProperties() const { return dictionary_properties_; }
 };
 
 // shared pointer

--- a/keyvi/include/keyvi/dictionary/fsa/automata.h
+++ b/keyvi/include/keyvi/dictionary/fsa/automata.h
@@ -394,9 +394,13 @@ class Automata final {
     return value_store_reader_->GetRawValueAsString(state_value);
   }
 
-  std::string GetStatistics() const { return dictionary_properties_->GetStatistics(); }
+  std::string GetStatistics() const {
+    return dictionary_properties_->GetStatistics();
+  }
 
-  const std::string& GetManifest() const { return dictionary_properties_->GetManifest(); }
+  const std::string& GetManifest() const {
+    return dictionary_properties_->GetManifest();
+  }
 
  private:
   dictionary_properties_t dictionary_properties_;
@@ -458,7 +462,9 @@ class Automata final {
 
   friend class keyvi::dictionary::SecondaryKeyDictionary;
 
-  const dictionary_properties_t& GetDictionaryProperties() const { return dictionary_properties_; }
+  const dictionary_properties_t& GetDictionaryProperties() const {
+    return dictionary_properties_;
+  }
 };
 
 // shared pointer

--- a/keyvi/include/keyvi/dictionary/fsa/generator.h
+++ b/keyvi/include/keyvi/dictionary/fsa/generator.h
@@ -297,7 +297,8 @@ class Generator final {
 
     keyvi::dictionary::DictionaryProperties p(KEYVI_FILE_VERSION_CURRENT, start_state_, number_of_keys_added_,
                                               number_of_states_, value_store_->GetValueStoreType(),
-                                              persistence_->GetVersion(), persistence_->GetSize(), manifest_);
+                                              persistence_->GetVersion(), persistence_->GetSize(), manifest_,
+                                              specialized_dictionary_properties_);
     p.WriteAsJsonV2(stream);
 
     // write data from persistence
@@ -323,6 +324,10 @@ class Generator final {
    */
   inline void SetManifest(const std::string& manifest) { manifest_ = manifest; }
 
+  inline void SetSpecializedDictionaryProperties(const std::string& specialized_dictionary_properties) {
+    specialized_dictionary_properties_ = specialized_dictionary_properties;
+  }
+
  private:
   size_t memory_limit_;
   keyvi::util::parameters_t params_;
@@ -337,6 +342,7 @@ class Generator final {
   OffsetTypeT start_state_ = 0;
   uint64_t number_of_states_ = 0;
   std::string manifest_;
+  std::string specialized_dictionary_properties_;
   bool minimize_ = true;
 
   inline void FeedStack(const size_t start, const std::string& key) {

--- a/keyvi/include/keyvi/dictionary/fsa/generator_adapter.h
+++ b/keyvi/include/keyvi/dictionary/fsa/generator_adapter.h
@@ -58,6 +58,7 @@ class GeneratorAdapterInterface {
   virtual void Write(std::ostream& stream) {}
   virtual void WriteToFile(const std::string& filename) {}
   virtual void SetManifest(const std::string& manifest) {}
+  virtual void SetSpecializedDictionaryProperties(const std::string& specialized_dictionary_properties) {}
 
   virtual ~GeneratorAdapterInterface() {}
 };
@@ -84,6 +85,10 @@ class GeneratorAdapter final : public GeneratorAdapterInterface<typename ValueSt
   void WriteToFile(const std::string& filename) { generator_.WriteToFile(filename); }
 
   void SetManifest(const std::string& manifest) { generator_.SetManifest(manifest); }
+
+  void SetSpecializedDictionaryProperties(const std::string& specialized_dictionary_properties) {
+    generator_.SetSpecializedDictionaryProperties(specialized_dictionary_properties);
+  }
 
  private:
   Generator<PersistenceT, ValueStoreT, OffsetTypeT, HashCodeTypeT> generator_;

--- a/keyvi/include/keyvi/dictionary/fsa/internal/constants.h
+++ b/keyvi/include/keyvi/dictionary/fsa/internal/constants.h
@@ -85,4 +85,7 @@ static const char VECTOR_SIZE_KEY[] = "vector_size";
 static const char MERGE_MODE[] = "merge_mode";
 static const char MERGE_APPEND[] = "append";
 
+// constants for specialized dictionaries
+static const char SECONDARY_KEY_DICT_KEYS_PROPERTY[] = "secondary_keys";
+
 #endif  // KEYVI_DICTIONARY_FSA_INTERNAL_CONSTANTS_H_

--- a/keyvi/include/keyvi/dictionary/fsa/internal/value_store_types.h
+++ b/keyvi/include/keyvi/dictionary/fsa/internal/value_store_types.h
@@ -45,6 +45,26 @@ enum class value_store_t {
   FLOAT_VECTOR = 7,      //!< FloatVectorValueStore
 };
 
+/**
+ * Wheter the given value store has persisted value store properties.
+ */
+inline bool ValueStoreHasPersistedProperties(const value_store_t type) {
+  switch (type) {
+    case value_store_t::KEY_ONLY:
+    case value_store_t::INT:
+    case value_store_t::INT_WITH_WEIGHTS:
+      return false;
+    case value_store_t::STRING:
+    case value_store_t::JSON:
+    case value_store_t::FLOAT_VECTOR:
+      return true;
+    case value_store_t::JSON_DEPRECATED:
+      throw std::invalid_argument("Deprecated Value Storage type");
+    default:
+      throw std::invalid_argument("Unknown Value Storage type");
+  }
+}
+
 } /* namespace internal */
 } /* namespace fsa */
 } /* namespace dictionary */

--- a/keyvi/include/keyvi/dictionary/matching/fuzzy_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/fuzzy_matching.h
@@ -47,6 +47,8 @@
 namespace keyvi {
 namespace index {
 namespace internal {
+template <class PayloadT, class SegmentT>
+class BaseIndexReader;
 template <class MatcherT, class DeletedT>
 keyvi::dictionary::match_t NextFilteredMatchSingle(const MatcherT&, const DeletedT&);
 template <class MatcherT, class DeletedT>
@@ -70,7 +72,21 @@ class FuzzyMatching final {
   template <class innerTraverserType = fsa::WeightedStateTraverser>
   static FuzzyMatching FromSingleFsa(const fsa::automata_t& fsa, const std::string& query,
                                      const int32_t max_edit_distance, const size_t minimum_exact_prefix = 2) {
-    uint64_t state = fsa->GetStartState();
+    return FromSingleFsa<innerTraverserType>(fsa, fsa->GetStartState(), query, max_edit_distance, minimum_exact_prefix);
+  }
+  /**
+   * Create a fuzzy matcher from a single Fsa
+   *
+   * @param fsa the fsa
+   * @param start_state the state to start from
+   * @param query the query
+   * @param max_edit_distance the maximum allowed edit distance
+   * @param minimum_exact_prefix the minimum exact prefix to match before matching approximate
+   */
+  template <class innerTraverserType = fsa::WeightedStateTraverser>
+  static FuzzyMatching FromSingleFsa(const fsa::automata_t& fsa, const uint64_t start_state, const std::string& query,
+                                     const int32_t max_edit_distance, const size_t minimum_exact_prefix = 2) {
+    uint64_t state = start_state;
 
     size_t depth = 0;
     size_t utf8_depth = 0;
@@ -89,54 +105,8 @@ class FuzzyMatching final {
       return FuzzyMatching<innerTraverserType>();
     }
 
-    return FromSingleFsa<innerTraverserType>(fsa, state, query, max_edit_distance, minimum_exact_prefix);
-  }
-
-  /**
-   * Create a fuzzy matcher from a single Fsa
-   *
-   * @param fsa the fsa
-   * @param start_state the state to start from
-   * @param query the query
-   * @param max_edit_distance the maximum allowed edit distance
-   * @param exact_prefix the exact prefix that already matched
-   */
-  template <class innerTraverserType = fsa::WeightedStateTraverser>
-  static FuzzyMatching FromSingleFsa(const fsa::automata_t& fsa, const uint64_t start_state, const std::string& query,
-                                     const int32_t max_edit_distance, const size_t exact_prefix) {
-    if (start_state == 0) {
-      return FuzzyMatching<innerTraverserType>();
-    }
-
-    std::unique_ptr<stringdistance::Levenshtein> metric;
-    std::unique_ptr<fsa::CodePointStateTraverser<innerTraverserType>> traverser;
-    match_t first_match;
-
-    std::vector<uint32_t> codepoints;
-    utf8::unchecked::utf8to32(query.begin(), query.end(), back_inserter(codepoints));
-
-    if (start_state == 0) {
-      TRACE("query lengh < minimum exact prefix, returning empty iterator");
-      return FuzzyMatching<innerTraverserType>();
-    }
-
-    // initialize the distance metric with the exact prefix
-    metric.reset(new stringdistance::Levenshtein(codepoints, 20, max_edit_distance));
-    for (size_t i = 0; i < exact_prefix; ++i) {
-      metric->Put(codepoints[i], i);
-    }
-
-    traverser.reset(new fsa::CodePointStateTraverser<innerTraverserType>(fsa, start_state));
-
-    if (fsa->IsFinalState(start_state) && metric->GetScore() <= max_edit_distance) {
-      TRACE("exact prefix matched");
-      first_match = std::make_shared<Match>(0, exact_prefix, metric->GetCandidate(), metric->GetScore(), fsa,
-                                            fsa->GetStateValue(start_state));
-    }
-
-    TRACE("create iterator");
-    return FuzzyMatching<innerTraverserType>(std::move(traverser), std::move(metric), std::move(first_match),
-                                             max_edit_distance, exact_prefix);
+    return FromSingleFsaWithMatchedExactPrefix<innerTraverserType>(fsa, state, query, max_edit_distance,
+                                                                   minimum_exact_prefix);
   }
 
   /**
@@ -154,57 +124,7 @@ class FuzzyMatching final {
     std::vector<std::pair<fsa::automata_t, uint64_t>> fsa_start_state_pairs =
         FilterWithExactPrefix(fsas, query, minimum_exact_prefix);
 
-    return FromMulipleFsas<innerTraverserType>(fsa_start_state_pairs, query, max_edit_distance, minimum_exact_prefix);
-  }
-
-  /**
-   * Create a fuzzy matcher with already matched exact prefix.
-   *
-   * @param fsa_start_state_pairs pairs of fsa and current state
-   * @param query the query
-   * @param max_edit_distance the maximum allowed edit distance
-   * @param exact_prefix the exact prefix that already matched
-   */
-  template <class innerTraverserType = fsa::WeightedStateTraverser>
-  static FuzzyMatching<fsa::ZipStateTraverser<innerTraverserType>> FromMulipleFsas(
-      const std::vector<std::pair<fsa::automata_t, uint64_t>>& fsa_start_state_pairs, const std::string& query,
-      const int32_t max_edit_distance, const size_t exact_prefix) {
-    // if the list of fsa's is empty return an empty matcher
-    if (fsa_start_state_pairs.size() == 0) {
-      return FuzzyMatching<fsa::ZipStateTraverser<innerTraverserType>>();
-    }
-
-    std::unique_ptr<stringdistance::Levenshtein> metric;
-    std::unique_ptr<fsa::CodePointStateTraverser<fsa::ZipStateTraverser<innerTraverserType>>> traverser;
-    match_t first_match;
-
-    // decode the utf8 query into single codepoints
-    std::vector<uint32_t> codepoints;
-    utf8::unchecked::utf8to32(query.begin(), query.end(), back_inserter(codepoints));
-
-    // initialize the distance metric with the exact prefix
-    metric.reset(new stringdistance::Levenshtein(codepoints, 20, max_edit_distance));
-    for (size_t i = 0; i < exact_prefix; ++i) {
-      metric->Put(codepoints[i], i);
-    }
-
-    // check for a match given the exact prefix
-    for (const auto& fsa_state : fsa_start_state_pairs) {
-      if (fsa_state.first->IsFinalState(fsa_state.second) && metric->GetScore() <= max_edit_distance) {
-        first_match = std::make_shared<Match>(0, exact_prefix, metric->GetCandidate(), metric->GetScore(),
-                                              fsa_state.first, fsa_state.first->GetStateValue(fsa_state.second));
-        break;
-      }
-    }
-
-    TRACE("create zip traverser with %ul inner traversers", fsa_start_state_pairs.size());
-    fsa::ZipStateTraverser<innerTraverserType> zip_state_traverser(fsa_start_state_pairs, false);
-    traverser.reset(
-        new fsa::CodePointStateTraverser<fsa::ZipStateTraverser<innerTraverserType>>(std::move(zip_state_traverser)));
-
-    TRACE("create iterator");
-    return FuzzyMatching<fsa::ZipStateTraverser<innerTraverserType>>(
-        std::move(traverser), std::move(metric), std::move(first_match), max_edit_distance, exact_prefix);
+    return FromMulipleFsasWithMatchedExactPrefix<innerTraverserType>(fsa_start_state_pairs, query, max_edit_distance, minimum_exact_prefix);
   }
 
   static inline std::vector<std::pair<fsa::automata_t, uint64_t>> FilterWithExactPrefix(
@@ -285,11 +205,112 @@ class FuzzyMatching final {
   const size_t exact_prefix_;
   match_t first_match_;
 
+  template <class PayloadT, class SegmentT>
+  friend class index::internal::BaseIndexReader;
+
   // reset method for the index in the special case the match is deleted
   template <class MatcherT, class DeletedT>
   friend match_t index::internal::NextFilteredMatchSingle(const MatcherT&, const DeletedT&);
   template <class MatcherT, class DeletedT>
   friend match_t index::internal::NextFilteredMatch(const MatcherT&, const DeletedT&);
+
+  /**
+   * Create a fuzzy matcher from a single Fsa
+   *
+   * @param fsa the fsa
+   * @param start_state the state to start from
+   * @param query the query
+   * @param max_edit_distance the maximum allowed edit distance
+   * @param exact_prefix the exact prefix that already matched
+   */
+  template <class innerTraverserType = fsa::WeightedStateTraverser>
+  static FuzzyMatching FromSingleFsaWithMatchedExactPrefix(const fsa::automata_t& fsa, const uint64_t start_state,
+                                                           const std::string& query, const int32_t max_edit_distance,
+                                                           const size_t exact_prefix) {
+    if (start_state == 0) {
+      return FuzzyMatching<innerTraverserType>();
+    }
+
+    std::unique_ptr<stringdistance::Levenshtein> metric;
+    std::unique_ptr<fsa::CodePointStateTraverser<innerTraverserType>> traverser;
+    Match first_match;
+
+    std::vector<uint32_t> codepoints;
+    utf8::unchecked::utf8to32(query.begin(), query.end(), back_inserter(codepoints));
+
+    if (start_state == 0) {
+      TRACE("query lengh < minimum exact prefix, returning empty iterator");
+      return FuzzyMatching<innerTraverserType>();
+    }
+
+    // initialize the distance metric with the exact prefix
+    metric.reset(new stringdistance::Levenshtein(codepoints, 20, max_edit_distance));
+    for (size_t i = 0; i < exact_prefix; ++i) {
+      metric->Put(codepoints[i], i);
+    }
+
+    traverser.reset(new fsa::CodePointStateTraverser<innerTraverserType>(fsa, start_state));
+
+    if (fsa->IsFinalState(start_state) && metric->GetScore() <= max_edit_distance) {
+      TRACE("exact prefix matched");
+      first_match =
+          Match(0, exact_prefix, metric->GetCandidate(), metric->GetScore(), fsa, fsa->GetStateValue(start_state));
+    }
+
+    TRACE("create iterator");
+    return FuzzyMatching<innerTraverserType>(std::move(traverser), std::move(metric), std::move(first_match),
+                                             max_edit_distance, exact_prefix);
+  }
+
+  /**
+   * Create a fuzzy matcher with already matched exact prefix.
+   *
+   * @param fsa_start_state_pairs pairs of fsa and current state
+   * @param query the query
+   * @param max_edit_distance the maximum allowed edit distance
+   * @param exact_prefix the exact prefix that already matched
+   */
+  template <class innerTraverserType = fsa::WeightedStateTraverser>
+  static FuzzyMatching<fsa::ZipStateTraverser<innerTraverserType>> FromMulipleFsasWithMatchedExactPrefix(
+      const std::vector<std::pair<fsa::automata_t, uint64_t>>& fsa_start_state_pairs, const std::string& query,
+      const int32_t max_edit_distance, const size_t exact_prefix) {
+    // if the list of fsa's is empty return an empty matcher
+    if (fsa_start_state_pairs.size() == 0) {
+      return FuzzyMatching<fsa::ZipStateTraverser<innerTraverserType>>();
+    }
+
+    std::unique_ptr<stringdistance::Levenshtein> metric;
+    std::unique_ptr<fsa::CodePointStateTraverser<fsa::ZipStateTraverser<innerTraverserType>>> traverser;
+    Match first_match;
+
+    // decode the utf8 query into single codepoints
+    std::vector<uint32_t> codepoints;
+    utf8::unchecked::utf8to32(query.begin(), query.end(), back_inserter(codepoints));
+
+    // initialize the distance metric with the exact prefix
+    metric.reset(new stringdistance::Levenshtein(codepoints, 20, max_edit_distance));
+    for (size_t i = 0; i < exact_prefix; ++i) {
+      metric->Put(codepoints[i], i);
+    }
+
+    // check for a match given the exact prefix
+    for (const auto& fsa_state : fsa_start_state_pairs) {
+      if (fsa_state.first->IsFinalState(fsa_state.second) && metric->GetScore() <= max_edit_distance) {
+        first_match = Match(0, exact_prefix, metric->GetCandidate(), metric->GetScore(), fsa_state.first,
+                            fsa_state.first->GetStateValue(fsa_state.second));
+        break;
+      }
+    }
+
+    TRACE("create zip traverser with %ul inner traversers", fsa_start_state_pairs.size());
+    fsa::ZipStateTraverser<innerTraverserType> zip_state_traverser(fsa_start_state_pairs, false);
+    traverser.reset(
+        new fsa::CodePointStateTraverser<fsa::ZipStateTraverser<innerTraverserType>>(std::move(zip_state_traverser)));
+
+    TRACE("create iterator");
+    return FuzzyMatching<fsa::ZipStateTraverser<innerTraverserType>>(
+        std::move(traverser), std::move(metric), std::move(first_match), max_edit_distance, exact_prefix);
+  }
 
   void ResetLastMatch() {}
 };

--- a/keyvi/include/keyvi/dictionary/matching/fuzzy_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/fuzzy_matching.h
@@ -234,7 +234,7 @@ class FuzzyMatching final {
 
     std::unique_ptr<stringdistance::Levenshtein> metric;
     std::unique_ptr<fsa::CodePointStateTraverser<innerTraverserType>> traverser;
-    Match first_match;
+    match_t first_match;
 
     std::vector<uint32_t> codepoints;
     utf8::unchecked::utf8to32(query.begin(), query.end(), back_inserter(codepoints));
@@ -254,8 +254,8 @@ class FuzzyMatching final {
 
     if (fsa->IsFinalState(start_state) && metric->GetScore() <= max_edit_distance) {
       TRACE("exact prefix matched");
-      first_match =
-          Match(0, exact_prefix, metric->GetCandidate(), metric->GetScore(), fsa, fsa->GetStateValue(start_state));
+      first_match = std::make_shared<Match>(0, exact_prefix, metric->GetCandidate(), metric->GetScore(), fsa,
+                                            fsa->GetStateValue(start_state));
     }
 
     TRACE("create iterator");
@@ -282,7 +282,7 @@ class FuzzyMatching final {
 
     std::unique_ptr<stringdistance::Levenshtein> metric;
     std::unique_ptr<fsa::CodePointStateTraverser<fsa::ZipStateTraverser<innerTraverserType>>> traverser;
-    Match first_match;
+    match_t first_match;
 
     // decode the utf8 query into single codepoints
     std::vector<uint32_t> codepoints;
@@ -297,8 +297,8 @@ class FuzzyMatching final {
     // check for a match given the exact prefix
     for (const auto& fsa_state : fsa_start_state_pairs) {
       if (fsa_state.first->IsFinalState(fsa_state.second) && metric->GetScore() <= max_edit_distance) {
-        first_match = Match(0, exact_prefix, metric->GetCandidate(), metric->GetScore(), fsa_state.first,
-                            fsa_state.first->GetStateValue(fsa_state.second));
+        first_match = std::make_shared<Match>(0, exact_prefix, metric->GetCandidate(), metric->GetScore(),
+                                              fsa_state.first, fsa_state.first->GetStateValue(fsa_state.second));
         break;
       }
     }

--- a/keyvi/include/keyvi/dictionary/matching/fuzzy_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/fuzzy_matching.h
@@ -124,7 +124,8 @@ class FuzzyMatching final {
     std::vector<std::pair<fsa::automata_t, uint64_t>> fsa_start_state_pairs =
         FilterWithExactPrefix(fsas, query, minimum_exact_prefix);
 
-    return FromMulipleFsasWithMatchedExactPrefix<innerTraverserType>(fsa_start_state_pairs, query, max_edit_distance, minimum_exact_prefix);
+    return FromMulipleFsasWithMatchedExactPrefix<innerTraverserType>(fsa_start_state_pairs, query, max_edit_distance,
+                                                                     minimum_exact_prefix);
   }
 
   static inline std::vector<std::pair<fsa::automata_t, uint64_t>> FilterWithExactPrefix(

--- a/keyvi/include/keyvi/dictionary/matching/near_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/near_matching.h
@@ -146,6 +146,7 @@ class NearMatching final {
 
     return match_t();
   }
+
  private:
   std::unique_ptr<innerTraverserType> traverser_ptr_;
   const std::string exact_prefix_;

--- a/keyvi/include/keyvi/dictionary/matching/near_matching.h
+++ b/keyvi/include/keyvi/dictionary/matching/near_matching.h
@@ -40,6 +40,8 @@
 namespace keyvi {
 namespace index {
 namespace internal {
+template <class PayloadT, class SegmentT>
+class BaseIndexReader;
 template <class MatcherT, class DeletedT>
 keyvi::dictionary::match_t NextFilteredMatchSingle(const MatcherT&, const DeletedT&);
 template <class MatcherT, class DeletedT>
@@ -66,11 +68,25 @@ class NearMatching final {
    */
   static NearMatching FromSingleFsa(const fsa::automata_t& fsa, const std::string& query,
                                     const size_t minimum_exact_prefix, const bool greedy = false) {
-    uint64_t state = fsa->GetStartState();
+    return FromSingleFsa(fsa, fsa->GetStartState(), query, minimum_exact_prefix, greedy);
+  }
 
+  /**
+   * Create a near matcher from a single Fsa
+   *
+   * @param fsa the fsa
+   * @param start_state the state to start from
+   * @param query the query
+   * @param minimum_exact_prefix the minimum exact prefix to match before matching approximate
+   * @param greedy if true matches everything below minimum prefix
+   */
+  static NearMatching FromSingleFsa(const fsa::automata_t& fsa, const uint64_t start_state, const std::string& query,
+                                    const size_t minimum_exact_prefix, const bool greedy = false) {
     if (query.size() < minimum_exact_prefix) {
       return NearMatching();
     }
+
+    uint64_t state = start_state;
 
     TRACE("GetNear %s, matching prefix first", query.substr(0, minimum_exact_prefix).c_str());
     for (size_t i = 0; i < minimum_exact_prefix; ++i) {
@@ -81,33 +97,7 @@ class NearMatching final {
       }
     }
 
-    return FromSingleFsa(fsa, state, query, minimum_exact_prefix, greedy);
-  }
-
-  /**
-   * Create a near matcher from a single Fsa
-   *
-   * @param fsa the fsa
-   * @param query the query
-   * @param exact_prefix the exact prefix that already matched
-   * @param greedy if true matches everything below minimum prefix
-   */
-  static NearMatching FromSingleFsa(const fsa::automata_t& fsa, const uint64_t start_state, const std::string& query,
-                                    const size_t exact_prefix, const bool greedy = false) {
-    match_t first_match;
-    if (fsa->IsFinalState(start_state)) {
-      first_match = std::make_shared<Match>(0, query.size(), query, exact_prefix, fsa, fsa->GetStateValue(start_state));
-    }
-
-    std::shared_ptr<std::string> near_key = std::make_shared<std::string>(query.substr(exact_prefix));
-
-    auto payload = fsa::traversal::TraversalPayload<fsa::traversal::NearTransition>(near_key);
-
-    std::unique_ptr<fsa::ComparableStateTraverser<fsa::NearStateTraverser>> traverser =
-        std::make_unique<fsa::ComparableStateTraverser<fsa::NearStateTraverser>>(fsa, start_state, std::move(payload),
-                                                                                 true, 0);
-
-    return NearMatching(std::move(traverser), std::move(first_match), query.substr(0, exact_prefix), greedy);
+    return FromSingleFsaWithMatchedExactPrefix(fsa, state, query, minimum_exact_prefix, greedy);
   }
 
   /**
@@ -125,6 +115,89 @@ class NearMatching final {
     return FromMulipleFsas(std::move(fsa_start_state_payloads), query, minimum_exact_prefix, greedy);
   }
 
+  Match FirstMatch() const { return first_match_; }
+
+  Match NextMatch() {
+    TRACE("call next match %lu", matched_depth_);
+    for (; traverser_ptr_ && traverser_ptr_->GetDepth() > matched_depth_;) {
+      if (traverser_ptr_->IsFinalState()) {
+        // optimize? fill vector upfront?
+        std::string match_str =
+            exact_prefix_ + std::string(reinterpret_cast<const char*>(traverser_ptr_->GetStateLabels().data()),
+                                        traverser_ptr_->GetDepth());
+
+        // length should be query.size???
+        Match m(0, traverser_ptr_->GetDepth() + exact_prefix_.size(), match_str,
+                exact_prefix_.size() + traverser_ptr_->GetTraversalPayload().exact_depth, traverser_ptr_->GetFsa(),
+                traverser_ptr_->GetStateValue());
+
+        if (!greedy_) {
+          // remember the depth
+          TRACE("found a match, remember depth, only allow matches with same depth %ld",
+                traverser_ptr_->GetTraversalPayload().exact_depth);
+          matched_depth_ = traverser_ptr_->GetTraversalPayload().exact_depth;
+        }
+
+        (*traverser_ptr_)++;
+        return m;
+      }
+      (*traverser_ptr_)++;
+    }
+
+    return Match();
+  }
+
+ private:
+  std::unique_ptr<innerTraverserType> traverser_ptr_;
+  const std::string exact_prefix_;
+  const Match first_match_;
+  const bool greedy_ = false;
+  size_t matched_depth_ = 0;
+
+  NearMatching(std::unique_ptr<innerTraverserType>&& traverser, Match&& first_match, std::string&& minimum_exact_prefix,
+               const bool greedy)
+      : traverser_ptr_(std::move(traverser)),
+        exact_prefix_(std::move(minimum_exact_prefix)),
+        first_match_(std::move(first_match)),
+        greedy_(greedy) {}
+
+  NearMatching() {}
+
+  template <class PayloadT, class SegmentT>
+  friend class index::internal::BaseIndexReader;
+
+  // reset method for the index in the special case the match is deleted
+  template <class MatcherT, class DeletedT>
+  friend Match index::internal::NextFilteredMatchSingle(const MatcherT&, const DeletedT&);
+  template <class MatcherT, class DeletedT>
+  friend Match index::internal::NextFilteredMatch(const MatcherT&, const DeletedT&);
+
+  /**
+   * Create a near matcher from a single Fsa
+   *
+   * @param fsa the fsa
+   * @param query the query
+   * @param exact_prefix the exact prefix that already matched
+   * @param greedy if true matches everything below minimum prefix
+   */
+  static NearMatching FromSingleFsaWithMatchedExactPrefix(const fsa::automata_t& fsa, const uint64_t start_state,
+                                                          const std::string& query, const size_t exact_prefix,
+                                                          const bool greedy = false) {
+    if (fsa->IsFinalState(start_state)) {
+      first_match = std::make_shared<Match>(0, query.size(), query, exact_prefix, fsa, fsa->GetStateValue(start_state));
+    }
+
+    std::shared_ptr<std::string> near_key = std::make_shared<std::string>(query.substr(exact_prefix));
+
+    auto payload = fsa::traversal::TraversalPayload<fsa::traversal::NearTransition>(near_key);
+
+    std::unique_ptr<fsa::ComparableStateTraverser<fsa::NearStateTraverser>> traverser =
+        std::make_unique<fsa::ComparableStateTraverser<fsa::NearStateTraverser>>(fsa, start_state, std::move(payload),
+                                                                                 true, 0);
+
+    return NearMatching(std::move(traverser), std::move(first_match), query.substr(0, exact_prefix), greedy);
+  }
+
   /**
    * Create a near matcher with already matched exact prefix.
    *
@@ -134,8 +207,9 @@ class NearMatching final {
    * @param greedy if true matches everything below minimum prefix, if false everything at the longest matched prefix
    */
 
-  static NearMatching FromMulipleFsas(fsa_start_state_payloads_t&& fsa_start_state_payloads, const std::string& query,
-                                      const size_t exact_prefix, const bool greedy = false) {
+  static NearMatching FromMulipleFsasWithMatchedExactPrefix(fsa_start_state_payloads_t&& fsa_start_state_payloads,
+                                                            const std::string& query, const size_t exact_prefix,
+                                                            const bool greedy = false) {
     if (fsa_start_state_payloads.size() == 0) {
       return NearMatching();
     }
@@ -181,60 +255,6 @@ class NearMatching final {
     }
     return fsa_start_state_payloads;
   }
-
-  match_t& FirstMatch() { return first_match_; }
-
-  match_t NextMatch() {
-    TRACE("call next match %lu", matched_depth_);
-    for (; traverser_ptr_ && traverser_ptr_->GetDepth() > matched_depth_;) {
-      if (traverser_ptr_->IsFinalState()) {
-        // optimize? fill vector upfront?
-        std::string match_str =
-            exact_prefix_ + std::string(reinterpret_cast<const char*>(traverser_ptr_->GetStateLabels().data()),
-                                        traverser_ptr_->GetDepth());
-
-        // length should be query.size???
-        match_t m = std::make_shared<Match>(0, traverser_ptr_->GetDepth() + exact_prefix_.size(), match_str,
-                                            exact_prefix_.size() + traverser_ptr_->GetTraversalPayload().exact_depth,
-                                            traverser_ptr_->GetFsa(), traverser_ptr_->GetStateValue());
-
-        if (!greedy_) {
-          // remember the depth
-          TRACE("found a match, remember depth, only allow matches with same depth %ld",
-                traverser_ptr_->GetTraversalPayload().exact_depth);
-          matched_depth_ = traverser_ptr_->GetTraversalPayload().exact_depth;
-        }
-
-        (*traverser_ptr_)++;
-        return m;
-      }
-      (*traverser_ptr_)++;
-    }
-
-    return match_t();
-  }
-
- private:
-  std::unique_ptr<innerTraverserType> traverser_ptr_;
-  const std::string exact_prefix_;
-  match_t first_match_;
-  const bool greedy_ = false;
-  size_t matched_depth_ = 0;
-
-  NearMatching(std::unique_ptr<innerTraverserType>&& traverser, match_t&& first_match,
-               std::string&& minimum_exact_prefix, const bool greedy)
-      : traverser_ptr_(std::move(traverser)),
-        exact_prefix_(std::move(minimum_exact_prefix)),
-        first_match_(std::move(first_match)),
-        greedy_(greedy) {}
-
-  NearMatching() {}
-
-  // reset method for the index in the special case the match is deleted
-  template <class MatcherT, class DeletedT>
-  friend match_t index::internal::NextFilteredMatchSingle(const MatcherT&, const DeletedT&);
-  template <class MatcherT, class DeletedT>
-  friend match_t index::internal::NextFilteredMatch(const MatcherT&, const DeletedT&);
 
   void ResetLastMatch() { matched_depth_ = 0; }
 };

--- a/keyvi/include/keyvi/dictionary/secondary_key_dictionary.h
+++ b/keyvi/include/keyvi/dictionary/secondary_key_dictionary.h
@@ -101,7 +101,7 @@ class SecondaryKeyDictionary final {
     return dictionary_->Contains(GetStartState(meta), key);
   }
 
-  Match GetFirst(const std::string& key, const std::map<std::string, std::string>& meta) const {
+  match_t GetFirst(const std::string& key, const std::map<std::string, std::string>& meta) const {
     return dictionary_->GetSubscript(GetStartState(meta), key);
   }
 

--- a/keyvi/include/keyvi/dictionary/secondary_key_dictionary.h
+++ b/keyvi/include/keyvi/dictionary/secondary_key_dictionary.h
@@ -1,6 +1,6 @@
 /** keyvi - A key value store.
  *
- * Copyright 2015 Hendrik Muhs<hendrik.muhs@gmail.com>
+ * Copyright 2024 Hendrik Muhs<hendrik.muhs@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/keyvi/include/keyvi/dictionary/secondary_key_dictionary.h
+++ b/keyvi/include/keyvi/dictionary/secondary_key_dictionary.h
@@ -1,0 +1,152 @@
+/** keyvi - A key value store.
+ *
+ * Copyright 2015 Hendrik Muhs<hendrik.muhs@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * secondary_key_dictionary.h
+ *
+ *  Created on: May 25, 2024
+ *      Author: hendrik
+ */
+
+#ifndef KEYVI_DICTIONARY_SECONDARY_KEY_DICTIONARY_H_
+#define KEYVI_DICTIONARY_SECONDARY_KEY_DICTIONARY_H_
+
+#include "keyvi/dictionary/dictionary.h"
+
+// #define ENABLE_TRACING
+#include "keyvi/dictionary/util/trace.h"
+
+namespace keyvi {
+namespace dictionary {
+
+class SecondaryKeyDictionary final {
+ public:
+  /**
+   * Initialize a dictionary from a file.
+   *
+   * @param filename filename to load keyvi file from.
+   * @param loading_strategy optional: Loading strategy to use.
+   */
+  explicit SecondaryKeyDictionary(const std::string& filename,
+                                  loading_strategy_types loading_strategy = loading_strategy_types::lazy)
+      : SecondaryKeyDictionary(std::make_shared<fsa::Automata>(filename, loading_strategy)) {}
+
+  //
+  explicit SecondaryKeyDictionary(fsa::automata_t f) : dictionary_(std::make_shared<Dictionary>(f)) {
+    // TODO: load map of secondary keys from dictionary properties and initialize lookup table
+  }
+
+  /**
+   * A simple Contains method to check whether a key is in the dictionary.
+   *
+   * @param key The key
+   * @return True if key is in the dictionary, False otherwise.
+   */
+  bool Contains(const std::string& key, const std::map<std::string, std::string>& meta) const { return false; }
+
+  Match GetFirst(const std::string& key, const std::map<std::string, std::string>& meta) const {
+    // TODO: construct the secondary key from the given meta data and move the start state accordingly
+    uint64_t start_state = dictionary_->GetFsa()->GetStartState();
+    return dictionary_->GetSubscript(key, start_state);
+  }
+
+  /**
+   * Exact Match function.
+   *
+   * @param key the key to lookup.
+   * @return a match iterator
+   */
+  MatchIterator::MatchIteratorPair Get(const std::string& key, const std::map<std::string, std::string>& meta) const {
+    return MatchIterator::EmptyIteratorPair();
+  }
+
+  /**
+   * All the items in the dictionary.
+   *
+   * @return a match iterator of all the items
+   */
+  MatchIterator::MatchIteratorPair GetAllItems(const std::map<std::string, std::string>& meta) const {
+    return MatchIterator::EmptyIteratorPair();
+  }
+
+  /**
+   * Match a key near: Match as much as possible exact given the minimum prefix length and then return everything below.
+   *
+   * If greedy is True it matches everything below the minimum_prefix_length, but in the order of exact first.
+   *
+   * @param key
+   * @param minimum_prefix_length
+   * @param greedy if true matches everything below minimum prefix
+   * @return
+   */
+  MatchIterator::MatchIteratorPair GetNear(const std::string& key, const std::map<std::string, std::string>& meta,
+                                           const size_t minimum_prefix_length, const bool greedy = false) const {
+    return MatchIterator::EmptyIteratorPair();
+  }
+
+  MatchIterator::MatchIteratorPair GetFuzzy(const std::string& query, const std::map<std::string, std::string>& meta,
+                                            const int32_t max_edit_distance,
+                                            const size_t minimum_exact_prefix = 2) const {
+    return MatchIterator::EmptyIteratorPair();
+  }
+
+  MatchIterator::MatchIteratorPair GetPrefixCompletion(const std::string& query,
+                                                       const std::map<std::string, std::string>& meta) const {
+    return MatchIterator::EmptyIteratorPair();
+  }
+
+  MatchIterator::MatchIteratorPair GetPrefixCompletion(const std::string& query,
+                                                       const std::map<std::string, std::string>& meta,
+                                                       size_t top_n) const {
+    return MatchIterator::EmptyIteratorPair();
+  }
+
+  MatchIterator::MatchIteratorPair GetMultiwordCompletion(const std::string& query,
+                                                          const std::map<std::string, std::string>& meta,
+                                                          const unsigned char multiword_separator = 0x1b) const {
+    // TODO: construct the secondary key from the given meta data and move the start state accordingly
+    uint64_t start_state = dictionary_->GetFsa()->GetStartState();
+    return dictionary_->GetMultiWordCompletion(start_state, query, multiword_separator);
+  }
+
+  MatchIterator::MatchIteratorPair GetMultiwordCompletion(const std::string& query,
+                                                          const std::map<std::string, std::string>& meta, size_t top_n,
+                                                          const unsigned char multiword_separator = 0x1b) const {
+    return MatchIterator::EmptyIteratorPair();
+  }
+
+  MatchIterator::MatchIteratorPair GetFuzzyMultiwordCompletion(const std::string& query,
+                                                               const std::map<std::string, std::string>& meta,
+                                                               const int32_t max_edit_distance,
+                                                               const size_t minimum_exact_prefix = 0,
+                                                               const unsigned char multiword_separator = 0x1b) const {
+    return MatchIterator::EmptyIteratorPair();
+  }
+
+  std::string GetManifest() const { return dictionary_->GetManifest(); }
+
+ private:
+  dictionary_t dictionary_;
+};
+
+// shared pointer
+typedef std::shared_ptr<SecondaryKeyDictionary> secondary_key_dictionary_t;
+
+} /* namespace dictionary */
+} /* namespace keyvi */
+
+#endif  //  KEYVI_DICTIONARY_SECONDARY_KEY_DICTIONARY_H_

--- a/keyvi/include/keyvi/dictionary/secondary_key_dictionary.h
+++ b/keyvi/include/keyvi/dictionary/secondary_key_dictionary.h
@@ -77,16 +77,15 @@ class SecondaryKeyDictionary final {
 
     uint64_t i = 1;
     std::vector<char> string_buffer;
-    size_t length;
 
     // reserve a slot for empty replacement
-    keyvi::util::encodeVarInt(i++, &string_buffer, &length);
+    keyvi::util::encodeVarInt(i++, &string_buffer);
     secondary_key_replacements_.emplace("", std::string(string_buffer.begin(), string_buffer.end()));
 
     // create lookup table for values
     for (auto const& value: parsed_manifest["SecondaryKeyValues"].GetArray()) {
         string_buffer.clear();
-        keyvi::util::encodeVarInt(i++, &string_buffer, &length);
+        keyvi::util::encodeVarInt(i++, &string_buffer);
         secondary_key_replacements_.emplace(value.GetString(), std::string(string_buffer.begin(), string_buffer.end()));
     }*/
   }

--- a/keyvi/include/keyvi/dictionary/secondary_key_dictionary.h
+++ b/keyvi/include/keyvi/dictionary/secondary_key_dictionary.h
@@ -78,6 +78,10 @@ class SecondaryKeyDictionary final {
     }
   }
 
+  std::string GetStatistics() const { return dictionary_->GetStatistics(); }
+
+  uint64_t GetSize() const { return dictionary_->GetSize(); }
+
   /**
    * A simple Contains method to check whether a key is in the dictionary.
    *

--- a/keyvi/include/keyvi/dictionary/secondary_key_dictionary.h
+++ b/keyvi/include/keyvi/dictionary/secondary_key_dictionary.h
@@ -52,11 +52,11 @@ class SecondaryKeyDictionary final {
    * @param loading_strategy optional: Loading strategy to use.
    */
   explicit SecondaryKeyDictionary(const std::string& filename,
-                                  loading_strategy_types loading_strategy = loading_strategy_types::lazy)
+                                  const loading_strategy_types loading_strategy = loading_strategy_types::lazy)
       : SecondaryKeyDictionary(std::make_shared<fsa::Automata>(filename, loading_strategy), loading_strategy) {}
 
-  explicit SecondaryKeyDictionary(fsa::automata_t f,
-                                  loading_strategy_types loading_strategy = loading_strategy_types::lazy)
+  explicit SecondaryKeyDictionary(const fsa::automata_t& f,
+                                  const loading_strategy_types loading_strategy = loading_strategy_types::lazy)
       : dictionary_(std::make_shared<Dictionary>(f)) {
     std::string properties = dictionary_->GetFsa()->GetDictionaryProperties()->GetSpecializedDictionaryProperties();
 

--- a/keyvi/include/keyvi/dictionary/secondary_key_dictionary.h
+++ b/keyvi/include/keyvi/dictionary/secondary_key_dictionary.h
@@ -26,6 +26,7 @@
 #define KEYVI_DICTIONARY_SECONDARY_KEY_DICTIONARY_H_
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -54,7 +55,7 @@ class SecondaryKeyDictionary final {
 
   //
   explicit SecondaryKeyDictionary(fsa::automata_t f) : dictionary_(std::make_shared<Dictionary>(f)) {
-    // TODO: use a custom property instead
+    // TODO(hendrik): use a custom property instead
     std::string manifest = dictionary_->GetManifest();
     rapidjson::Document parsed_manifest;
     parsed_manifest.Parse(manifest);
@@ -111,7 +112,7 @@ class SecondaryKeyDictionary final {
    * @return a match iterator
    */
   MatchIterator::MatchIteratorPair Get(const std::string& key, const std::map<std::string, std::string>& meta) const {
-    return MatchIterator::EmptyIteratorPair();
+    return dictionary_->Get(GetStartState(meta), key);
   }
 
   /**
@@ -120,7 +121,7 @@ class SecondaryKeyDictionary final {
    * @return a match iterator of all the items
    */
   MatchIterator::MatchIteratorPair GetAllItems(const std::map<std::string, std::string>& meta) const {
-    return MatchIterator::EmptyIteratorPair();
+    return dictionary_->GetAllItems(GetStartState(meta));
   }
 
   /**
@@ -135,38 +136,36 @@ class SecondaryKeyDictionary final {
    */
   MatchIterator::MatchIteratorPair GetNear(const std::string& key, const std::map<std::string, std::string>& meta,
                                            const size_t minimum_prefix_length, const bool greedy = false) const {
-    return MatchIterator::EmptyIteratorPair();
+    return dictionary_->GetNear(GetStartState(meta), key, minimum_prefix_length, greedy);
   }
 
   MatchIterator::MatchIteratorPair GetFuzzy(const std::string& query, const std::map<std::string, std::string>& meta,
                                             const int32_t max_edit_distance,
                                             const size_t minimum_exact_prefix = 2) const {
-    return MatchIterator::EmptyIteratorPair();
+    return dictionary_->GetFuzzy(GetStartState(meta), query, max_edit_distance, minimum_exact_prefix);
   }
 
   MatchIterator::MatchIteratorPair GetPrefixCompletion(const std::string& query,
                                                        const std::map<std::string, std::string>& meta) const {
-    return MatchIterator::EmptyIteratorPair();
+    return dictionary_->GetPrefixCompletion(GetStartState(meta), query);
   }
 
   MatchIterator::MatchIteratorPair GetPrefixCompletion(const std::string& query,
                                                        const std::map<std::string, std::string>& meta,
                                                        size_t top_n) const {
-    return MatchIterator::EmptyIteratorPair();
+    return dictionary_->GetPrefixCompletion(GetStartState(meta), query, top_n);
   }
 
   MatchIterator::MatchIteratorPair GetMultiwordCompletion(const std::string& query,
                                                           const std::map<std::string, std::string>& meta,
                                                           const unsigned char multiword_separator = 0x1b) const {
-    // TODO: construct the secondary key from the given meta data and move the start state accordingly
-    uint64_t start_state = dictionary_->GetFsa()->GetStartState();
-    return dictionary_->GetMultiwordCompletion(query, start_state, multiword_separator);
+    return dictionary_->GetMultiwordCompletion(GetStartState(meta), query, multiword_separator);
   }
 
   MatchIterator::MatchIteratorPair GetMultiwordCompletion(const std::string& query,
                                                           const std::map<std::string, std::string>& meta, size_t top_n,
                                                           const unsigned char multiword_separator = 0x1b) const {
-    return MatchIterator::EmptyIteratorPair();
+    return dictionary_->GetMultiwordCompletion(GetStartState(meta), query, top_n, multiword_separator);
   }
 
   MatchIterator::MatchIteratorPair GetFuzzyMultiwordCompletion(const std::string& query,
@@ -174,7 +173,8 @@ class SecondaryKeyDictionary final {
                                                                const int32_t max_edit_distance,
                                                                const size_t minimum_exact_prefix = 0,
                                                                const unsigned char multiword_separator = 0x1b) const {
-    return MatchIterator::EmptyIteratorPair();
+    return dictionary_->GetFuzzyMultiwordCompletion(GetStartState(meta), query, max_edit_distance, minimum_exact_prefix,
+                                                    multiword_separator);
   }
 
   std::string GetManifest() const { return dictionary_->GetManifest(); }

--- a/keyvi/include/keyvi/dictionary/secondary_key_dictionary_compiler.h
+++ b/keyvi/include/keyvi/dictionary/secondary_key_dictionary_compiler.h
@@ -25,7 +25,9 @@
 #ifndef KEYVI_DICTIONARY_SECONDARY_KEY_DICTIONARY_COMPILER_H_
 #define KEYVI_DICTIONARY_SECONDARY_KEY_DICTIONARY_COMPILER_H_
 
+#include <map>
 #include <string>
+#include <vector>
 
 #include "keyvi/dictionary/dictionary_compiler.h"
 
@@ -48,16 +50,14 @@ class SecondaryKeyDictionaryCompiler final {
 
  public:
   /**
-   * Instantiate a dictionary compiler.
+   * Instantiate a secondary key dictionary compiler.
    *
-   * Note the memory limit only limits the memory used for internal buffers,
-   * memory usage for small short-lived objects and the library itself is not
-   * part of the limit.
-   *
+   * @param secondary_keys a list of secondary keys
    * @param params compiler parameters
    */
-  explicit SecondaryKeyDictionaryCompiler(const keyvi::util::parameters_t& params = keyvi::util::parameters_t())
-      : dictionary_compiler_(params) {}
+  explicit SecondaryKeyDictionaryCompiler(const std::vector<std::string> secondary_keys,
+                                          const keyvi::util::parameters_t& params = keyvi::util::parameters_t())
+      : dictionary_compiler_(params), secondary_keys_(secondary_keys) {}
 
   SecondaryKeyDictionaryCompiler& operator=(SecondaryKeyDictionaryCompiler const&) = delete;
   SecondaryKeyDictionaryCompiler(const SecondaryKeyDictionaryCompiler& that) = delete;
@@ -70,7 +70,7 @@ class SecondaryKeyDictionaryCompiler final {
   /**
    * Do the final compilation
    */
-  void Compile(callback_t progress_callback = nullptr, void* user_data = nullptr) {
+  void Compile(DictionaryCompiler<>::callback_t progress_callback = nullptr, void* user_data = nullptr) {
     dictionary_compiler_.Compile(progress_callback, user_data);
   }
 
@@ -87,6 +87,8 @@ class SecondaryKeyDictionaryCompiler final {
 
  private:
   DictionaryCompiler<ValueStoreType> dictionary_compiler_;
+  std::vector<std::string> secondary_keys_;
+  std::map<std::string, std::string> secondary_key_replacements_;
 };
 
 } /* namespace dictionary */

--- a/keyvi/include/keyvi/dictionary/secondary_key_dictionary_compiler.h
+++ b/keyvi/include/keyvi/dictionary/secondary_key_dictionary_compiler.h
@@ -31,7 +31,6 @@
 #include <vector>
 
 #include "keyvi/dictionary/dictionary_compiler.h"
-#include "keyvi/dictionary/dictionary_types.h"
 #include "keyvi/dictionary/fsa/internal/constants.h"
 
 // #define ENABLE_TRACING
@@ -131,7 +130,7 @@ class SecondaryKeyDictionaryCompiler final {
     dictionary_compiler_.SetSpecializedDictionaryProperties(string_buffer.GetString());
     dictionary_compiler_.Write(stream);
 
-    StringDictionaryCompiler secondary_key_compiler(params_);
+    keyvi::dictionary::DictionaryCompiler<fsa::internal::value_store_t::STRING> secondary_key_compiler(params_);
 
     for (auto const& [value, replacement] : secondary_key_replacements_) {
       secondary_key_compiler.Add(value, replacement);

--- a/keyvi/include/keyvi/dictionary/secondary_key_dictionary_compiler.h
+++ b/keyvi/include/keyvi/dictionary/secondary_key_dictionary_compiler.h
@@ -57,7 +57,7 @@ class SecondaryKeyDictionaryCompiler final {
    * @param secondary_keys a list of secondary keys
    * @param params compiler parameters
    */
-  explicit SecondaryKeyDictionaryCompiler(const std::vector<std::string> secondary_keys,
+  explicit SecondaryKeyDictionaryCompiler(const std::vector<std::string>& secondary_keys,
                                           const keyvi::util::parameters_t& params = keyvi::util::parameters_t())
       : params_(params), dictionary_compiler_(params), secondary_keys_(secondary_keys) {}
 
@@ -147,9 +147,9 @@ class SecondaryKeyDictionaryCompiler final {
   }
 
  private:
-  keyvi::util::parameters_t params_;
+  const keyvi::util::parameters_t params_;
   DictionaryCompiler<ValueStoreType> dictionary_compiler_;
-  std::vector<std::string> secondary_keys_;
+  const std::vector<std::string> secondary_keys_;
   std::map<std::string, std::string> secondary_key_replacements_;
   uint64_t current_index_ = 2;  //  starting from 2, 1 is reserved for empty string
   std::vector<char> replacements_buffer_;

--- a/keyvi/include/keyvi/dictionary/secondary_key_dictionary_compiler.h
+++ b/keyvi/include/keyvi/dictionary/secondary_key_dictionary_compiler.h
@@ -1,0 +1,95 @@
+/* * keyvi - A key value store.
+ *
+ * Copyright 2024 Hendrik Muhs<hendrik.muhs@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * secondary_key_dictionary_compiler.h
+ *
+ *  Created on: Jun 2, 2024
+ *      Author: hendrik
+ */
+
+#ifndef KEYVI_DICTIONARY_SECONDARY_KEY_DICTIONARY_COMPILER_H_
+#define KEYVI_DICTIONARY_SECONDARY_KEY_DICTIONARY_COMPILER_H_
+
+#include <string>
+
+#include "keyvi/dictionary/dictionary_compiler.h"
+
+// #define ENABLE_TRACING
+#include "keyvi/dictionary/util/trace.h"
+
+namespace keyvi {
+namespace dictionary {
+
+/**
+ * Secondary Key Dictionary Compiler
+ *
+ * @tparam ValueStoreType The type of the value store to use
+ * @tparam N Array size for fixed size value vectors, ignored otherwise
+ */
+template <keyvi::dictionary::fsa::internal::value_store_t ValueStoreType = fsa::internal::value_store_t::KEY_ONLY>
+class SecondaryKeyDictionaryCompiler final {
+ public:
+  using ValueStoreT = typename fsa::internal::ValueStoreComponents<ValueStoreType>::value_store_writer_t;
+
+ public:
+  /**
+   * Instantiate a dictionary compiler.
+   *
+   * Note the memory limit only limits the memory used for internal buffers,
+   * memory usage for small short-lived objects and the library itself is not
+   * part of the limit.
+   *
+   * @param params compiler parameters
+   */
+  explicit SecondaryKeyDictionaryCompiler(const keyvi::util::parameters_t& params = keyvi::util::parameters_t())
+      : dictionary_compiler_(params) {}
+
+  SecondaryKeyDictionaryCompiler& operator=(SecondaryKeyDictionaryCompiler const&) = delete;
+  SecondaryKeyDictionaryCompiler(const SecondaryKeyDictionaryCompiler& that) = delete;
+
+  void Add(const std::string& input_key, const std::map<std::string, std::string>& meta,
+           typename ValueStoreT::value_t value = ValueStoreT::no_value) {
+    dictionary_compiler_.Add(input_key, value);
+  }
+
+  /**
+   * Do the final compilation
+   */
+  void Compile(callback_t progress_callback = nullptr, void* user_data = nullptr) {
+    dictionary_compiler_.Compile(progress_callback, user_data);
+  }
+
+  /**
+   * Set a custom manifest to be embedded into the index file.
+   *
+   * @param manifest as string
+   */
+  void SetManifest(const std::string& manifest) { dictionary_compiler_.SetManifest; }
+
+  void Write(std::ostream& stream) { dictionary_compiler_.Write(stream); }
+
+  void WriteToFile(const std::string& filename) { dictionary_compiler_.WriteToFile(filename); }
+
+ private:
+  DictionaryCompiler<ValueStoreType> dictionary_compiler_;
+};
+
+} /* namespace dictionary */
+} /* namespace keyvi */
+
+#endif  // KEYVI_DICTIONARY_SECONDARY_KEY_DICTIONARY_COMPILER_H_

--- a/keyvi/include/keyvi/dictionary/secondary_key_dictionary_compiler.h
+++ b/keyvi/include/keyvi/dictionary/secondary_key_dictionary_compiler.h
@@ -110,7 +110,7 @@ class SecondaryKeyDictionaryCompiler final {
    *
    * @param manifest as string
    */
-  void SetManifest(const std::string& manifest) { dictionary_compiler_.SetManifest; }
+  void SetManifest(const std::string& manifest) { dictionary_compiler_.SetManifest(manifest); }
 
   void Write(std::ostream& stream) {
     rapidjson::StringBuffer string_buffer;

--- a/keyvi/include/keyvi/index/internal/base_index_reader.h
+++ b/keyvi/include/keyvi/index/internal/base_index_reader.h
@@ -131,7 +131,7 @@ class BaseIndexReader {
 
     if (fsa_start_state_payloads.size() == 1) {
       auto near_matcher =
-          std::make_shared<dictionary::matching::NearMatching<>>(dictionary::matching::NearMatching<>::FromSingleFsa(
+          std::make_shared<dictionary::matching::NearMatching<>>(dictionary::matching::NearMatching<>::FromSingleFsaWithMatchedExactPrefix(
               std::get<0>(fsa_start_state_payloads[0]), std::get<1>(fsa_start_state_payloads[0]), query,
               minimum_exact_prefix, greedy));
 
@@ -157,7 +157,7 @@ class BaseIndexReader {
     auto near_matcher = std::make_shared<
         dictionary::matching::NearMatching<dictionary::fsa::ZipStateTraverser<dictionary::fsa::NearStateTraverser>>>(
         dictionary::matching::NearMatching<dictionary::fsa::ZipStateTraverser<dictionary::fsa::NearStateTraverser>>::
-            FromMulipleFsas(std::move(fsa_start_state_payloads), query, minimum_exact_prefix, greedy));
+            FromMulipleFsasWithMatchedExactPrefix(std::move(fsa_start_state_payloads), query, minimum_exact_prefix, greedy));
 
     if (deleted_keys_map.size() == 0) {
       auto func = [near_matcher]() { return near_matcher->NextMatch(); };

--- a/keyvi/include/keyvi/index/internal/base_index_reader.h
+++ b/keyvi/include/keyvi/index/internal/base_index_reader.h
@@ -130,8 +130,8 @@ class BaseIndexReader {
     }
 
     if (fsa_start_state_payloads.size() == 1) {
-      auto near_matcher =
-          std::make_shared<dictionary::matching::NearMatching<>>(dictionary::matching::NearMatching<>::FromSingleFsaWithMatchedExactPrefix(
+      auto near_matcher = std::make_shared<dictionary::matching::NearMatching<>>(
+          dictionary::matching::NearMatching<>::FromSingleFsaWithMatchedExactPrefix(
               std::get<0>(fsa_start_state_payloads[0]), std::get<1>(fsa_start_state_payloads[0]), query,
               minimum_exact_prefix, greedy));
 
@@ -157,7 +157,8 @@ class BaseIndexReader {
     auto near_matcher = std::make_shared<
         dictionary::matching::NearMatching<dictionary::fsa::ZipStateTraverser<dictionary::fsa::NearStateTraverser>>>(
         dictionary::matching::NearMatching<dictionary::fsa::ZipStateTraverser<dictionary::fsa::NearStateTraverser>>::
-            FromMulipleFsasWithMatchedExactPrefix(std::move(fsa_start_state_payloads), query, minimum_exact_prefix, greedy));
+            FromMulipleFsasWithMatchedExactPrefix(std::move(fsa_start_state_payloads), query, minimum_exact_prefix,
+                                                  greedy));
 
     if (deleted_keys_map.size() == 0) {
       auto func = [near_matcher]() { return near_matcher->NextMatch(); };
@@ -200,9 +201,9 @@ class BaseIndexReader {
 
     if (fsa_start_state_pairs.size() == 1) {
       auto fuzzy_matcher = std::make_shared<dictionary::matching::FuzzyMatching<>>(
-          dictionary::matching::FuzzyMatching<>::FromSingleFsa<>(fsa_start_state_pairs[0].first,
-                                                                 fsa_start_state_pairs[0].second, query,
-                                                                 max_edit_distance, minimum_exact_prefix));
+          dictionary::matching::FuzzyMatching<>::FromSingleFsaWithMatchedExactPrefix<>(
+              fsa_start_state_pairs[0].first, fsa_start_state_pairs[0].second, query, max_edit_distance,
+              minimum_exact_prefix));
 
       for (auto it = segments->crbegin(); it != segments->crend(); it++) {
         if ((*it)->GetDictionary()->GetFsa() == fsa_start_state_pairs[0].first) {
@@ -233,8 +234,8 @@ class BaseIndexReader {
     auto fuzzy_matcher = std::make_shared<
         dictionary::matching::FuzzyMatching<dictionary::fsa::ZipStateTraverser<dictionary::fsa::StateTraverser<>>>>(
         dictionary::matching::FuzzyMatching<dictionary::fsa::ZipStateTraverser<dictionary::fsa::StateTraverser<>>>::
-            FromMulipleFsas<dictionary::fsa::StateTraverser<>>(fsa_start_state_pairs, query, max_edit_distance,
-                                                               minimum_exact_prefix));
+            FromMulipleFsasWithMatchedExactPrefix<dictionary::fsa::StateTraverser<>>(
+                fsa_start_state_pairs, query, max_edit_distance, minimum_exact_prefix));
 
     if (deleted_keys_map.size() == 0) {
       auto func = [fuzzy_matcher]() { return fuzzy_matcher->NextMatch(); };

--- a/keyvi/include/keyvi/util/vint.h
+++ b/keyvi/include/keyvi/util/vint.h
@@ -120,6 +120,7 @@ size_t getVarShortLength(int_t value) {
  * Encode variable length integer and write it to the given buffer
  * @param value the integer
  * @param output the buffer to write to
+ * @param written_bytes number of bytes written
  */
 template <typename int_t = uint64_t, typename buffer_t>
 void encodeVarInt(int_t value, buffer_t* output, size_t* written_bytes) {
@@ -135,6 +136,24 @@ void encodeVarInt(int_t value, buffer_t* output, size_t* written_bytes) {
   }
   output->push_back(((uint8_t)value) & 127);
   *written_bytes = ++length;
+}
+
+/**
+ * Encode variable length integer and write it to the given buffer
+ * @param value the integer
+ * @param output the buffer to write to
+ */
+template <typename int_t = uint64_t, typename buffer_t>
+void encodeVarInt(int_t value, buffer_t* output) {
+  size_t length = 0;
+  while (value > 127) {
+    // |128: Set the next byte flag
+    output->push_back(((uint8_t)(value & 127)) | 128);
+    // Remove the seven bits we just wrote
+    value >>= 7;
+    ++length;
+  }
+  output->push_back(((uint8_t)value) & 127);
 }
 
 /**

--- a/keyvi/include/keyvi/util/vint.h
+++ b/keyvi/include/keyvi/util/vint.h
@@ -145,13 +145,11 @@ void encodeVarInt(int_t value, buffer_t* output, size_t* written_bytes) {
  */
 template <typename int_t = uint64_t, typename buffer_t>
 void encodeVarInt(int_t value, buffer_t* output) {
-  size_t length = 0;
   while (value > 127) {
     // |128: Set the next byte flag
     output->push_back(((uint8_t)(value & 127)) | 128);
     // Remove the seven bits we just wrote
     value >>= 7;
-    ++length;
   }
   output->push_back(((uint8_t)value) & 127);
 }

--- a/keyvi/tests/keyvi/dictionary/secondary_key_dictionary_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/secondary_key_dictionary_test.cpp
@@ -1,0 +1,60 @@
+/** keyvi - A key value store.
+ *
+ * Copyright 2015 Hendrik Muhs<hendrik.muhs@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * secondary_key_dictionary_test.cpp
+ *
+ *  Created on: May 25, 2024
+ *      Author: hendrik
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include "keyvi/dictionary/secondary_key_dictionary.h"
+#include "keyvi/testing/temp_dictionary.h"
+
+namespace keyvi {
+namespace dictionary {
+BOOST_AUTO_TEST_SUITE(SecondaryKeyDictionaryTests)
+
+BOOST_AUTO_TEST_CASE(OneSecondaryKey) {
+  std::vector<std::pair<std::string, uint32_t>> test_data = {
+      {"acme:siegfried", 22},
+      {"acma:walpurga", 10},
+  };
+
+  testing::TempDictionary dictionary(&test_data);
+  secondary_key_dictionary_t d(new SecondaryKeyDictionary(dictionary.GetFsa()));
+
+  auto m = d->GetFirst("siegfried", {{"skey", "acme"}});
+  BOOST_CHECK_EQUAL(22, m.GetWeight());
+
+  auto completer = d->GetMultiwordCompletion("sie", {{"skey", "acme"}});
+  auto completer_it = completer.begin();
+  size_t i = 0;
+
+  while (completer_it != completer.end()) {
+    BOOST_CHECK_EQUAL("siegfried", completer_it->GetMatchedString());
+    BOOST_CHECK_EQUAL(22, completer_it->GetWeight());
+  }
+  BOOST_CHECK_EQUAL(1, i);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} /* namespace dictionary */
+} /* namespace keyvi */

--- a/keyvi/tests/keyvi/dictionary/secondary_key_dictionary_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/secondary_key_dictionary_test.cpp
@@ -121,14 +121,13 @@ BOOST_AUTO_TEST_CASE(completions) {
 
 BOOST_AUTO_TEST_CASE(json) {
   std::vector<std::tuple<std::string, std::map<std::string, std::string>, std::string>> test_data = {
-      {"siegfried", {{"company", "acme"}}, "{a:1}"},
-      {"walburga", {{"company", "acma"}}, "{a:2}"},
-      {"walburga", {{"company", "abcde"}}, "{b:1}"},
-      {"walburga", {{"company", ""}}, "{c:1}"},
+      {"key", {{"user_id", "a1"}}, "{a:1}"},
+      {"key", {{"user_id", "a2"}}, "{a:2}"},
+      {"key", {{"user_id", ""}}, "{c:1}"},
   };
 
   SecondaryKeyDictionaryCompiler<fsa::internal::value_store_t::JSON> compiler(
-      {"company"}, keyvi::util::parameters_t({{"memory_limit_mb", "10"}}));
+      {"user_id"}, keyvi::util::parameters_t({{"memory_limit_mb", "10"}}));
 
   for (auto p : test_data) {
     compiler.Add(std::get<0>(p), std::get<1>(p), std::get<2>(p));
@@ -145,6 +144,18 @@ BOOST_AUTO_TEST_CASE(json) {
   compiler.WriteToFile(file_name);
 
   SecondaryKeyDictionary d(file_name.c_str());
+
+  match_t m = d.GetFirst("key", {{"user_id", "a1"}});
+  BOOST_CHECK(m);
+  BOOST_CHECK_EQUAL("\"{a:1}\"", m->GetValueAsString());
+  m = d.GetFirst("key", {{"user_id", "a2"}});
+  BOOST_CHECK(m);
+  BOOST_CHECK_EQUAL("\"{a:2}\"", m->GetValueAsString());
+  m = d.GetFirst("key", {{"user_id", ""}});
+  BOOST_CHECK(m);
+  BOOST_CHECK_EQUAL("\"{c:1}\"", m->GetValueAsString());
+
+  std::filesystem::remove_all(temp_path);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/keyvi/tests/keyvi/dictionary/secondary_key_dictionary_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/secondary_key_dictionary_test.cpp
@@ -22,6 +22,7 @@
  *      Author: hendrik
  */
 
+#include <filesystem>
 #include <map>
 #include <tuple>
 #include <vector>
@@ -35,7 +36,7 @@ namespace keyvi {
 namespace dictionary {
 BOOST_AUTO_TEST_SUITE(SecondaryKeyDictionaryTests)
 
-BOOST_AUTO_TEST_CASE(OneSecondaryKey) {
+BOOST_AUTO_TEST_CASE(completions) {
   std::vector<std::tuple<std::string, std::map<std::string, std::string>, uint32_t>> test_data = {
       {"siegfried", {{"company", "acme"}}, 22},
       {"walburga", {{"company", "acma"}}, 10},
@@ -51,10 +52,11 @@ BOOST_AUTO_TEST_CASE(OneSecondaryKey) {
   }
   compiler.Compile();
 
-  boost::filesystem::path temp_path = boost::filesystem::temp_directory_path();
+  std::filesystem::path temp_path = std::filesystem::temp_directory_path();
 
   temp_path /=
-      boost::filesystem::unique_path("secondary-key-dictionary-unit-test-dictionarycompiler-%%%%-%%%%-%%%%-%%%%");
+      boost::filesystem::unique_path("secondary-key-dictionary-unit-test-dictionarycompiler-%%%%-%%%%-%%%%-%%%%")
+          .string();
   std::string file_name = temp_path.string();
 
   compiler.WriteToFile(file_name);
@@ -113,6 +115,36 @@ BOOST_AUTO_TEST_CASE(OneSecondaryKey) {
     completer_it++;
   }
   BOOST_CHECK_EQUAL(1, i);
+
+  std::filesystem::remove_all(temp_path);
+}
+
+BOOST_AUTO_TEST_CASE(json) {
+  std::vector<std::tuple<std::string, std::map<std::string, std::string>, std::string>> test_data = {
+      {"siegfried", {{"company", "acme"}}, "{a:1}"},
+      {"walburga", {{"company", "acma"}}, "{a:2}"},
+      {"walburga", {{"company", "abcde"}}, "{b:1}"},
+      {"walburga", {{"company", ""}}, "{c:1}"},
+  };
+
+  SecondaryKeyDictionaryCompiler<fsa::internal::value_store_t::JSON> compiler(
+      {"company"}, keyvi::util::parameters_t({{"memory_limit_mb", "10"}}));
+
+  for (auto p : test_data) {
+    compiler.Add(std::get<0>(p), std::get<1>(p), std::get<2>(p));
+  }
+  compiler.Compile();
+
+  std::filesystem::path temp_path = std::filesystem::temp_directory_path();
+
+  temp_path /=
+      boost::filesystem::unique_path("secondary-key-dictionary-unit-test-dictionarycompiler-%%%%-%%%%-%%%%-%%%%")
+          .string();
+  std::string file_name = temp_path.string();
+
+  compiler.WriteToFile(file_name);
+
+  SecondaryKeyDictionary d(file_name.c_str());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/keyvi/tests/keyvi/dictionary/secondary_key_dictionary_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/secondary_key_dictionary_test.cpp
@@ -30,7 +30,6 @@
 
 #include "keyvi/dictionary/secondary_key_dictionary.h"
 #include "keyvi/dictionary/secondary_key_dictionary_compiler.h"
-#include "keyvi/testing/temp_dictionary.h"
 
 namespace keyvi {
 namespace dictionary {
@@ -39,7 +38,9 @@ BOOST_AUTO_TEST_SUITE(SecondaryKeyDictionaryTests)
 BOOST_AUTO_TEST_CASE(OneSecondaryKey) {
   std::vector<std::tuple<std::string, std::map<std::string, std::string>, uint32_t>> test_data = {
       {"siegfried", {{"company", "acme"}}, 22},
-      {"walpurga", {{"company", "acma"}}, 10},
+      {"walburga", {{"company", "acma"}}, 10},
+      {"walburga", {{"company", "abcde"}}, 33},
+      {"walburga", {{"company", ""}}, 23},
   };
 
   SecondaryKeyDictionaryCompiler<fsa::internal::value_store_t::INT_WITH_WEIGHTS> compiler(
@@ -58,23 +59,60 @@ BOOST_AUTO_TEST_CASE(OneSecondaryKey) {
 
   compiler.WriteToFile(file_name);
 
-  Dictionary d(file_name.c_str());
+  SecondaryKeyDictionary d(file_name.c_str());
 
-  // secondary_key_dictionary_t d(new SecondaryKeyDictionary(dictionary.GetFsa()));
+  match_t m = d.GetFirst("siegfried", {{"company", "acme"}});
+  BOOST_CHECK(m);
+  BOOST_CHECK_EQUAL(22, m->GetWeight());
+  m = d.GetFirst("siegfried", {{"company", "acma"}});
+  BOOST_CHECK(!m);
 
-  /*auto m = d->GetFirst("siegfried", {{"skey", "acme"}});
-  BOOST_CHECK_EQUAL(22, m.GetWeight());
+  m = d.GetFirst("walburga", {{"company", "acme"}});
+  BOOST_CHECK(!m);
+  m = d.GetFirst("walburga", {{"company", "acma"}});
+  BOOST_CHECK(m);
+  BOOST_CHECK_EQUAL(10, m->GetWeight());
+  m = d.GetFirst("walburga", {{"company", "abcde"}});
+  BOOST_CHECK(m);
+  BOOST_CHECK_EQUAL(33, m->GetWeight());
+  m = d.GetFirst("walburga", {{"company", ""}});
+  BOOST_CHECK(m);
+  BOOST_CHECK_EQUAL(23, m->GetWeight());
 
-  auto completer = d->GetMultiwordCompletion("sie", {{"skey", "acme"}});
+  // more cases
+  m = d.GetFirst("walburga", {{"something", "acma"}});
+  BOOST_CHECK(!m);
+  m = d.GetFirst("walburga", {{"something", "xyz"}, {"company", "acma"}});
+  BOOST_CHECK(m);
+  BOOST_CHECK_EQUAL("walburga", m->GetMatchedString());
+  m = d.GetFirst("walburga", {{}});
+  BOOST_CHECK(!m);
+  m = d.GetFirst("siegfried", {{"company", ""}});
+  BOOST_CHECK(!m);
+
+  auto completer = d.GetMultiwordCompletion("sie", {{"company", "acme"}});
   auto completer_it = completer.begin();
   size_t i = 0;
 
   while (completer_it != completer.end()) {
-    BOOST_CHECK_EQUAL("siegfried", completer_it->GetMatchedString());
-    BOOST_CHECK_EQUAL(22, completer_it->GetWeight());
+    i++;
+    BOOST_CHECK_EQUAL("siegfried", (*completer_it)->GetMatchedString());
+    BOOST_CHECK_EQUAL(22, (*completer_it)->GetWeight());
+    completer_it++;
   }
   BOOST_CHECK_EQUAL(1, i);
-  */
+
+  completer = d.GetMultiwordCompletion("wa", {{"company", "abcde"}});
+  completer_it = completer.begin();
+  i = 0;
+
+  while (completer_it != completer.end()) {
+    i++;
+    BOOST_CHECK_EQUAL("walburga", (*completer_it)->GetMatchedString());
+    BOOST_CHECK_EQUAL(33, (*completer_it)->GetWeight());
+    completer_it++;
+  }
+  BOOST_CHECK_EQUAL(1, i);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/keyvi/tests/keyvi/dictionary/secondary_key_dictionary_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/secondary_key_dictionary_test.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(OneSecondaryKey) {
   testing::TempDictionary dictionary(&test_data);
   secondary_key_dictionary_t d(new SecondaryKeyDictionary(dictionary.GetFsa()));
 
-  auto m = d->GetFirst("siegfried", {{"skey", "acme"}});
+  /*auto m = d->GetFirst("siegfried", {{"skey", "acme"}});
   BOOST_CHECK_EQUAL(22, m.GetWeight());
 
   auto completer = d->GetMultiwordCompletion("sie", {{"skey", "acme"}});
@@ -52,6 +52,7 @@ BOOST_AUTO_TEST_CASE(OneSecondaryKey) {
     BOOST_CHECK_EQUAL(22, completer_it->GetWeight());
   }
   BOOST_CHECK_EQUAL(1, i);
+  */
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/keyvi/tests/keyvi/dictionary/secondary_key_dictionary_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/secondary_key_dictionary_test.cpp
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(OneSecondaryKey) {
   };
 
   testing::TempDictionary dictionary(&test_data);
-  secondary_key_dictionary_t d(new SecondaryKeyDictionary(dictionary.GetFsa()));
+  // secondary_key_dictionary_t d(new SecondaryKeyDictionary(dictionary.GetFsa()));
 
   /*auto m = d->GetFirst("siegfried", {{"skey", "acme"}});
   BOOST_CHECK_EQUAL(22, m.GetWeight());

--- a/keyvi/tests/keyvi/index/internal/tiered_merge_policy_test.cpp
+++ b/keyvi/tests/keyvi/index/internal/tiered_merge_policy_test.cpp
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_SUITE(MergePolicySelectorTests)
 static dictionary::dictionary_properties_t createDictionaryProperties(const uint64_t number_of_keys,
                                                                       const uint64_t start_state = 0) {
   return std::make_shared<dictionary::DictionaryProperties>(0, start_state, number_of_keys, 0,
-                                                            dictionary::dictionary_type_t::KEY_ONLY, 0, 0, "");
+                                                            dictionary::dictionary_type_t::KEY_ONLY, 0, 0, "", "");
 }
 
 BOOST_AUTO_TEST_CASE(one_segment) {

--- a/python/src/addons/SecondaryKeyCompletionDictionaryCompiler.pyx
+++ b/python/src/addons/SecondaryKeyCompletionDictionaryCompiler.pyx
@@ -1,0 +1,20 @@
+
+
+    def __enter__(self):
+        return self
+
+
+    def __exit__(self, type, value, traceback):
+        self.Compile()
+
+
+    def Compile(self, *args):
+        if not args:
+            with nogil:
+                self.inst.get().Compile()
+            return
+
+        cdef void* callback = <void*> args[0]
+        with nogil:
+            self.inst.get().Compile(progress_compiler_callback, callback)
+

--- a/python/src/addons/SecondaryKeyCompletionDictionaryCompiler.pyx
+++ b/python/src/addons/SecondaryKeyCompletionDictionaryCompiler.pyx
@@ -8,7 +8,7 @@
         self.Compile()
 
 
-    def Compile(self, *args):
+    def compile(self, *args):
         if not args:
             with nogil:
                 self.inst.get().Compile()

--- a/python/src/addons/SecondaryKeyDictionary.pyx
+++ b/python/src/addons/SecondaryKeyDictionary.pyx
@@ -1,0 +1,79 @@
+
+
+    def get (self, key, meta, default = None):
+        if isinstance(key, unicode):
+            key = key.encode('utf-8')
+        assert isinstance(key, bytes), 'arg in_0 wrong type'
+        assert isinstance(meta, dict), 'arg in_1 wrong type'
+
+        cdef libcpp_map[libcpp_utf8_string, libcpp_utf8_string] * v1 = new libcpp_map[libcpp_utf8_string, libcpp_utf8_string]()
+        for key, value in meta.items():
+            if isinstance(key, unicode):
+                key = key.encode('utf-8')
+            if isinstance(value, unicode):
+                value = value.encode('utf-8')
+            deref(v1)[ (<libcpp_string>key) ] = (<libcpp_string>value)
+
+        cdef shared_ptr[_Match] _r = self.inst.get().GetFirst(<libcpp_string>key, deref(v1))
+        del(v1)
+
+        if _r.get() == nullptr:
+            return default
+        cdef Match py_result = Match.__new__(Match)
+        py_result.inst = _r
+        return py_result
+
+    def contains(self, key, meta):
+        if isinstance(key, unicode):
+            key = key.encode('utf-8')
+
+        assert isinstance(key, bytes), 'arg in_0 wrong type'
+        assert isinstance(meta, dict), 'arg in_1 wrong type'
+
+        return self.inst.get().Contains(key, meta)
+
+    def __len__(self):
+        return self.inst.get().GetSize()
+
+    def _key_iterator_wrapper(self, iterator):
+        for m in iterator:
+            yield m.matched_string
+
+    def _value_iterator_wrapper(self, iterator):
+        for m in iterator:
+            yield m.value
+
+    def _item_iterator_wrapper(self, iterator):
+        for m in iterator:
+            yield (m.matched_string, m.value)
+
+    def keys(self, meta):
+        assert isinstance(meta, dict), 'arg in_0 wrong type'
+        cdef _MatchIteratorPair _r = self.inst.get().GetAllItems(meta)
+        cdef MatchIterator py_result = MatchIterator.__new__(MatchIterator)
+        py_result.it = _r.begin()
+        py_result.end = _r.end()
+        return self._key_iterator_wrapper(py_result)
+
+    def values(self, meta):
+        assert isinstance(meta, dict), 'arg in_1 wrong type'
+        cdef _MatchIteratorPair _r = self.inst.get().GetAllItems(meta)
+        cdef MatchIterator py_result = MatchIterator.__new__(MatchIterator)
+        py_result.it = _r.begin()
+        py_result.end = _r.end()
+        return self._value_iterator_wrapper(py_result)
+
+    def items(self, meta):
+        assert isinstance(meta, dict), 'arg in_1 wrong type'
+        cdef _MatchIteratorPair _r = self.inst.get().GetAllItems(meta)
+        cdef MatchIterator py_result = MatchIterator.__new__(MatchIterator)
+        py_result.it = _r.begin()
+        py_result.end = _r.end()
+        return self._item_iterator_wrapper(py_result)
+
+    def statistics(self):
+        cdef libcpp_string _r = self.inst.get().GetStatistics()
+        cdef bytes py_result = _r
+        py_result_unicode = _r.decode('utf-8')
+
+        return json.loads(py_result_unicode)

--- a/python/src/addons/SecondaryKeyDictionary.pyx
+++ b/python/src/addons/SecondaryKeyDictionary.pyx
@@ -1,20 +1,20 @@
 
 
-    def get (self, key, meta, default = None):
-        if isinstance(key, unicode):
-            key = key.encode('utf-8')
-        assert isinstance(key, bytes), 'arg in_0 wrong type'
+    def get (self, the_key, meta, default = None):
+        if isinstance(the_key, unicode):
+            the_key = the_key.encode('utf-8')
+        assert isinstance(the_key, bytes), 'arg in_0 wrong type'
         assert isinstance(meta, dict), 'arg in_1 wrong type'
 
         cdef libcpp_map[libcpp_utf8_string, libcpp_utf8_string] * v1 = new libcpp_map[libcpp_utf8_string, libcpp_utf8_string]()
-        for key, value in meta.items():
-            if isinstance(key, unicode):
-                key = key.encode('utf-8')
-            if isinstance(value, unicode):
-                value = value.encode('utf-8')
-            deref(v1)[ (<libcpp_string>key) ] = (<libcpp_string>value)
+        for _key, _value in meta.items():
+            if isinstance(_key, unicode):
+                _key = _key.encode('utf-8')
+            if isinstance(_value, unicode):
+                _value = _value.encode('utf-8')
+            deref(v1)[ (<libcpp_string>_key) ] = (<libcpp_string>_value)
 
-        cdef shared_ptr[_Match] _r = self.inst.get().GetFirst(<libcpp_string>key, deref(v1))
+        cdef shared_ptr[_Match] _r = self.inst.get().GetFirst(<libcpp_string>the_key, deref(v1))
         del(v1)
 
         if _r.get() == nullptr:
@@ -23,14 +23,14 @@
         py_result.inst = _r
         return py_result
 
-    def contains(self, key, meta):
-        if isinstance(key, unicode):
-            key = key.encode('utf-8')
+    def contains(self, the_key, meta):
+        if isinstance(the_key, unicode):
+            the_key = the_key.encode('utf-8')
 
-        assert isinstance(key, bytes), 'arg in_0 wrong type'
+        assert isinstance(the_key, bytes), 'arg in_0 wrong type'
         assert isinstance(meta, dict), 'arg in_1 wrong type'
 
-        return self.inst.get().Contains(key, meta)
+        return self.inst.get().Contains(the_key, meta)
 
     def __len__(self):
         return self.inst.get().GetSize()

--- a/python/src/addons/SecondaryKeyFloatDictionaryCompiler.pyx
+++ b/python/src/addons/SecondaryKeyFloatDictionaryCompiler.pyx
@@ -1,0 +1,20 @@
+
+
+    def __enter__(self):
+        return self
+
+
+    def __exit__(self, type, value, traceback):
+        self.Compile()
+
+
+    def Compile(self, *args):
+        if not args:
+            with nogil:
+                self.inst.get().Compile()
+            return
+
+        cdef void* callback = <void*> args[0]
+        with nogil:
+            self.inst.get().Compile(progress_compiler_callback, callback)
+

--- a/python/src/addons/SecondaryKeyFloatVectorDictionaryCompiler.pyx
+++ b/python/src/addons/SecondaryKeyFloatVectorDictionaryCompiler.pyx
@@ -8,7 +8,7 @@
         self.Compile()
 
 
-    def Compile(self, *args):
+    def compile(self, *args):
         if not args:
             with nogil:
                 self.inst.get().Compile()

--- a/python/src/addons/SecondaryKeyIntDictionaryCompiler.pyx
+++ b/python/src/addons/SecondaryKeyIntDictionaryCompiler.pyx
@@ -1,0 +1,20 @@
+
+
+    def __enter__(self):
+        return self
+
+
+    def __exit__(self, type, value, traceback):
+        self.Compile()
+
+
+    def Compile(self, *args):
+        if not args:
+            with nogil:
+                self.inst.get().Compile()
+            return
+
+        cdef void* callback = <void*> args[0]
+        with nogil:
+            self.inst.get().Compile(progress_compiler_callback, callback)
+

--- a/python/src/addons/SecondaryKeyIntDictionaryCompiler.pyx
+++ b/python/src/addons/SecondaryKeyIntDictionaryCompiler.pyx
@@ -8,7 +8,7 @@
         self.Compile()
 
 
-    def Compile(self, *args):
+    def compile(self, *args):
         if not args:
             with nogil:
                 self.inst.get().Compile()

--- a/python/src/addons/SecondaryKeyJsonDictionaryCompiler.pyx
+++ b/python/src/addons/SecondaryKeyJsonDictionaryCompiler.pyx
@@ -1,0 +1,20 @@
+
+
+    def __enter__(self):
+        return self
+
+
+    def __exit__(self, type, value, traceback):
+        self.Compile()
+
+
+    def Compile(self, *args):
+        if not args:
+            with nogil:
+                self.inst.get().Compile()
+            return
+
+        cdef void* callback = <void*> args[0]
+        with nogil:
+            self.inst.get().Compile(progress_compiler_callback, callback)
+

--- a/python/src/addons/SecondaryKeyJsonDictionaryCompiler.pyx
+++ b/python/src/addons/SecondaryKeyJsonDictionaryCompiler.pyx
@@ -8,7 +8,7 @@
         self.Compile()
 
 
-    def Compile(self, *args):
+    def compile(self, *args):
         if not args:
             with nogil:
                 self.inst.get().Compile()

--- a/python/src/addons/SecondaryKeyKeyOnlyDictionaryCompiler.pyx
+++ b/python/src/addons/SecondaryKeyKeyOnlyDictionaryCompiler.pyx
@@ -1,0 +1,20 @@
+
+
+    def __enter__(self):
+        return self
+
+
+    def __exit__(self, type, value, traceback):
+        self.Compile()
+
+
+    def Compile(self, *args):
+        if not args:
+            with nogil:
+                self.inst.get().Compile()
+            return
+
+        cdef void* callback = <void*> args[0]
+        with nogil:
+            self.inst.get().Compile(progress_compiler_callback, callback)
+

--- a/python/src/addons/SecondaryKeyKeyOnlyDictionaryCompiler.pyx
+++ b/python/src/addons/SecondaryKeyKeyOnlyDictionaryCompiler.pyx
@@ -8,7 +8,7 @@
         self.Compile()
 
 
-    def Compile(self, *args):
+    def compile(self, *args):
         if not args:
             with nogil:
                 self.inst.get().Compile()

--- a/python/src/addons/SecondaryKeyStringDictionaryCompiler.pyx
+++ b/python/src/addons/SecondaryKeyStringDictionaryCompiler.pyx
@@ -1,0 +1,20 @@
+
+
+    def __enter__(self):
+        return self
+
+
+    def __exit__(self, type, value, traceback):
+        self.Compile()
+
+
+    def Compile(self, *args):
+        if not args:
+            with nogil:
+                self.inst.get().Compile()
+            return
+
+        cdef void* callback = <void*> args[0]
+        with nogil:
+            self.inst.get().Compile(progress_compiler_callback, callback)
+

--- a/python/src/addons/SecondaryKeyStringDictionaryCompiler.pyx
+++ b/python/src/addons/SecondaryKeyStringDictionaryCompiler.pyx
@@ -8,7 +8,7 @@
         self.Compile()
 
 
-    def Compile(self, *args):
+    def compile(self, *args):
         if not args:
             with nogil:
                 self.inst.get().Compile()

--- a/python/src/pxds/dictionary_compiler.pxd
+++ b/python/src/pxds/dictionary_compiler.pxd
@@ -78,3 +78,56 @@ cdef extern from "keyvi/dictionary/dictionary_types.h" namespace "keyvi::diction
         void SetManifest(libcpp_utf8_string) except +
         void WriteToFile(libcpp_utf8_string) except +
 
+    cdef cppclass SecondaryKeyCompletionDictionaryCompiler:
+        SecondaryKeyCompletionDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys) except +
+        SecondaryKeyCompletionDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
+        void Add(libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, int value) except + # wrap-as:add
+        void Compile() nogil # wrap-ignore
+        void Compile(callback_t, void*) nogil # wrap-ignore
+        void SetManifest(libcpp_utf8_string) except + # wrap-as:set_manifest
+        void WriteToFile(libcpp_utf8_string) except + # wrap-as:write_to_file
+
+    cdef cppclass SecondaryKeyFloatVectorDictionaryCompiler:
+        SecondaryKeyFloatVectorDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys) except +
+        SecondaryKeyFloatVectorDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
+        void Add(libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, libcpp_vector[float] value) except + # wrap-as:add
+        void Compile() nogil # wrap-ignore
+        void Compile(callback_t, void*) nogil # wrap-ignore
+        void SetManifest(libcpp_utf8_string) except + # wrap-as:set_manifest
+        void WriteToFile(libcpp_utf8_string) except + # wrap-as:write_to_file
+
+    cdef cppclass SecondaryKeyIntDictionaryCompiler:
+        SecondaryKeyIntDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys) except +
+        SecondaryKeyIntDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
+        void Add(libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, long value) except + # wrap-as:add
+        void Compile() nogil # wrap-ignore
+        void Compile(callback_t, void*) nogil # wrap-ignore
+        void SetManifest(libcpp_utf8_string) except + # wrap-as:set_manifest
+        void WriteToFile(libcpp_utf8_string) except + # wrap-as:write_to_file
+
+    cdef cppclass SecondaryKeyKeyOnlyDictionaryCompiler:
+        SecondaryKeyKeyOnlyDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys) except +
+        SecondaryKeyKeyOnlyDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
+        void Add(libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) except + # wrap-as:add
+        void Compile() nogil # wrap-ignore
+        void Compile(callback_t, void*) nogil # wrap-ignore
+        void SetManifest(libcpp_utf8_string) except + # wrap-as:set_manifest
+        void WriteToFile(libcpp_utf8_string) except + # wrap-as:write_to_file
+
+    cdef cppclass SecondaryKeyJsonDictionaryCompiler:
+        SecondaryKeyJsonDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys) except +
+        SecondaryKeyJsonDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
+        void Add(libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, libcpp_utf8_string value) except + # wrap-as:add
+        void Compile() nogil # wrap-ignore
+        void Compile(callback_t, void*) nogil # wrap-ignore
+        void SetManifest(libcpp_utf8_string) except + # wrap-as:set_manifest
+        void WriteToFile(libcpp_utf8_string) except + # wrap-as:write_to_file
+
+    cdef cppclass SecondaryKeyStringDictionaryCompiler:
+        SecondaryKeyStringDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys) except +
+        SecondaryKeyStringDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
+        void Add(libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, libcpp_utf8_string value) except + # wrap-as:add
+        void Compile() nogil # wrap-ignore
+        void Compile(callback_t, void*) nogil # wrap-ignore
+        void SetManifest(libcpp_utf8_string) except + # wrap-as:set_manifest
+        void WriteToFile(libcpp_utf8_string) except + # wrap-as:write_to_file

--- a/python/src/pxds/dictionary_compiler.pxd
+++ b/python/src/pxds/dictionary_compiler.pxd
@@ -81,7 +81,7 @@ cdef extern from "keyvi/dictionary/dictionary_types.h" namespace "keyvi::diction
     cdef cppclass SecondaryKeyCompletionDictionaryCompiler:
         SecondaryKeyCompletionDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys) except +
         SecondaryKeyCompletionDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
-        void Add(libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, int value) except + # wrap-as:add
+        void Add(libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, int the_value) except + # wrap-as:add
         void Compile() nogil # wrap-ignore
         void Compile(callback_t, void*) nogil # wrap-ignore
         void SetManifest(libcpp_utf8_string) except + # wrap-as:set_manifest
@@ -90,7 +90,7 @@ cdef extern from "keyvi/dictionary/dictionary_types.h" namespace "keyvi::diction
     cdef cppclass SecondaryKeyFloatVectorDictionaryCompiler:
         SecondaryKeyFloatVectorDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys) except +
         SecondaryKeyFloatVectorDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
-        void Add(libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, libcpp_vector[float] value) except + # wrap-as:add
+        void Add(libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, libcpp_vector[float] the_value) except + # wrap-as:add
         void Compile() nogil # wrap-ignore
         void Compile(callback_t, void*) nogil # wrap-ignore
         void SetManifest(libcpp_utf8_string) except + # wrap-as:set_manifest
@@ -99,7 +99,7 @@ cdef extern from "keyvi/dictionary/dictionary_types.h" namespace "keyvi::diction
     cdef cppclass SecondaryKeyIntDictionaryCompiler:
         SecondaryKeyIntDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys) except +
         SecondaryKeyIntDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
-        void Add(libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, long value) except + # wrap-as:add
+        void Add(libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, long the_value) except + # wrap-as:add
         void Compile() nogil # wrap-ignore
         void Compile(callback_t, void*) nogil # wrap-ignore
         void SetManifest(libcpp_utf8_string) except + # wrap-as:set_manifest
@@ -108,7 +108,7 @@ cdef extern from "keyvi/dictionary/dictionary_types.h" namespace "keyvi::diction
     cdef cppclass SecondaryKeyKeyOnlyDictionaryCompiler:
         SecondaryKeyKeyOnlyDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys) except +
         SecondaryKeyKeyOnlyDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
-        void Add(libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) except + # wrap-as:add
+        void Add(libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) except + # wrap-as:add
         void Compile() nogil # wrap-ignore
         void Compile(callback_t, void*) nogil # wrap-ignore
         void SetManifest(libcpp_utf8_string) except + # wrap-as:set_manifest
@@ -117,7 +117,7 @@ cdef extern from "keyvi/dictionary/dictionary_types.h" namespace "keyvi::diction
     cdef cppclass SecondaryKeyJsonDictionaryCompiler:
         SecondaryKeyJsonDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys) except +
         SecondaryKeyJsonDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
-        void Add(libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, libcpp_utf8_string value) except + # wrap-as:add
+        void Add(libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, libcpp_utf8_string the_value) except + # wrap-as:add
         void Compile() nogil # wrap-ignore
         void Compile(callback_t, void*) nogil # wrap-ignore
         void SetManifest(libcpp_utf8_string) except + # wrap-as:set_manifest
@@ -126,7 +126,7 @@ cdef extern from "keyvi/dictionary/dictionary_types.h" namespace "keyvi::diction
     cdef cppclass SecondaryKeyStringDictionaryCompiler:
         SecondaryKeyStringDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys) except +
         SecondaryKeyStringDictionaryCompiler(libcpp_vector[libcpp_utf8_string] secondary_keys, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
-        void Add(libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, libcpp_utf8_string value) except + # wrap-as:add
+        void Add(libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, libcpp_utf8_string the_value) except + # wrap-as:add
         void Compile() nogil # wrap-ignore
         void Compile(callback_t, void*) nogil # wrap-ignore
         void SetManifest(libcpp_utf8_string) except + # wrap-as:set_manifest

--- a/python/src/pxds/secondary_key_dictionary.pxd
+++ b/python/src/pxds/secondary_key_dictionary.pxd
@@ -19,21 +19,21 @@ cdef extern from "keyvi/dictionary/secondary_key_dictionary.h" namespace "keyvi:
 
         SecondaryKeyDictionary (libcpp_utf8_string filename) except +
         #SecondaryKeyDictionary (libcpp_utf8_string filename, loading_strategy_types) except +
-        shared_ptr[_Match] GetFirst (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) # wrap-ignore
-        bool Contains (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) # wrap-ignore
-        _MatchIteratorPair Get (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) # wrap-as:match
-        _MatchIteratorPair GetNear (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, size_t minimum_prefix_length) except + # wrap-as:match_near
-        _MatchIteratorPair GetNear (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, size_t minimum_prefix_length, bool greedy) except + # wrap-as:match_near
-        _MatchIteratorPair GetFuzzy (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, int32_t max_edit_distance) except + # wrap-as:match_fuzzy
-        _MatchIteratorPair GetFuzzy (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, int32_t max_edit_distance, size_t minimum_exact_prefix) except + # wrap-as:match_fuzzy
-        _MatchIteratorPair GetPrefixCompletion (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) except + # wrap-as:complete_prefix
+        shared_ptr[_Match] GetFirst (libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) # wrap-ignore
+        bool Contains (libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) # wrap-ignore
+        _MatchIteratorPair Get (libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) # wrap-as:match
+        _MatchIteratorPair GetNear (libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, size_t minimum_prefix_length) except + # wrap-as:match_near
+        _MatchIteratorPair GetNear (libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, size_t minimum_prefix_length, bool greedy) except + # wrap-as:match_near
+        _MatchIteratorPair GetFuzzy (libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, int32_t max_edit_distance) except + # wrap-as:match_fuzzy
+        _MatchIteratorPair GetFuzzy (libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, int32_t max_edit_distance, size_t minimum_exact_prefix) except + # wrap-as:match_fuzzy
+        _MatchIteratorPair GetPrefixCompletion (libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) except + # wrap-as:complete_prefix
         # wrap-doc:
         #  Complete the given key to full matches(prefix matching)
         #  In case the used dictionary supports inner weights, the
         #  completer traverses the dictionary according to weights,
         #  otherwise byte-order.
 
-        _MatchIteratorPair GetPrefixCompletion (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, size_t top_n) except + # wrap-as:complete_prefix
+        _MatchIteratorPair GetPrefixCompletion (libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, size_t top_n) except + # wrap-as:complete_prefix
         # wrap-doc:
         #  Complete the given key to full matches(prefix matching)
         #  and return the top n completions.
@@ -47,14 +47,14 @@ cdef extern from "keyvi/dictionary/secondary_key_dictionary.h" namespace "keyvi:
         #  and truncate the lists of results.
         #  Only the number of top completions is guaranteed.
 
-        _MatchIteratorPair GetMultiwordCompletion (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) except + # wrap-as:complete_multiword
+        _MatchIteratorPair GetMultiwordCompletion (libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) except + # wrap-as:complete_multiword
         # wrap-doc:
         #  Complete the given key to full matches after whitespace tokenizing.
         #  In case the used dictionary supports inner weights, the
         #  completer traverses the dictionary according to weights,
         #  otherwise byte-order.
 
-        _MatchIteratorPair GetMultiwordCompletion (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, size_t top_n) except + # wrap-as:complete_multiword
+        _MatchIteratorPair GetMultiwordCompletion (libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, size_t top_n) except + # wrap-as:complete_multiword
         # wrap-doc:
         #  Complete the given key to full matches after whitespace tokenizing
         #  and return the top n completions.
@@ -68,7 +68,7 @@ cdef extern from "keyvi/dictionary/secondary_key_dictionary.h" namespace "keyvi:
         #  and truncate the lists of results.
         #  Only the number of top completions is guaranteed.
 
-        _MatchIteratorPair GetFuzzyMultiwordCompletion (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, int32_t max_edit_distance) except + # wrap-as:complete_fuzzy_multiword
+        _MatchIteratorPair GetFuzzyMultiwordCompletion (libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, int32_t max_edit_distance) except + # wrap-as:complete_fuzzy_multiword
         # wrap-doc:
         #  Complete the given key to full matches after whitespace tokenizing,
         #  allowing up to max_edit_distance distance(Levenshtein).
@@ -76,7 +76,7 @@ cdef extern from "keyvi/dictionary/secondary_key_dictionary.h" namespace "keyvi:
         #  completer traverses the dictionary according to weights,
         #  otherwise byte-order.
 
-        _MatchIteratorPair GetFuzzyMultiwordCompletion (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, int32_t max_edit_distance, size_t minimum_exact_prefix) except + # wrap-as:complete_fuzzy_multiword
+        _MatchIteratorPair GetFuzzyMultiwordCompletion (libcpp_utf8_string the_key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, int32_t max_edit_distance, size_t minimum_exact_prefix) except + # wrap-as:complete_fuzzy_multiword
         # wrap-doc:
         #  Complete the given key to full matches after whitespace tokenizing,
         #  allowing up to max_edit_distance distance(Levenshtein) except for

--- a/python/src/pxds/secondary_key_dictionary.pxd
+++ b/python/src/pxds/secondary_key_dictionary.pxd
@@ -1,0 +1,91 @@
+from libcpp.string cimport string as libcpp_string
+from libcpp.string cimport string as libcpp_utf8_string
+from libcpp.string cimport string as libcpp_utf8_output_string
+from libcpp.map cimport map as libcpp_map
+from libc.stdint cimport int32_t
+from libc.stdint cimport uint32_t
+from libc.stdint cimport uint64_t
+from libcpp cimport bool
+from libcpp.pair cimport pair as libcpp_pair
+from match cimport Match as _Match
+from match_iterator cimport MatchIteratorPair as _MatchIteratorPair
+from libcpp.memory cimport shared_ptr
+
+cdef extern from "keyvi/dictionary/secondary_key_dictionary.h" namespace "keyvi::dictionary":
+    cdef cppclass SecondaryKeyDictionary:
+        # wrap-doc:
+        #  Secondary Key dictionary, specialized dictionary type that takes additional key value pairs
+        #  that are matched exact upfront, enabling use cases like multi-tenancy and personalization.
+
+        SecondaryKeyDictionary (libcpp_utf8_string filename) except +
+        #SecondaryKeyDictionary (libcpp_utf8_string filename, loading_strategy_types) except +
+        shared_ptr[_Match] GetFirst (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) # wrap-ignore
+        bool Contains (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) # wrap-ignore
+        _MatchIteratorPair Get (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) # wrap-as:match
+        _MatchIteratorPair GetNear (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, size_t minimum_prefix_length) except + # wrap-as:match_near
+        _MatchIteratorPair GetNear (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, size_t minimum_prefix_length, bool greedy) except + # wrap-as:match_near
+        _MatchIteratorPair GetFuzzy (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, int32_t max_edit_distance) except + # wrap-as:match_fuzzy
+        _MatchIteratorPair GetFuzzy (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, int32_t max_edit_distance, size_t minimum_exact_prefix) except + # wrap-as:match_fuzzy
+        _MatchIteratorPair GetPrefixCompletion (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) except + # wrap-as:complete_prefix
+        # wrap-doc:
+        #  Complete the given key to full matches(prefix matching)
+        #  In case the used dictionary supports inner weights, the
+        #  completer traverses the dictionary according to weights,
+        #  otherwise byte-order.
+
+        _MatchIteratorPair GetPrefixCompletion (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, size_t top_n) except + # wrap-as:complete_prefix
+        # wrap-doc:
+        #  Complete the given key to full matches(prefix matching)
+        #  and return the top n completions.
+        #  In case the used dictionary supports inner weights, the
+        #  completer traverses the dictionary according to weights,
+        #  otherwise byte-order.
+        #  
+        #  Note, due to depth-first traversal the traverser
+        #  immediately yields results when it visits them. The results are
+        #  neither in order nor limited to n. It is up to the caller to resort
+        #  and truncate the lists of results.
+        #  Only the number of top completions is guaranteed.
+
+        _MatchIteratorPair GetMultiwordCompletion (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) except + # wrap-as:complete_multiword
+        # wrap-doc:
+        #  Complete the given key to full matches after whitespace tokenizing.
+        #  In case the used dictionary supports inner weights, the
+        #  completer traverses the dictionary according to weights,
+        #  otherwise byte-order.
+
+        _MatchIteratorPair GetMultiwordCompletion (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, size_t top_n) except + # wrap-as:complete_multiword
+        # wrap-doc:
+        #  Complete the given key to full matches after whitespace tokenizing
+        #  and return the top n completions.
+        #  In case the used dictionary supports inner weights, the
+        #  completer traverses the dictionary according to weights,
+        #  otherwise byte-order.
+        #  
+        #  Note, due to depth-first traversal the traverser
+        #  immediately yields results when it visits them. The results are
+        #  neither in order nor limited to n. It is up to the caller to resort
+        #  and truncate the lists of results.
+        #  Only the number of top completions is guaranteed.
+
+        _MatchIteratorPair GetFuzzyMultiwordCompletion (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, int32_t max_edit_distance) except + # wrap-as:complete_fuzzy_multiword
+        # wrap-doc:
+        #  Complete the given key to full matches after whitespace tokenizing,
+        #  allowing up to max_edit_distance distance(Levenshtein).
+        #  In case the used dictionary supports inner weights, the
+        #  completer traverses the dictionary according to weights,
+        #  otherwise byte-order.
+
+        _MatchIteratorPair GetFuzzyMultiwordCompletion (libcpp_utf8_string key, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta, int32_t max_edit_distance, size_t minimum_exact_prefix) except + # wrap-as:complete_fuzzy_multiword
+        # wrap-doc:
+        #  Complete the given key to full matches after whitespace tokenizing,
+        #  allowing up to max_edit_distance distance(Levenshtein) except for
+        #  a given exaxt prefix which must match exaxt.
+        #  In case the used dictionary supports inner weights, the
+        #  completer traverses the dictionary according to weights,
+        #  otherwise byte-order.
+
+        _MatchIteratorPair GetAllItems (libcpp_map[libcpp_utf8_string, libcpp_utf8_string] meta) # wrap-ignore
+        libcpp_utf8_output_string GetManifest() except + # wrap-as:manifest
+        libcpp_string GetStatistics() # wrap-ignore
+        uint64_t GetSize() # wrap-ignore

--- a/python/src/py/keyvi/compiler/__init__.py
+++ b/python/src/py/keyvi/compiler/__init__.py
@@ -24,4 +24,4 @@ from keyvi._core import KeyOnlyDictionaryCompiler, KeyOnlyDictionaryGenerator, K
 from keyvi._core import StringDictionaryCompiler, StringDictionaryMerger
 from keyvi._core import FloatVectorDictionaryCompiler
 from keyvi._core import SecondaryKeyCompletionDictionaryCompiler, SecondaryKeyFloatVectorDictionaryCompiler, SecondaryKeyIntDictionaryCompiler
-from keyvi._core import SecondaryKeyKeyOnlyDictionaryCompiler, SecondaryKeyStringDictionaryCompiler
+from keyvi._core import SecondaryKeyKeyOnlyDictionaryCompiler, SecondaryKeyStringDictionaryCompiler, SecondaryKeyJsonDictionaryCompiler

--- a/python/src/py/keyvi/compiler/__init__.py
+++ b/python/src/py/keyvi/compiler/__init__.py
@@ -23,3 +23,5 @@ from keyvi._core import IntDictionaryCompilerSmallData
 from keyvi._core import KeyOnlyDictionaryCompiler, KeyOnlyDictionaryGenerator, KeyOnlyDictionaryMerger
 from keyvi._core import StringDictionaryCompiler, StringDictionaryMerger
 from keyvi._core import FloatVectorDictionaryCompiler
+from keyvi._core import SecondaryKeyCompletionDictionaryCompiler, SecondaryKeyFloatVectorDictionaryCompiler, SecondaryKeyIntDictionaryCompiler
+from keyvi._core import SecondaryKeyKeyOnlyDictionaryCompiler, SecondaryKeyStringDictionaryCompiler

--- a/python/src/py/keyvi/dictionary/__init__.py
+++ b/python/src/py/keyvi/dictionary/__init__.py
@@ -17,4 +17,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 
-from keyvi._core import Dictionary
+from keyvi._core import Dictionary, SecondaryKeyDictionary

--- a/python/tests/dictionary/secondary_key/secondary_key_dictionary_test.py
+++ b/python/tests/dictionary/secondary_key/secondary_key_dictionary_test.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# Usage: py.test tests
+
+import contextlib
+import os
+import tempfile
+from keyvi.dictionary import SecondaryKeyDictionary
+from keyvi.compiler import SecondaryKeyCompletionDictionaryCompiler, SecondaryKeyJsonDictionaryCompiler
+
+
+@contextlib.contextmanager
+def tmp_secondary_key_dictionary(compiler, file_name):
+    tmp_dir = tempfile.gettempdir()
+    fq_file_name = os.path.join(tmp_dir, file_name)
+    compiler.compile()
+    compiler.write_to_file(fq_file_name)
+    del compiler
+    d = SecondaryKeyDictionary(fq_file_name)
+    yield d
+    del d
+    os.remove(fq_file_name)
+
+def test_completion():
+    c=SecondaryKeyCompletionDictionaryCompiler(["user_id"], {"memory_limit_mb": "10"})
+
+    c.add("my_completion", {"user_id": "1"}, 10)
+    c.add("my_completion", {"user_id": "2"}, 20)
+    c.add("my_completion", {"user_id": "3"}, 30)
+    c.add("my_completion", {"user_id": "4"}, 40)
+
+    c.add("my_other_completion", {"user_id": "1"}, 100)
+    c.add("my_other_completion", {"user_id": "3"}, 200)
+    with tmp_secondary_key_dictionary(c, 'secondary_key_completion.kv') as d:
+        assert len(d) == 6
+        assert [m.value for m in d.complete_prefix("my", {"user_id": "3"})] == [200, 30]
+        assert [m.value for m in d.complete_prefix("my", {"user_id": "2"})] == [20]
+
+        # ensure no accidental prefix hit
+        for i in range(0, 255):
+            assert [m.value for m in d.complete_prefix(chr(i), {"user_id": ""})] == []
+
+
+def test_json():
+    c=SecondaryKeyJsonDictionaryCompiler(["user_id"], {"memory_limit_mb": "10"})
+
+    c.add("my_key", {"user_id": "1"}, '{"a" : 2}')
+    c.add("my_key", {"user_id": "2"}, '{"a" : 3}')
+    c.add("my_key", {"user_id": "3"}, '{"a" : 4}')
+    c.add("my_key", {"user_id": "4"}, '{"a" : 5}')
+    c.add("my_key", {"user_id": ""}, '{"a" : 6}')
+    c.add("my_other_key", {"user_id": "1"}, '{"a" : 15}')
+    c.add("my_other_key", {"user_id": "3"}, '{"a" : 16}')
+
+    with tmp_secondary_key_dictionary(c, 'secondary_key_json.kv') as d:
+        assert len(d) == 7
+
+        assert d.get("my_key", {"user_id": "1"}).value == {'a': 2}
+        assert d.get("my_key", {"user_id": "2"}).value == {'a': 3}
+        assert d.get("my_key", {"user_id": "3"}).value == {'a': 4}
+        assert d.get("my_key", {"user_id": ""}).value == {'a': 6}
+        assert d.get("my_other_key", {"user_id": "1"}).value == {'a': 15}
+        assert d.get("my_other_key", {"user_id": "2"}) == None
+        assert [m for m in d.complete_prefix("user", {"user_id": "3"})] == []


### PR DESCRIPTION
Secondary key dictionaries match a set of key before the real matching. Those secondary keys can be arbitrary strings, e.g. a user, account or a tenant id.

At compile time, a list of secondary keys must be provided at construction, e.g. `["region", "account_id", "user_id"]`. The order defines matching order. For every entry as well as for every match operation an unordered map of keys and values must be provided :

```
{
    "account_id": "xyz", 
    "region": "eu-west",
    "user_id": "abcd"
}
```

Example use:

`dictionary.complete("sie", {"account_id": "xyz", "region": "eu-west", "user_id": "abcd" })`

With other words: APIs are equal to ordinary dictionaries with the extension of a map with secondary keys next to the primary key.

## Implementation details

Before doing the real matching, the root state is altered according to the additional secondary key(s) by matching a prefix. Given the "moved" start state, re-use the existing match functionality from `Dictionary`. This is implemented by wrapping an ordinary dictionary (most code changes are just refactorings to provide the altered start state). 
 
The `SecondaryKeyDictionaryCompiler` is similar, it wraps the existing `DictionaryCompiler`. In addition it:

- alters the lookup key by prefixing the secondary keys
- the list of secondary keys are stored as property
- The secondary key values are stored as dictionary which gets concatenated to the normal dictionary

To efficiently store secondary key values, values get replaced by a short representation. This helps e.g. for cases where secondary key values are long, e.g. UUIDs. Equally to the primary dictionary the replacement dict uses memory mapping.

### Python bindings

Unfortunately the python bindings required a lot of boiler plate code. In theory it could be auto-generated, however I wonder how much effort we should put into the autowrap generated code. I am playing with the idea to migrate to pybind11.
