### PR TITLE
create a cargo push job for rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,7 @@ jobs:
     environment:
       name: crates.io
     permissions:
-      id-token: write     # Required for OIDC token exchange
+      id-token: write
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
implement publish to crates.io using trusted publishing

(we know if it works for the next release)