### PR TITLE
add clang tidy post workflow

### DIFF
--- a/.github/workflows/clang-tidy-post.yml
+++ b/.github/workflows/clang-tidy-post.yml
@@ -1,0 +1,21 @@
+name: Post clang-tidy review comments
+
+on:
+  workflow_run:
+    # The name field of the lint action
+    workflows: ["clang-tidy-review"]
+    types:
+      - completed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: ZedThree/clang-tidy-review/post@v0.21.0
+        # lgtm_comment_body, max_comments, and annotations need to be set on the posting workflow in a split setup
+        with:
+          # adjust options as necessary
+          lgtm_comment_body: ''
+          annotations: false
+          max_comments: 10


### PR DESCRIPTION
add clang-tidy post workflow to test out #372

This workflow loads the clang-tidy output and posts it as comments