### PR TITLE
update musl base image to 1_2

### DIFF
--- a/.github/workflows/python-dockerimages-cibuildwheel.yml
+++ b/.github/workflows/python-dockerimages-cibuildwheel.yml
@@ -45,7 +45,7 @@ jobs:
         if: matrix.base_image == 'many'
       - name: Sets env for musllinux
         run: |
-          echo "BASE_IMAGE=quay.io/pypa/musllinux_1_1_${{ env.ARCH }}" >> $GITHUB_ENV
+          echo "BASE_IMAGE=quay.io/pypa/musllinux_1_2_${{ env.ARCH }}" >> $GITHUB_ENV
         if: matrix.base_image == 'musl'
       - name: Build and push ${{ matrix.base_image }}-${{ env.ARCH }} docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
musllinux_1_1 is EOL since 11/2024, cibuildwheel dropped support. Therefore upgrading to 1_2