### PR TITLE
fix build issue for rust binding on ubuntu 24.04

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,3 +41,4 @@ jobs:
       - run: cargo update --verbose --manifest-path rust/Cargo.toml
       - run: cargo build --verbose --manifest-path rust/Cargo.toml
       - run: cargo test --verbose --manifest-path rust/Cargo.toml
+

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,8 +11,12 @@ env:
 
 jobs:
   build:
-
-    runs-on: ubuntu-22.04
+    runs-on: ${{matrix.os}}
+    name:  ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-22.04', 'ubuntu-24.04']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,13 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: ${{matrix.os}}
-    name:  ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ['ubuntu-22.04', 'ubuntu-24.04']
-
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Install system packages
@@ -30,3 +24,20 @@ jobs:
       run: cargo build --verbose --manifest-path rust/Cargo.toml
     - name: Run tests
       run: cargo test --verbose --manifest-path rust/Cargo.toml
+
+  build_latest_deps:
+    name: Latest Dependencies
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: allow
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsnappy-dev libzzip-dev zlib1g-dev libboost-all-dev
+      - run: rustup update stable && rustup default stable
+      - run: cargo update --verbose --manifest-path rust/Cargo.toml
+      - run: cargo build --verbose --manifest-path rust/Cargo.toml
+      - run: cargo test --verbose --manifest-path rust/Cargo.toml

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["data-structures", "algorithms", "external-ffi-bindings", "memory-
 keywords = ["big-data", "keyvaluestore", "fst", "search"]
 
 [build-dependencies]
-bindgen = ">=0.58"
+bindgen = ">=0.69.5"
 cmake = ">=0.1"
 
 [dependencies]


### PR DESCRIPTION
up bindings to `>= 0.69.5` to prevent creating empty bindings on ubuntu 24.04. In addition add a workflow that checks compatibility for the news versions of rust dependencies
