### PR TITLE
make testing of deprecated python APIs optional

### DIFF
--- a/python/tests/dictionary/iterators_test.py
+++ b/python/tests/dictionary/iterators_test.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-# Usage: py.test tests
-
 from test_tools import tmp_dictionary
 import sys
 import os
@@ -9,20 +6,18 @@ import warnings
 
 from keyvi.compiler import JsonDictionaryCompiler
 
+
+TEST_DEPRECATIONS = os.getenv("KEYVI_SKIP_TEST_DEPRECATIONS") != "1"
+
+
 root = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(root, "../"))
 
 
-key_values = [
-    ('a', {"a": 2}),
-    ('b', {"b": 2}),
-    ('c', {"c": 2}),
-    ('d', {"d": 2})
-]
+key_values = [("a", {"a": 2}), ("b", {"b": 2}), ("c", {"c": 2}), ("d", {"d": 2})]
 
 
 def generate_dictionary_compiler():
-
     dictionary_compiler = JsonDictionaryCompiler({"memory_limit_mb": "10"})
     for key, value in key_values:
         dictionary_compiler.add(key, json.dumps(value))
@@ -31,38 +26,55 @@ def generate_dictionary_compiler():
 
 
 def test_keys():
-    with tmp_dictionary(generate_dictionary_compiler(), 'test_keys.kv') as keyvi_dictionary:
+    with tmp_dictionary(
+        generate_dictionary_compiler(), "test_keys.kv"
+    ) as keyvi_dictionary:
         for (base_key, _), keyvi_key in zip(key_values, keyvi_dictionary.keys()):
             assert base_key == keyvi_key
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            for (base_key, _), keyvi_key in zip(key_values, keyvi_dictionary.GetAllKeys()):
-                assert base_key == keyvi_key
-            assert len(w) == 1
-            assert issubclass(w[-1].category, DeprecationWarning)
+        if TEST_DEPRECATIONS:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                for (base_key, _), keyvi_key in zip(
+                    key_values, keyvi_dictionary.GetAllKeys()
+                ):
+                    assert base_key == keyvi_key
+                assert len(w) == 1
+                assert issubclass(w[-1].category, DeprecationWarning)
 
 
 def test_values():
-    with tmp_dictionary(generate_dictionary_compiler(), 'test_values.kv') as keyvi_dictionary:
+    with tmp_dictionary(
+        generate_dictionary_compiler(), "test_values.kv"
+    ) as keyvi_dictionary:
         for (_, base_value), keyvi_value in zip(key_values, keyvi_dictionary.values()):
             assert base_value == keyvi_value
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            for (_, base_value), keyvi_value in zip(key_values, keyvi_dictionary.GetAllValues()):
-                assert base_value == keyvi_value
-            assert len(w) == 1
-            assert issubclass(w[-1].category, DeprecationWarning)
+        if TEST_DEPRECATIONS:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                for (_, base_value), keyvi_value in zip(
+                    key_values, keyvi_dictionary.GetAllValues()
+                ):
+                    assert base_value == keyvi_value
+                assert len(w) == 1
+                assert issubclass(w[-1].category, DeprecationWarning)
 
 
 def test_items():
-    with tmp_dictionary(generate_dictionary_compiler(), 'test_items.kv') as keyvi_dictionary:
-        for (base_key, base_value), (keyvi_key, keyvi_value) in zip(key_values, keyvi_dictionary.items()):
+    with tmp_dictionary(
+        generate_dictionary_compiler(), "test_items.kv"
+    ) as keyvi_dictionary:
+        for (base_key, base_value), (keyvi_key, keyvi_value) in zip(
+            key_values, keyvi_dictionary.items()
+        ):
             assert base_key == keyvi_key
             assert base_value == keyvi_value
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            for (base_key, base_value), (keyvi_key, keyvi_value) in zip(key_values, keyvi_dictionary.GetAllItems()):
-                assert base_key == keyvi_key
-                assert base_value == keyvi_value
-            assert len(w) == 1
-            assert issubclass(w[-1].category, DeprecationWarning)
+        if TEST_DEPRECATIONS:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                for (base_key, base_value), (keyvi_key, keyvi_value) in zip(
+                    key_values, keyvi_dictionary.GetAllItems()
+                ):
+                    assert base_key == keyvi_key
+                    assert base_value == keyvi_value
+                assert len(w) == 1
+                assert issubclass(w[-1].category, DeprecationWarning)

--- a/python/tests/match_object_test.py
+++ b/python/tests/match_object_test.py
@@ -1,12 +1,10 @@
-# -*- coding: utf-8 -*-
-# Usage: py.test tests
-
 import json
 import keyvi
 import msgpack
 from test_tools import tmp_dictionary
 import warnings
 import zlib
+import os
 import snappy
 import zstd
 
@@ -16,6 +14,9 @@ from keyvi.compiler import (
     KeyOnlyDictionaryCompiler,
     StringDictionaryCompiler,
 )
+
+
+TEST_DEPRECATIONS = os.getenv("KEYVI_SKIP_TEST_DEPRECATIONS") != "1"
 
 
 def test_serialization():
@@ -41,11 +42,12 @@ def test_raw_serialization():
         m2 = keyvi.Match.loads(d)
         assert m2.value_as_string() == '{"a":2}'
         assert msgpack.loads(m.msgpacked_value_as_string()) == {"a": 2}
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            assert m.GetValueAsString() == '{"a":2}'
-            assert len(w) == 1
-            assert issubclass(w[-1].category, DeprecationWarning)
+        if TEST_DEPRECATIONS:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                assert m.GetValueAsString() == '{"a":2}'
+                assert len(w) == 1
+                assert issubclass(w[-1].category, DeprecationWarning)
 
 
 def test_unicode_attributes():
@@ -56,14 +58,15 @@ def test_unicode_attributes():
     m.score = 99
     assert m["k2"] == " 吃饭了吗"
     assert m.score == 99.0
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        m.SetAttribute("k2", "öäü")
-        assert m["k2"] == "öäü"
-        assert m.GetAttribute("k2") == "öäü"
-        assert len(w) == 2
-        assert issubclass(w[0].category, DeprecationWarning)
-        assert issubclass(w[1].category, DeprecationWarning)
+    if TEST_DEPRECATIONS:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            m.SetAttribute("k2", "öäü")
+            assert m["k2"] == "öäü"
+            assert m.GetAttribute("k2") == "öäü"
+            assert len(w) == 2
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert issubclass(w[1].category, DeprecationWarning)
 
 
 def test_bytes_attributes():
@@ -94,36 +97,39 @@ def test_start():
     m = keyvi.Match()
     m.start = 42
     assert m.start == 42
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        m.SetStart(44)
-        assert m.start == 44
-        assert len(w) == 1
-        assert issubclass(w[-1].category, DeprecationWarning)
+    if TEST_DEPRECATIONS:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            m.SetStart(44)
+            assert m.start == 44
+            assert len(w) == 1
+            assert issubclass(w[-1].category, DeprecationWarning)
 
 
 def test_end():
     m = keyvi.Match()
     m.end = 49
     assert m.end == 49
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        m.SetEnd(55)
-        assert m.end == 55
-        assert len(w) == 1
-        assert issubclass(w[-1].category, DeprecationWarning)
+    if TEST_DEPRECATIONS:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            m.SetEnd(55)
+            assert m.end == 55
+            assert len(w) == 1
+            assert issubclass(w[-1].category, DeprecationWarning)
 
 
 def test_score():
     m = keyvi.Match()
     m.score = 149
     assert m.score == 149
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        m.SetScore(155)
-        assert m.score == 155
-        assert len(w) == 1
-        assert issubclass(w[-1].category, DeprecationWarning)
+    if TEST_DEPRECATIONS:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            m.SetScore(155)
+            assert m.score == 155
+            assert len(w) == 1
+            assert issubclass(w[-1].category, DeprecationWarning)
 
 
 def test_get_value():
@@ -236,20 +242,22 @@ def test_matched_string():
     m = keyvi.Match()
     m.matched_string = "match"
     assert m.matched_string == "match"
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        m.SetMatchedString("other_match")
-        assert m.matched_string == "other_match"
-        assert len(w) == 1
-        assert issubclass(w[-1].category, DeprecationWarning)
+    if TEST_DEPRECATIONS:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            m.SetMatchedString("other_match")
+            assert m.matched_string == "other_match"
+            assert len(w) == 1
+            assert issubclass(w[-1].category, DeprecationWarning)
 
 
 def test_bool_operator():
     m = keyvi.Match()
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        assert m.IsEmpty()
-        assert issubclass(w[-1].category, DeprecationWarning)
+    if TEST_DEPRECATIONS:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            assert m.IsEmpty()
+            assert issubclass(w[-1].category, DeprecationWarning)
     assert not m
     m.end = 42
     assert m is not False

--- a/python/tests/statistics_test.py
+++ b/python/tests/statistics_test.py
@@ -1,21 +1,24 @@
-# -*- coding: utf-8 -*-
-# Usage: py.test tests
-
 import json
 import os
 import tempfile
 import warnings
 from test_tools import tmp_dictionary
 
-from keyvi.compiler import KeyOnlyDictionaryCompiler, JsonDictionaryCompiler, JsonDictionaryMerger
+from keyvi.compiler import (
+    KeyOnlyDictionaryCompiler,
+    JsonDictionaryCompiler,
+    JsonDictionaryMerger,
+)
 from keyvi.dictionary import Dictionary
+
+TEST_DEPRECATIONS = os.getenv("KEYVI_SKIP_TEST_DEPRECATIONS") != "1"
 
 
 def test_size():
     c = KeyOnlyDictionaryCompiler({"memory_limit_mb": "10"})
     c.add("Leela")
     c.add("Kif")
-    with tmp_dictionary(c, 'brannigan_size.kv') as d:
+    with tmp_dictionary(c, "brannigan_size.kv") as d:
         assert len(d) == 2
 
 
@@ -24,9 +27,9 @@ def test_manifest():
     c.add("Leela")
     c.add("Kif")
     c.set_manifest('{"author": "Zapp Brannigan"}')
-    with tmp_dictionary(c, 'brannigan_manifest.kv') as d:
+    with tmp_dictionary(c, "brannigan_manifest.kv") as d:
         m = json.loads(d.manifest())
-        assert m['author'] == "Zapp Brannigan"
+        assert m["author"] == "Zapp Brannigan"
 
 
 def test_manifest_after_compile():
@@ -35,12 +38,12 @@ def test_manifest_after_compile():
     c.add("Kif")
     c.compile()
     c.set_manifest('{"author": "Zapp Brannigan"}')
-    file_name = os.path.join(tempfile.gettempdir(), 'brannigan_manifest2.kv')
+    file_name = os.path.join(tempfile.gettempdir(), "brannigan_manifest2.kv")
     try:
         c.write_to_file(file_name)
         d = Dictionary(file_name)
         m = json.loads(d.manifest())
-        assert m['author'] == "Zapp Brannigan"
+        assert m["author"] == "Zapp Brannigan"
         del d
     finally:
         os.remove(file_name)
@@ -51,23 +54,24 @@ def test_statistics():
     c.add("Leela")
     c.add("Kif")
     c.set_manifest('{"author": "Zapp Brannigan"}')
-    with tmp_dictionary(c, 'brannigan_statistics.kv') as d:
+    with tmp_dictionary(c, "brannigan_statistics.kv") as d:
         stats = d.statistics()
-        gen = stats.get('General', {})
+        gen = stats.get("General", {})
         man = json.loads(d.manifest())
-        size = int(gen.get('number_of_keys', 0))
+        size = int(gen.get("number_of_keys", 0))
         assert size == 2
-        assert man.get('author') == "Zapp Brannigan"
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            stats = d.GetStatistics()
-            gen = stats.get('General', {})
-            man = json.loads(d.manifest())
-            size = int(gen.get('number_of_keys', 0))
-            assert size == 2
-            assert man.get('author') == "Zapp Brannigan"
-            assert len(w) == 1
-            assert issubclass(w[-1].category, DeprecationWarning)
+        assert man.get("author") == "Zapp Brannigan"
+        if TEST_DEPRECATIONS:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                stats = d.GetStatistics()
+                gen = stats.get("General", {})
+                man = json.loads(d.manifest())
+                size = int(gen.get("number_of_keys", 0))
+                assert size == 2
+                assert man.get("author") == "Zapp Brannigan"
+                assert len(w) == 1
+                assert issubclass(w[-1].category, DeprecationWarning)
 
 
 def test_manifest_for_merger():
@@ -76,26 +80,26 @@ def test_manifest_for_merger():
         c.add("abc", '{"a" : 2}')
         c.compile()
         c.set_manifest('{"author": "Zapp Brannigan"}')
-        c.write_to_file('manifest_json_merge1.kv')
+        c.write_to_file("manifest_json_merge1.kv")
         del c
 
         c2 = JsonDictionaryCompiler({"memory_limit_mb": "10"})
         c2.add("abd", '{"a" : 3}')
         c2.compile()
         c2.set_manifest('{"author": "Leela"}')
-        c2.write_to_file('manifest_json_merge2.kv')
+        c2.write_to_file("manifest_json_merge2.kv")
         del c2
 
         merger = JsonDictionaryMerger({"memory_limit_mb": "10"})
         merger.set_manifest('{"author": "Fry"}')
-        merger.merge('manifest_json_merged.kv')
+        merger.merge("manifest_json_merged.kv")
 
-        d = Dictionary('manifest_json_merged.kv')
+        d = Dictionary("manifest_json_merged.kv")
         m = json.loads(d.manifest())
-        assert m['author'] == "Fry"
+        assert m["author"] == "Fry"
         del d
 
     finally:
-        os.remove('manifest_json_merge1.kv')
-        os.remove('manifest_json_merge2.kv')
-        os.remove('manifest_json_merged.kv')
+        os.remove("manifest_json_merge1.kv")
+        os.remove("manifest_json_merge2.kv")
+        os.remove("manifest_json_merged.kv")


### PR DESCRIPTION
make testing of deprecated python APIs optional