### PR TITLE
remove git submodule from utfcpp dependency

### DIFF
--- a/keyvi/3rdparty/utfcpp/.gitmodules
+++ b/keyvi/3rdparty/utfcpp/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "extern/ftest"]
-	path = extern/ftest
-	url = https://github.com/nemtrif/ftest


### PR DESCRIPTION
remove `.gitmodule` from utfcpp 3rdparty dependency. This allows building keyvi from git in a rust project.