### PR TITLE
Adapt build to new cibuildwheel and other upstream changes

### DIFF
--- a/.github/workflows/python-cibuildwheel.yml
+++ b/.github/workflows/python-cibuildwheel.yml
@@ -94,6 +94,7 @@ jobs:
         # Note: when brew reinstall finds unsolved deps, it downloads and installs using the wrong arch(x86_64 instead of arm64)
         run: |
           set -e
+          echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV
           echo "_CMAKE_PREFIX_PATH=${{ github.workspace }}/arm64-homebrew" >> $GITHUB_ENV
           echo "CIBW_REPAIR_WHEEL_COMMAND_MACOS=DYLD_LIBRARY_PATH=${{ github.workspace }}/arm64-homebrew delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}" >> $GITHUB_ENV
           mkdir arm64-homebrew && curl -L https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C arm64-homebrew
@@ -113,7 +114,7 @@ jobs:
         env:
           # Skip CPython 3.6 and CPython 3.7
           # skip pypy 3.8, https://github.com/pypa/distutils/issues/283
-          CIBW_SKIP: ${{ env.CIBW_SKIP }} cp36-* cp37-* pp38*
+          CIBW_SKIP: ${{ env.CIBW_SKIP }} cp36-* cp37-* pp38* pp39*
 
           # skip testing all python versions on linux arm, only test 3.12
           # skip tests on pypy, currently fails for indexer tests

--- a/.github/workflows/python-cibuildwheel.yml
+++ b/.github/workflows/python-cibuildwheel.yml
@@ -17,18 +17,20 @@ jobs:
         os: [ubuntu-22.04, macos-13]
         # separate archs, so they use individual caches
         arch: [ 'x86_64', 'arm64' ]
-        flavor: ['cpython', 'pypy']
+        # skip pypy, https://github.com/pypa/distutils/issues/283
+        flavor: ['cpython']
         # separate musl and many on linux, for mac we just skip one of those
         target: [ 'many', 'musl' ]
         exclude:
           - os: macos-13
             target: musl
-          - os: ubuntu-22.04
-            target: musl
-            flavor: pypy
-          - os: macos-13
-            arch: arm64
-            flavor: pypy
+          # skip pypy, https://github.com/pypa/distutils/issues/283
+          #- os: ubuntu-22.04
+          #  target: musl
+          #  flavor: pypy
+          #- os: macos-13
+          #  arch: arm64
+          #  flavor: pypy
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -113,8 +115,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.21.3
         env:
           # Skip CPython 3.6 and CPython 3.7
-          # skip pypy 3.8, https://github.com/pypa/distutils/issues/283
-          CIBW_SKIP: ${{ env.CIBW_SKIP }} cp36-* cp37-* pp38* pp39*
+          CIBW_SKIP: ${{ env.CIBW_SKIP }} cp36-* cp37-*
 
           # skip testing all python versions on linux arm, only test 3.12
           # skip tests on pypy, currently fails for indexer tests

--- a/.github/workflows/python-cibuildwheel.yml
+++ b/.github/workflows/python-cibuildwheel.yml
@@ -109,7 +109,7 @@ jobs:
           ls /Users/runner/work/keyvi/keyvi/arm64-homebrew
 
       - name: Build python wheels for ${{ matrix.os }} on ${{ matrix.arch }}
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v2.21.3
         env:
           # Skip CPython 3.6 and CPython 3.7
           # skip pypy 3.8, https://github.com/pypa/distutils/issues/283

--- a/.github/workflows/python-cibuildwheel.yml
+++ b/.github/workflows/python-cibuildwheel.yml
@@ -84,6 +84,7 @@ jobs:
       - name: install mac dependencies X86_64
         if: ${{ (runner.os == 'macOS') && (matrix.arch == 'x86_64') }}
         run: |
+          echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV && \
           brew update && \
           brew install zlib snappy boost
 
@@ -93,7 +94,6 @@ jobs:
         # Note: when brew reinstall finds unsolved deps, it downloads and installs using the wrong arch(x86_64 instead of arm64)
         run: |
           set -e
-          echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV
           echo "_CMAKE_PREFIX_PATH=${{ github.workspace }}/arm64-homebrew" >> $GITHUB_ENV
           echo "CIBW_REPAIR_WHEEL_COMMAND_MACOS=DYLD_LIBRARY_PATH=${{ github.workspace }}/arm64-homebrew delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}" >> $GITHUB_ENV
           mkdir arm64-homebrew && curl -L https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C arm64-homebrew

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["autowrap>=0.16.0", "msgpack>=1.0.0", "pytest>=7.1.1", "cython>=3.0", "setuptools>=61.0"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["autowrap>=0.16.0", "msgpack>=1.0.0", "pytest>=7.1.1", "cython>=3.0", "setuptools>=61.0"]
+requires = ["autowrap>=0.16.0", "msgpack>=1.0.0", "pytest>=7.1.1", "cython>=3.0"]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,4 +2,3 @@ autowrap>=0.16.0
 msgpack>=1.0.0
 pytest>=7.1.1
 cython>=3.0
-setuptools<72.2.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,3 +2,4 @@ autowrap>=0.16.0
 msgpack>=1.0.0
 pytest>=7.1.1
 cython>=3.0
+setuptools<72.2.0

--- a/python/setup.py
+++ b/python/setup.py
@@ -327,18 +327,6 @@ with symlink_keyvi() as (pykeyvi_source_path, keyvi_source_path):
             clean_pykeyvi_build_directory()
             _clean.clean.run(self)
 
-    have_wheel = False
-    try:
-        import wheel.bdist_wheel as _bdist_wheel
-
-        class bdist_wheel(custom_opts, _bdist_wheel.bdist_wheel):
-            parent = _bdist_wheel.bdist_wheel
-            user_options = _bdist_wheel.bdist_wheel.user_options + custom_user_options
-
-        have_wheel = True
-    except:
-        None
-
     class build_cxx(_build_ext.build_ext):
         description = "customized for keyvi: " + _build_ext.build_ext.description
 
@@ -388,8 +376,7 @@ with symlink_keyvi() as (pykeyvi_source_path, keyvi_source_path):
         "bdist": bdist,
         "clean": clean,
     }
-    if have_wheel:
-        commands["bdist_wheel"] = bdist_wheel
+
     for e in ext_modules:
         e.cython_directives = {"embedsignature": True}
 


### PR DESCRIPTION
Fixes builds using the latest cibuildwheel. Due to incompatible changes introduced upstream pypy(https://github.com/pypa/distutils/issues/283) had to be taken out for now.

In the long run we should switch away from setuptools, so these changes are just considered temporary until #310 is ready.

