### PR TITLE
Switch to pypi trusted workflow publishing, cleanup build workflows

### DIFF
--- a/.github/workflows/keyvi.yml
+++ b/.github/workflows/keyvi.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.18
         with:
           key: ${{ matrix.os }}-${{ matrix.type }}
 

--- a/.github/workflows/python-cibuildwheel.yml
+++ b/.github/workflows/python-cibuildwheel.yml
@@ -25,16 +25,13 @@ jobs:
         exclude:
           - os: macos-13
             target: musl
-          # skip pypy, https://github.com/pypa/distutils/issues/283
-          #- os: ubuntu-22.04
-          #  target: musl
-          #  flavor: pypy
-          #- os: macos-13
-          #  flavor: pypy
+          - os: macos-14
+            target: musl
+
     steps:
       - uses: actions/checkout@v5
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2.18
         with:
           key: ${{ matrix.os }}-${{ matrix.target }}-${{ matrix.flavor }}-python
 
@@ -79,8 +76,7 @@ jobs:
       - name: Build python wheels for ${{ matrix.os }}
         uses: pypa/cibuildwheel@v3.1.4
         env:
-          # Skip CPython 3.{6, 7, 8}
-          CIBW_SKIP: ${{ env.CIBW_SKIP }} cp36-* cp37-* cp38-*
+          CIBW_SKIP: ${{ env.CIBW_SKIP }}
 
           # only build native packages
           CIBW_ARCHS: native
@@ -127,7 +123,7 @@ jobs:
         sudo apt-get update && \
         sudo apt-get install -y libsnappy-dev libzzip-dev zlib1g-dev libboost-all-dev ccache
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2.11
+      uses: hendrikmuhs/ccache-action@v1.2.18
       with:
         key: ubuntu-sdist-python
 
@@ -152,6 +148,11 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/keyvi
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v5
         with:
@@ -160,5 +161,3 @@ jobs:
           path: dist
   
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/python-cibuildwheel.yml
+++ b/.github/workflows/python-cibuildwheel.yml
@@ -76,7 +76,8 @@ jobs:
       - name: Build python wheels for ${{ matrix.os }}
         uses: pypa/cibuildwheel@v3.1.4
         env:
-          CIBW_SKIP: ${{ env.CIBW_SKIP }}
+          # Skip CPython 3.8
+          CIBW_SKIP: ${{ env.CIBW_SKIP }} cp38-*
 
           # only build native packages
           CIBW_ARCHS: native

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["autowrap>=0.16.0", "msgpack>=1.0.0", "pytest>=7.1.1", "cython>=3.0"]
+requires = ["autowrap>=0.23.0", "msgpack>=1.0.0", "pytest>=7.1.1", "cython>=3.0"]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-autowrap>=0.16.0
+autowrap>=0.23.0
 msgpack>=1.0.0
 pytest>=7.1.1
 cython>=3.0


### PR DESCRIPTION
switch to trusted publishing, skip unnecessary double build on mac, cleanup and bump versions
