### PR TITLE
cleanup state traverser from unnecessary member

### DIFF
--- a/keyvi/include/keyvi/dictionary/dictionary.h
+++ b/keyvi/include/keyvi/dictionary/dictionary.h
@@ -324,7 +324,7 @@ class Dictionary final {
       TRACE("GetAllKeys callback called");
 
       for (;;) {
-        if (!data->traverser.AtEnd()) {
+        if (data->traverser) {
           data->traversal_stack.resize(data->traverser.GetDepth() - 1);
           data->traversal_stack.push_back(data->traverser.GetStateLabel());
           TRACE("Current depth %d (%d)", data->traverser.GetDepth() - 1, data->traversal_stack.size());

--- a/keyvi/include/keyvi/dictionary/fsa/comparable_state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/comparable_state_traverser.h
@@ -135,8 +135,6 @@ class ComparableStateTraverser final {
 
   operator bool() const { return state_traverser_; }
 
-  bool AtEnd() const { return state_traverser_.AtEnd(); }
-
   void operator++(int) {
     state_traverser_++;
     if (state_traverser_) {

--- a/keyvi/include/keyvi/dictionary/fsa/state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/state_traverser.h
@@ -168,8 +168,6 @@ class StateTraverser final {
    */
   inline void SetMinWeight(uint32_t min_weight) {}
 
-  bool AtEnd() const { return at_end_; }
-
  private:
   automata_t fsa_;
   uint64_t current_state_;

--- a/keyvi/include/keyvi/dictionary/fsa/state_traverser.h
+++ b/keyvi/include/keyvi/dictionary/fsa/state_traverser.h
@@ -48,7 +48,7 @@ class StateTraverser final {
   using transition_t = TransitionT;
 
   explicit StateTraverser(automata_t f)
-      : fsa_(f), current_state_(f->GetStartState()), current_weight_(0), current_label_(0), at_end_(false), stack_() {
+      : fsa_(f), current_state_(f->GetStartState()), current_weight_(0), current_label_(0), stack_() {
     TRACE("StateTraverser starting with Start state %d", current_state_);
     f->GetOutGoingTransitions(current_state_, &stack_.GetStates(), &stack_.traversal_stack_payload, 0);
 
@@ -57,7 +57,7 @@ class StateTraverser final {
 
   StateTraverser(automata_t f, const uint64_t start_state, traversal::TraversalPayload<TransitionT> &&payload,
                  const bool advance = true)
-      : fsa_(f), current_weight_(0), current_label_(0), at_end_(false), stack_(std::move(payload)) {
+      : fsa_(f), current_weight_(0), current_label_(0), stack_(std::move(payload)) {
     current_state_ = start_state;
 
     TRACE("StateTraverser starting with Start state %d", current_state_);
@@ -70,7 +70,7 @@ class StateTraverser final {
   }
 
   StateTraverser(automata_t f, const uint64_t start_state, const bool advance = true)
-      : fsa_(f), current_state_(start_state), current_weight_(0), current_label_(0), at_end_(false), stack_() {
+      : fsa_(f), current_state_(start_state), current_weight_(0), current_label_(0), stack_() {
     TRACE("StateTraverser starting with Start state %d", current_state_);
     f->GetOutGoingTransitions(start_state, &stack_.GetStates(), &stack_.traversal_stack_payload,
                               f->GetInnerWeight(start_state));
@@ -89,13 +89,11 @@ class StateTraverser final {
         current_state_(other.current_state_),
         current_weight_(other.current_weight_),
         current_label_(other.current_label_),
-        at_end_(other.at_end_),
         stack_(std::move(other.stack_)) {
     other.fsa_ = 0;
     other.current_state_ = 0;
     other.current_weight_ = 0;
     other.current_label_ = 0;
-    other.at_end_ = true;
   }
 
   automata_t GetFsa() const { return fsa_; }
@@ -136,7 +134,7 @@ class StateTraverser final {
       if (stack_.GetDepth() == 0) {
         TRACE("traverser exhausted.");
         current_label_ = 0;
-        at_end_ = true;
+        current_state_ = 0;
         return;
       }
 
@@ -157,7 +155,7 @@ class StateTraverser final {
 
   label_t GetStateLabel() const { return current_label_; }
 
-  operator bool() const { return !at_end_; }
+  operator bool() const { return current_state_ != 0; }
 
   /**
    * Set the minimum weight states must be greater or equal to.
@@ -173,7 +171,6 @@ class StateTraverser final {
   uint64_t current_state_;
   uint32_t current_weight_;
   label_t current_label_;
-  bool at_end_;
   traversal::TraversalStack<TransitionT> stack_;
 
   /**

--- a/keyvi/tests/keyvi/dictionary/fsa/comparable_state_traverser_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fsa/comparable_state_traverser_test.cpp
@@ -17,7 +17,9 @@
 //
 
 #include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include <boost/test/unit_test.hpp>
 
@@ -34,8 +36,8 @@ BOOST_AUTO_TEST_SUITE(ComparableStateTraverserTests)
 
 BOOST_AUTO_TEST_CASE(StateTraverserCompatibility) {
   std::vector<std::string> test_data = {"aaaa", "aabb", "aabc", "aacd", "bbcd"};
-  testing::TempDictionary dictionary(&test_data);
-  automata_t f = dictionary.GetFsa();
+  const testing::TempDictionary dictionary(&test_data);
+  const automata_t f = dictionary.GetFsa();
 
   ComparableStateTraverser<StateTraverser<>> s(f);
 
@@ -112,8 +114,8 @@ BOOST_AUTO_TEST_CASE(StateTraverserCompatibility) {
 
 BOOST_AUTO_TEST_CASE(StateTraverserCompatSomeTraversalWithPrune) {
   std::vector<std::string> test_data = {"aaaa", "aabb", "aabc", "aacd", "bbcd"};
-  testing::TempDictionary dictionary(&test_data);
-  automata_t f = dictionary.GetFsa();
+  const testing::TempDictionary dictionary(&test_data);
+  const automata_t f = dictionary.GetFsa();
 
   ComparableStateTraverser<StateTraverser<>> s(f);
 
@@ -174,12 +176,12 @@ BOOST_AUTO_TEST_CASE(StateTraverserCompatSomeTraversalWithPrune) {
 }
 
 BOOST_AUTO_TEST_CASE(StateTraverserCompatLongkeys) {
-  std::string a(1000, 'a');
-  std::string b(1000, 'b');
+  const std::string a(1000, 'a');
+  const std::string b(1000, 'b');
 
   std::vector<std::string> test_data = {a, b};
-  testing::TempDictionary dictionary(&test_data);
-  automata_t f = dictionary.GetFsa();
+  const testing::TempDictionary dictionary(&test_data);
+  const automata_t f = dictionary.GetFsa();
 
   ComparableStateTraverser<StateTraverser<>> s(f);
 
@@ -216,8 +218,8 @@ BOOST_AUTO_TEST_CASE(StateTraverserCompatLongkeys) {
 BOOST_AUTO_TEST_CASE(StateTraverserCompatZeroByte) {
   std::vector<std::string> test_data = {std::string("\0aaaa", 5), std::string("aa\0bb", 5), "aabc", "aacd",
                                         std::string("bbcd\0", 5)};
-  testing::TempDictionary dictionary(&test_data);
-  automata_t f = dictionary.GetFsa();
+  const testing::TempDictionary dictionary(&test_data);
+  const automata_t f = dictionary.GetFsa();
 
   ComparableStateTraverser<StateTraverser<>> s(f);
 
@@ -321,13 +323,13 @@ BOOST_AUTO_TEST_CASE(StateTraverserCompatZeroByte) {
 
 BOOST_AUTO_TEST_CASE(same_data) {
   std::vector<std::string> test_data = {"aaaa", "aabb", "aabc", "aacd", "bbcd"};
-  testing::TempDictionary dictionary(&test_data);
-  automata_t f = dictionary.GetFsa();
+  const testing::TempDictionary dictionary(&test_data);
+  const automata_t f = dictionary.GetFsa();
 
   ComparableStateTraverser<StateTraverser<>> t1(f, false, 0);
   ComparableStateTraverser<StateTraverser<>> t2(f, false, 0);
   ComparableStateTraverser<StateTraverser<>> t3(f, false, 1);
-  ComparableStateTraverser<StateTraverser<>> t4(f, false, 1);
+  const ComparableStateTraverser<StateTraverser<>> t4(f, false, 1);
 
   BOOST_CHECK((t1 < t2) == false);
   BOOST_CHECK((t2 < t1) == false);
@@ -371,12 +373,12 @@ BOOST_AUTO_TEST_CASE(same_data) {
 
 BOOST_AUTO_TEST_CASE(interleave1) {
   std::vector<std::string> test_data1 = {"aaaa", "aabb", "aabc", "aacd", "bbcd"};
-  testing::TempDictionary dictionary1(&test_data1);
-  automata_t f1 = dictionary1.GetFsa();
+  const testing::TempDictionary dictionary1(&test_data1);
+  const automata_t f1 = dictionary1.GetFsa();
 
   std::vector<std::string> test_data2 = {"aabb", "aabd", "abcd", "bbcd"};
-  testing::TempDictionary dictionary2(&test_data2);
-  automata_t f2 = dictionary2.GetFsa();
+  const testing::TempDictionary dictionary2(&test_data2);
+  const automata_t f2 = dictionary2.GetFsa();
 
   ComparableStateTraverser<StateTraverser<>> t1(f1, false, 0);
   ComparableStateTraverser<StateTraverser<>> t2(f2, false, 1);
@@ -415,12 +417,12 @@ BOOST_AUTO_TEST_CASE(interleave1) {
 
 BOOST_AUTO_TEST_CASE(interleave2) {
   std::vector<std::string> test_data1 = {"aaaa", "aabb", "aabc", "aacd", "bbcd"};
-  testing::TempDictionary dictionary1(&test_data1);
-  automata_t f1 = dictionary1.GetFsa();
+  const testing::TempDictionary dictionary1(&test_data1);
+  const automata_t f1 = dictionary1.GetFsa();
 
   std::vector<std::string> test_data2 = {"aaab", "aabd", "abcd", "bbcd"};
-  testing::TempDictionary dictionary2(&test_data2);
-  automata_t f2 = dictionary2.GetFsa();
+  const testing::TempDictionary dictionary2(&test_data2);
+  const automata_t f2 = dictionary2.GetFsa();
 
   ComparableStateTraverser<StateTraverser<>> t1(f1, false, 0);
   ComparableStateTraverser<StateTraverser<>> t2(f2, false, 1);
@@ -449,12 +451,12 @@ BOOST_AUTO_TEST_CASE(interleave2) {
 
 BOOST_AUTO_TEST_CASE(nearTraversalSpecialization) {
   std::vector<std::string> test_data1 = {"aaaa", "aabb", "aabc", "aacd", "bbcd", "cdefgh"};
-  testing::TempDictionary dictionary1(&test_data1);
-  automata_t f1 = dictionary1.GetFsa();
+  const testing::TempDictionary dictionary1(&test_data1);
+  const automata_t f1 = dictionary1.GetFsa();
 
   std::vector<std::string> test_data2 = {"abbb", "aabc", "bbcd", "aaceh", "cdefgh"};
-  testing::TempDictionary dictionary2(&test_data2);
-  automata_t f2 = dictionary2.GetFsa();
+  const testing::TempDictionary dictionary2(&test_data2);
+  const automata_t f2 = dictionary2.GetFsa();
 
   std::shared_ptr<std::string> near_key = std::make_shared<std::string>("aace");
 
@@ -537,12 +539,12 @@ BOOST_AUTO_TEST_CASE(nearTraversalSpecialization) {
 
 BOOST_AUTO_TEST_CASE(nearTraversalSpecialization2) {
   std::vector<std::string> test_data1 = {"aaaa", "aabb", "aabc", "aacd", "bbcd", "cdefgh"};
-  testing::TempDictionary dictionary1(&test_data1);
-  automata_t f1 = dictionary1.GetFsa();
+  const testing::TempDictionary dictionary1(&test_data1);
+  const automata_t f1 = dictionary1.GetFsa();
 
   std::vector<std::string> test_data2 = {"abbb", "aabc", "bbcd", "aaceh", "aacexyz", "aacexz", "cdefgh"};
-  testing::TempDictionary dictionary2(&test_data2);
-  automata_t f2 = dictionary2.GetFsa();
+  const testing::TempDictionary dictionary2(&test_data2);
+  const automata_t f2 = dictionary2.GetFsa();
 
   std::shared_ptr<std::string> near_key = std::make_shared<std::string>("aace");
 

--- a/keyvi/tests/keyvi/dictionary/fsa/comparable_state_traverser_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fsa/comparable_state_traverser_test.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(StateTraverserCompatibility) {
 
   BOOST_CHECK_EQUAL('a', s.GetStateLabel());
   BOOST_CHECK_EQUAL(1, s.GetDepth());
-  BOOST_CHECK(!s.AtEnd());
+  BOOST_CHECK(s);
   BOOST_CHECK(s);
 
   s++;
@@ -101,12 +101,12 @@ BOOST_AUTO_TEST_CASE(StateTraverserCompatibility) {
   // traverser shall be exhausted
   s++;
   BOOST_CHECK_EQUAL(0, s.GetStateLabel());
-  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
   BOOST_CHECK(!s);
   BOOST_CHECK_EQUAL(0, s.GetDepth());
   s++;
   BOOST_CHECK_EQUAL(0, s.GetStateLabel());
-  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
   BOOST_CHECK_EQUAL(0, s.GetDepth());
 }
 
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(StateTraverserCompatSomeTraversalWithPrune) {
 
   BOOST_CHECK_EQUAL('a', s.GetStateLabel());
   BOOST_CHECK_EQUAL(1, s.GetDepth());
-  BOOST_CHECK(!s.AtEnd());
+  BOOST_CHECK(s);
 
   s++;
   BOOST_CHECK_EQUAL('a', s.GetStateLabel());
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(StateTraverserCompatSomeTraversalWithPrune) {
   BOOST_CHECK_EQUAL(2, s.GetDepth());
   BOOST_CHECK_EQUAL(2, s.GetStateLabels().size());
   s++;
-  BOOST_CHECK(!s.AtEnd());
+  BOOST_CHECK(s);
 
   BOOST_CHECK_EQUAL('c', s.GetStateLabel());
   BOOST_CHECK_EQUAL(3, s.GetDepth());
@@ -165,11 +165,11 @@ BOOST_AUTO_TEST_CASE(StateTraverserCompatSomeTraversalWithPrune) {
   // traverser shall be exhausted
   s++;
   BOOST_CHECK_EQUAL(0, s.GetStateLabel());
-  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
   BOOST_CHECK_EQUAL(0, s.GetDepth());
   s++;
   BOOST_CHECK_EQUAL(0, s.GetStateLabel());
-  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
   BOOST_CHECK_EQUAL(0, s.GetDepth());
 }
 
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(StateTraverserCompatLongkeys) {
     BOOST_CHECK_EQUAL('a', s.GetStateLabel());
     BOOST_CHECK_EQUAL(i, s.GetDepth());
     s++;
-    BOOST_CHECK(!s.AtEnd());
+    BOOST_CHECK(s);
   }
 
   for (int i = 1; i <= 1000; ++i) {
@@ -195,20 +195,20 @@ BOOST_AUTO_TEST_CASE(StateTraverserCompatLongkeys) {
     BOOST_CHECK_EQUAL(i, s.GetDepth());
     s++;
     if (i != 1000) {
-      BOOST_CHECK(!s.AtEnd());
+      BOOST_CHECK(s);
     } else {
-      BOOST_CHECK(s.AtEnd());
+      BOOST_CHECK(!s);
     }
   }
 
   // traverser shall be exhausted
   s++;
   BOOST_CHECK_EQUAL(0, s.GetStateLabel());
-  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
   BOOST_CHECK_EQUAL(0, s.GetDepth());
   s++;
   BOOST_CHECK_EQUAL(0, s.GetStateLabel());
-  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
 
   BOOST_CHECK_EQUAL(0, s.GetDepth());
 }
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE(StateTraverserCompatZeroByte) {
 
   BOOST_CHECK_EQUAL('\0', s.GetStateLabel());
   BOOST_CHECK_EQUAL(1, s.GetDepth());
-  BOOST_CHECK(!s.AtEnd());
+  BOOST_CHECK(s);
 
   s++;
   BOOST_CHECK_EQUAL('a', s.GetStateLabel());
@@ -311,12 +311,12 @@ BOOST_AUTO_TEST_CASE(StateTraverserCompatZeroByte) {
   s++;
   BOOST_CHECK_EQUAL(0, s.GetStateLabel());
   BOOST_CHECK_EQUAL(0, s.GetDepth());
-  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
 
   s++;
   BOOST_CHECK_EQUAL(0, s.GetStateLabel());
   BOOST_CHECK_EQUAL(0, s.GetDepth());
-  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
 }
 
 BOOST_AUTO_TEST_CASE(same_data) {

--- a/keyvi/tests/keyvi/dictionary/fsa/state_traverser_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fsa/state_traverser_test.cpp
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(someTraversalNoPrune) {
 
   BOOST_CHECK_EQUAL('a', s.GetStateLabel());
   BOOST_CHECK_EQUAL(1, s.GetDepth());
-  BOOST_CHECK(!s.AtEnd());
+  BOOST_CHECK(s);
   BOOST_CHECK(s);
 
   s++;
@@ -106,12 +106,12 @@ BOOST_AUTO_TEST_CASE(someTraversalNoPrune) {
   // traverser shall be exhausted
   s++;
   BOOST_CHECK_EQUAL(0, s.GetStateLabel());
-  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
   BOOST_CHECK(!s);
   BOOST_CHECK_EQUAL(0, s.GetDepth());
   s++;
   BOOST_CHECK_EQUAL(0, s.GetStateLabel());
-  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
   BOOST_CHECK_EQUAL(0, s.GetDepth());
 }
 
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(someTraversalWithPrune) {
 
   BOOST_CHECK_EQUAL('a', s.GetStateLabel());
   BOOST_CHECK_EQUAL(1, s.GetDepth());
-  BOOST_CHECK(!s.AtEnd());
+  BOOST_CHECK(s);
 
   s++;
   BOOST_CHECK_EQUAL('a', s.GetStateLabel());
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(someTraversalWithPrune) {
 
   s.Prune();
   s++;
-  BOOST_CHECK(!s.AtEnd());
+  BOOST_CHECK(s);
 
   BOOST_CHECK_EQUAL('c', s.GetStateLabel());
   BOOST_CHECK_EQUAL(3, s.GetDepth());
@@ -162,11 +162,11 @@ BOOST_AUTO_TEST_CASE(someTraversalWithPrune) {
   // traverser shall be exhausted
   s++;
   BOOST_CHECK_EQUAL(0, s.GetStateLabel());
-  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
   BOOST_CHECK_EQUAL(0, s.GetDepth());
   s++;
   BOOST_CHECK_EQUAL(0, s.GetStateLabel());
-  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
   BOOST_CHECK_EQUAL(0, s.GetDepth());
 }
 
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_CASE(longkeys) {
     BOOST_CHECK_EQUAL('a', s.GetStateLabel());
     BOOST_CHECK_EQUAL(i, s.GetDepth());
     s++;
-    BOOST_CHECK(!s.AtEnd());
+    BOOST_CHECK(s);
   }
 
   for (int i = 1; i <= 1000; ++i) {
@@ -192,20 +192,20 @@ BOOST_AUTO_TEST_CASE(longkeys) {
     BOOST_CHECK_EQUAL(i, s.GetDepth());
     s++;
     if (i != 1000) {
-      BOOST_CHECK(!s.AtEnd());
+      BOOST_CHECK(s);
     } else {
-      BOOST_CHECK(s.AtEnd());
+      BOOST_CHECK(!s);
     }
   }
 
   // traverser shall be exhausted
   s++;
   BOOST_CHECK_EQUAL(0, s.GetStateLabel());
-  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
   BOOST_CHECK_EQUAL(0, s.GetDepth());
   s++;
   BOOST_CHECK_EQUAL(0, s.GetStateLabel());
-  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
 
   BOOST_CHECK_EQUAL(0, s.GetDepth());
 }
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(zeroByte) {
 
   BOOST_CHECK_EQUAL('\0', s.GetStateLabel());
   BOOST_CHECK_EQUAL(1, s.GetDepth());
-  BOOST_CHECK(!s.AtEnd());
+  BOOST_CHECK(s);
 
   s++;
   BOOST_CHECK_EQUAL('a', s.GetStateLabel());
@@ -308,12 +308,12 @@ BOOST_AUTO_TEST_CASE(zeroByte) {
   s++;
   BOOST_CHECK_EQUAL(0, s.GetStateLabel());
   BOOST_CHECK_EQUAL(0, s.GetDepth());
-  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
 
   s++;
   BOOST_CHECK_EQUAL(0, s.GetStateLabel());
   BOOST_CHECK_EQUAL(0, s.GetDepth());
-  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
 }
 
 BOOST_AUTO_TEST_CASE(traversal_min_weight) {
@@ -328,7 +328,7 @@ BOOST_AUTO_TEST_CASE(traversal_min_weight) {
   BOOST_CHECK_EQUAL('b', s.GetStateLabel());
   BOOST_CHECK_EQUAL(1, s.GetDepth());
   BOOST_CHECK_EQUAL(40, s.GetInnerWeight());
-  BOOST_CHECK(!s.AtEnd());
+  BOOST_CHECK(s);
 
   s++;
   BOOST_CHECK_EQUAL('b', s.GetStateLabel());
@@ -341,11 +341,11 @@ BOOST_AUTO_TEST_CASE(traversal_min_weight) {
   BOOST_CHECK_EQUAL('d', s.GetStateLabel());
   BOOST_CHECK_EQUAL(4, s.GetDepth());
   BOOST_CHECK_EQUAL(40, s.GetInnerWeight());
-  BOOST_CHECK(!s.AtEnd());
+  BOOST_CHECK(s);
 
   s.SetMinWeight(12);
   s++;
-  BOOST_CHECK(!s.AtEnd());
+  BOOST_CHECK(s);
 
   BOOST_CHECK_EQUAL('a', s.GetStateLabel());
   BOOST_CHECK_EQUAL(1, s.GetDepth());
@@ -396,7 +396,7 @@ BOOST_AUTO_TEST_CASE(traversal_min_weight) {
 
   s.SetMinWeight(20);
   s++;
-  BOOST_CHECK(s.AtEnd());
+  BOOST_CHECK(!s);
   BOOST_CHECK_EQUAL(0, s.GetStateLabel());
   BOOST_CHECK_EQUAL(0, s.GetDepth());
 }

--- a/keyvi/tests/keyvi/dictionary/fsa/state_traverser_test.cpp
+++ b/keyvi/tests/keyvi/dictionary/fsa/state_traverser_test.cpp
@@ -23,6 +23,9 @@
  *      Author: hendrik
  */
 
+#include <string>
+#include <vector>
+
 #include "keyvi/dictionary/fsa/state_traverser.h"
 
 #include <boost/test/unit_test.hpp>
@@ -39,8 +42,8 @@ BOOST_AUTO_TEST_SUITE(StateTraverserTests)
 
 BOOST_AUTO_TEST_CASE(someTraversalNoPrune) {
   std::vector<std::string> test_data = {"aaaa", "aabb", "aabc", "aacd", "bbcd"};
-  testing::TempDictionary dictionary(&test_data);
-  automata_t f = dictionary.GetFsa();
+  const testing::TempDictionary dictionary(&test_data);
+  const automata_t f = dictionary.GetFsa();
 
   StateTraverser<> s(f);
 
@@ -117,8 +120,8 @@ BOOST_AUTO_TEST_CASE(someTraversalNoPrune) {
 
 BOOST_AUTO_TEST_CASE(someTraversalWithPrune) {
   std::vector<std::string> test_data = {"aaaa", "aabb", "aabc", "aacd", "bbcd"};
-  testing::TempDictionary dictionary(&test_data);
-  automata_t f = dictionary.GetFsa();
+  const testing::TempDictionary dictionary(&test_data);
+  const automata_t f = dictionary.GetFsa();
 
   StateTraverser<> s(f);
 
@@ -171,12 +174,12 @@ BOOST_AUTO_TEST_CASE(someTraversalWithPrune) {
 }
 
 BOOST_AUTO_TEST_CASE(longkeys) {
-  std::string a(1000, 'a');
-  std::string b(1000, 'b');
+  const std::string a(1000, 'a');
+  const std::string b(1000, 'b');
 
   std::vector<std::string> test_data = {a, b};
-  testing::TempDictionary dictionary(&test_data);
-  automata_t f = dictionary.GetFsa();
+  const testing::TempDictionary dictionary(&test_data);
+  const automata_t f = dictionary.GetFsa();
 
   StateTraverser<> s(f);
 
@@ -213,8 +216,8 @@ BOOST_AUTO_TEST_CASE(longkeys) {
 BOOST_AUTO_TEST_CASE(zeroByte) {
   std::vector<std::string> test_data = {std::string("\0aaaa", 5), std::string("aa\0bb", 5), "aabc", "aacd",
                                         std::string("bbcd\0", 5)};
-  testing::TempDictionary dictionary(&test_data);
-  automata_t f = dictionary.GetFsa();
+  const testing::TempDictionary dictionary(&test_data);
+  const automata_t f = dictionary.GetFsa();
 
   StateTraverser<> s(f);
 
@@ -320,8 +323,8 @@ BOOST_AUTO_TEST_CASE(traversal_min_weight) {
   std::vector<std::pair<std::string, uint32_t>> test_data = {{"aaaa", 5},  {"aabb", 15}, {"aabc", 10}, {"aacd", 20},
                                                              {"bbcd", 40}, {"cbcd", 18}, {"cefgh", 12}};
 
-  testing::TempDictionary dictionary(&test_data);
-  automata_t f = dictionary.GetFsa();
+  const testing::TempDictionary dictionary(&test_data);
+  const automata_t f = dictionary.GetFsa();
 
   StateTraverser<traversal::WeightedTransition> s(f);
 
@@ -404,8 +407,8 @@ BOOST_AUTO_TEST_CASE(traversal_min_weight) {
 BOOST_AUTO_TEST_CASE(traversal_inner_weight_long_entry) {
   std::vector<std::pair<std::string, uint32_t>> test_data = {{std::string(500, 'a'), 300}};
 
-  testing::TempDictionary dictionary(&test_data);
-  automata_t f = dictionary.GetFsa();
+  const testing::TempDictionary dictionary(&test_data);
+  const automata_t f = dictionary.GetFsa();
 
   StateTraverser<traversal::WeightedTransition> s(f);
 


### PR DESCRIPTION
removes an unnecessary bool in state traverser and fixes clang-tidy warnings in corresponding tests
