### PR TITLE
Migrate to boost process v2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,11 +14,11 @@ on:
 
 jobs:
   build:
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-24.04'
     name:  'github pages'
     env:
       BUILD_TYPE:  'Release'
-      PYTHON_VERSION: '3.9'
+      PYTHON_VERSION: '3.12'
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/keyvi.yml
+++ b/.github/workflows/keyvi.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         type: ['Release', 'Debug']
-        os: ['macos-latest', 'ubuntu-22.04']
+        os: ['macos-latest', 'ubuntu-24.04']
     steps:
       - name: install Linux deps
         if: runner.os == 'Linux'
@@ -55,4 +55,4 @@ jobs:
       - name: Unit tests
         id: unit_tests
         run: |
-         build/unit_test_all
+         build/unit_test_all -l unit_scope

--- a/keyvi/include/keyvi/dictionary/match.h
+++ b/keyvi/include/keyvi/dictionary/match.h
@@ -59,7 +59,7 @@ namespace dictionary {
 #ifdef Py_PYTHON_H
 class attributes_visitor : public boost::static_visitor<PyObject*> {
  public:
-  PyObject* operator()(int i) const { return PyInt_FromLong(i); }
+  PyObject* operator()(int i) const { return PyLong_FromLong(i); }
 
   PyObject* operator()(double i) const { return PyFloat_FromDouble(i); }
 

--- a/keyvi/tests/keyvi/index/index_limits_test.cpp
+++ b/keyvi/tests/keyvi/index/index_limits_test.cpp
@@ -28,6 +28,8 @@
 #else
 #include <sys/resource.h>
 
+#include <string>
+
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -63,7 +65,7 @@ BOOST_AUTO_TEST_CASE(filedescriptor_limit) {
   using boost::filesystem::temp_directory_path;
   using boost::filesystem::unique_path;
 
-  size_t old_limit = limit_filedescriptors(20);
+  size_t old_limit = limit_filedescriptors(40);
 
   auto tmp_path = temp_directory_path();
   tmp_path /= unique_path("index-limits-test-temp-index-%%%%-%%%%-%%%%-%%%%");
@@ -85,7 +87,7 @@ BOOST_AUTO_TEST_CASE(filedescriptor_limit) {
   boost::filesystem::remove_all(tmp_path);
 
   size_t increased_file_descriptors = keyvi::util::OsUtils::TryIncreaseFileDescriptors();
-  BOOST_CHECK(increased_file_descriptors > 20);
+  BOOST_CHECK(increased_file_descriptors > 40);
 
   limit_filedescriptors(old_limit);
 }

--- a/keyvi/tests/keyvi/index/internal/merge_job_test.cpp
+++ b/keyvi/tests/keyvi/index/internal/merge_job_test.cpp
@@ -51,6 +51,8 @@ namespace internal {
 BOOST_AUTO_TEST_SUITE(MergeJobTests)
 
 BOOST_AUTO_TEST_CASE(basic_merge) {
+  boost::asio::io_context external_process_ctx;
+
   std::vector<std::pair<std::string, std::string>> test_data = {
       {"abc", "{a:1}"}, {"abbc", "{b:2}"}, {"abbcd", "{c:3}"}, {"abcde", "{a:1}"}, {"abdd", "{b:2}"}, {"bba", "{c:3}"},
   };
@@ -70,7 +72,7 @@ BOOST_AUTO_TEST_CASE(basic_merge) {
   boost::filesystem::path p("merged.kv");
   IndexSettings settings({{KEYVIMERGER_BIN, get_keyvimerger_bin()}});
   MergeJob m({w1, w2}, 0, p, settings);
-  m.Run();
+  m.Run(&external_process_ctx);
 
   int retry = 100;
   while (retry > 0) {

--- a/keyvi/tests/keyvi/index/internal/merge_job_test.cpp
+++ b/keyvi/tests/keyvi/index/internal/merge_job_test.cpp
@@ -24,7 +24,9 @@
  */
 
 #include <chrono>  // NOLINT
+#include <string>
 #include <thread>  // NOLINT
+#include <vector>
 
 #include <boost/test/unit_test.hpp>
 

--- a/python/src/addons/JsonVector.pyx
+++ b/python/src/addons/JsonVector.pyx
@@ -1,7 +1,7 @@
 
 
     def __getitem__(self,  index ):
-        assert isinstance(index, (int, long)), 'arg index wrong type'
+        assert isinstance(index, (int, int)), 'arg index wrong type'
 
         cdef libcpp_utf8_string _r = self.inst.get().Get((<size_t>index))
         py_result = json.loads(_r.decode('utf-8'))


### PR DESCRIPTION
Migrate to boost process v2, fixes compile problems on newer versions of boost.

In addition:

- fix autowrap API breakage
- fix doc build
- fix concurrency issue in keyvi index which appeared after boost process update on Mac
